### PR TITLE
Make JSON flattening more explicit

### DIFF
--- a/docs/api/ingestion/logs/json.md
+++ b/docs/api/ingestion/logs/json.md
@@ -93,6 +93,48 @@ Please note only records having 200 or less fields/columns will be considered fo
 
 One can configure ZO_COLS_PER_RECORD_LIMIT to set desired value for allowed number of fields/columns per record.
 
+## Flattening of the JSON structure
+
+OpenObserve flattens deep JSON logs. Below is an example log before and after being flattened.
+
+#### Before
+
+```json
+{
+	"actor": {
+		"ip": "[redacted]",
+		"id": 558875,
+		"parent" : {
+			"id": 45516,
+			"active": true
+		}
+	}
+	"response": {
+		"error_occured": false,
+		"status_code": 200
+	}
+	
+}
+```
+
+#### After
+
+```json
+{
+	"actor_ip": "[redacted]",
+	"actor_id": 558875,
+	"actor_parent_id": 45516,
+	"actor_parent_active": true,
+	"response_error_occured": false,
+	"response_status_code": 200
+}
+```
+
+### Restriction on flattening depth
+
+⚠️ For performance reasons, OpenObserve limits the depth at which the JSON structure gets flattened. Past that limit, the generated field will contain unparsed JSON as a string.
+The default depth is `3`, but this limit can be configured via the `ZO_INGEST_FLATTEN_LEVEL` environment variable. `ZO_INGEST_FLATTEN_LEVEL` can either be `0`, which disables the flattening limit, or any positive number, to change the depth at which the flattening stops.
+
 ## Timestamp
 
 By default we add a field `_timestamp` for each record with the value of `NOW` in microseconds (unix epoch value). 


### PR DESCRIPTION
Following my previous PR #30, I thought it'd be useful to make JSON flattening behavior more explicit.

As it stands, unless you know where to look in the docs, flattening behavior is implicit. Most users will experience it when testing OpenObserve for the first time. This isn't ideal since it causes users to make assumptions about how flattening works, assumptions which might be wrong.

This PR proposes to add a new section in the _API Reference > Ingestion > Logs > JSON_ page, to explain the behavior with a quick example, and make the `ZO_INGEST_FLATTEN_LEVEL` variable more discoverable.

I'm not sure if this behavior differs between _cloud_ and _open-source_.
Anyway, if you want to change the wording, or you'd rather put this info somewhere else, no issues :smile: 