### PR TITLE
Fix default value of ZO_INGEST_FLATTEN_LEVEL

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -120,7 +120,7 @@ OpenObserve is configured through the use of below environment variables.
 | ZO_INGESTER_SERVICE_URL              |                            | No           |  |
 | ZO_INGEST_BLOCKED_STREAMS            |                            | No           |  |
 | ZO_INGEST_INFER_SCHEMA_PER_REQUEST   |                            | No           |  |
-| ZO_INGEST_FLATTEN_LEVEL              | 5                          | No           | The level of flatten ingestion json data, if you want flatten everything you can simple set it to `0`, or you can set it to `N` to limit the flatten level.   |
+| ZO_INGEST_FLATTEN_LEVEL              | 3                          | No           | The level of flatten ingestion json data, if you want flatten everything you can simple set it to `0`, or you can set it to `N` to limit the flatten level.   |
 | ZO_ENTRY_PER_SCHEMA_VERSION_ENABLED  |                            | No           |  |
 | ZO_CLUSTER_COORDINATOR               | etcd                       | No           | How the nodes in the cluster find each other. Options are etcd and nats. nats is preferred. |
 | ZO_QUEUE_STORE                       |                            | No           |  |


### PR DESCRIPTION
According to the docs, `ZO_INGEST_FLATTEN_LEVEL`'s default value is `5`, but the default value in code is `3` :

```rust
    // [...]
    pub query_group_base_speed: usize,
    #[env_config(name = "ZO_INGEST_ALLOWED_UPTO", default = 5)] // in hours - in past
    pub ingest_allowed_upto: i64,
    #[env_config(name = "ZO_INGEST_FLATTEN_LEVEL", default = 3)] // default flatten level
    pub ingest_flatten_level: u32,
    #[env_config(name = "ZO_IGNORE_FILE_RETENTION_BY_STREAM", default = false)]
    pub ignore_file_retention_by_stream: bool,
    // [...]
```

This could lead to dataloss if a developer considers 5 to be enough according to the depth of their logs, but 3 wouldn't be.

Not totally unrelated, a list of BC breaks on release pages would be quite great :smiling_face_with_tear:.