### PR TITLE
docs: fix stream delete URL

### DIFF
--- a/docs/api/stream/delete.md
+++ b/docs/api/stream/delete.md
@@ -1,6 +1,6 @@
 # Delete stream
 
-Endpoint: `DELETE /api/{organization}/{stream}`
+Endpoint: `DELETE /api/{organization}/streams/{stream}`
 
 ## Request
 


### PR DESCRIPTION
Related to this, the `type` query param is also not documented, but it's required to pass `type=metrics` to delete a metric stream.