### PR TITLE
Add example about node-feature-discovery

### DIFF
--- a/docs/operator-guide/simd.md
+++ b/docs/operator-guide/simd.md
@@ -21,3 +21,37 @@ else
     echo "public.ecr.aws/zinclabs/openobserve:latest"
 fi
 ```
+
+## Kubernetes
+
+The Kubernetes add-on [node-feature-discovery](https://kubernetes-sigs.github.io/node-feature-discovery/v0.17/get-started/index.html)
+can automatically label nodes with their supported CPU features. With node-feature-discovery installed on your k8s cluster,
+the SIMD image of OpenObserve can be deployed with our [helm charts](https://github.com/openobserve/openobserve-helm-chart)
+using a value for `nodeSelector`.
+
+### With `openobserve` (HA)
+
+```yaml
+image:
+  oss:
+    tag: v0.14.2-simd
+
+nodeSelector:
+  ingester: &AVX_NODE_SELECTOR
+    feature.node.kubernetes.io/cpu-cpuid.AVX512F: "true"
+  querier: *AVX_NODE_SELECTOR
+  compactor: *AVX_NODE_SELECTOR
+  router: *AVX_NODE_SELECTOR
+  alertmanager: *AVX_NODE_SELECTOR
+```
+
+### With `openobserve-standalone`
+
+```yaml
+image:
+  tag: v0.14.2-simd
+
+nodeSelector:
+  feature.node.kubernetes.io/cpu-cpuid.AVX512F: "true"
+```
+


### PR DESCRIPTION
Added a section to the documentation about SIMD suggesting how to use node-feature-discovery with the openobserve charts.