### PR TITLE
feat: add support for Hetzner Cloud Object Storage in storage documentation

### DIFF
--- a/docs/storage-management/storage.md
+++ b/docs/storage-management/storage.md
@@ -202,7 +202,7 @@ ZO_S3_SECRET_KEY=YOUR_SECRET_KEY
 ZO_S3_FEATURE_FORCE_HOSTED_STYLE=true
 ```
 
-Refer to [Hetzner Cloud Object Storage documentation](https://docs.hetzner.com/cloud/storage/apps/s3cmd/) for more information about endpoints and regions.
+Refer to [Hetzner Cloud Object Storage documentation](https://docs.hetzner.com/storage/object-storage/) for more information about endpoints and regions.
 
 
 ## Metadata Storage

--- a/docs/storage-management/storage.md
+++ b/docs/storage-management/storage.md
@@ -175,6 +175,35 @@ OpenObserve can use azure blob for storing stream data. Following environment va
 | AZURE_STORAGE_ACCOUNT_KEY  | Access key           | Need to provide mandatorily                  |
 | ZO_S3_BUCKET_NAME          | Blob Container name  | Need to provide mandatorily                  |
 
+### Hetzner Cloud Object Storage
+
+To use Hetzner Cloud Object Storage for storing stream data, first create the bucket in Hetzner Cloud.
+Then set the following environment variables:
+
+| Environment Variable | Value | Description |
+| -------------------- | ----- | ----------- |
+| ZO_LOCAL_MODE_STORAGE | s3 | Use S3-compatible storage |
+| ZO_S3_SERVER_URL | https://your-bucket.your-region.your-objectstorage.com | Hetzner Object Storage endpoint |
+| ZO_S3_REGION_NAME | your-region | Region name (e.g., hel1, nbg1, fsn1) |
+| ZO_S3_BUCKET_NAME | your-bucket | Bucket name |
+| ZO_S3_ACCESS_KEY | your-access-key | Access key |
+| ZO_S3_SECRET_KEY | your-secret-key | Secret key |
+| ZO_S3_FEATURE_FORCE_HOSTED_STYLE | true | Enable hosted-style addressing |
+
+Example configuration with placeholder values:
+
+```bash
+ZO_LOCAL_MODE_STORAGE=s3
+ZO_S3_SERVER_URL=https://my-bucket.hel1.your-objectstorage.com
+ZO_S3_REGION_NAME=hel1
+ZO_S3_BUCKET_NAME=my-bucket
+ZO_S3_ACCESS_KEY=YOUR_ACCESS_KEY
+ZO_S3_SECRET_KEY=YOUR_SECRET_KEY
+ZO_S3_FEATURE_FORCE_HOSTED_STYLE=true
+```
+
+Refer to [Hetzner Cloud Object Storage documentation](https://docs.hetzner.com/cloud/storage/apps/s3cmd/) for more information about endpoints and regions.
+
 
 ## Metadata Storage
 


### PR DESCRIPTION
Add support for Hetzner Cloud Object Storage in storage documentation. Tested and in use.