### PR TITLE
chore: remove Actix server environment variables and add Loki and OTLP

### DIFF
--- a/docs/api/ingestion/logs/.pages
+++ b/docs/api/ingestion/logs/.pages
@@ -2,3 +2,5 @@ nav:
     - JSON: json.md
     - Bulk: bulk.md
     - Multi: multi.md
+    - Loki: loki.md
+    - Otlp: otlp.md

--- a/docs/api/ingestion/logs/index.md
+++ b/docs/api/ingestion/logs/index.md
@@ -3,3 +3,5 @@
 1. [Bulk](bulk)
 1. [Json](json)
 1. [Mutli](multi)
+1. [Loki](loki)
+1. [Otlp](otlp)

--- a/docs/api/ingestion/logs/loki.md
+++ b/docs/api/ingestion/logs/loki.md
@@ -1,0 +1,95 @@
+---
+description: >-
+  Ingest logs via Grafana Loki-compatible push API at POST /api/{organization}/loki/api/v1/push.
+  Supports Loki stream labels, nanosecond timestamps, and structured metadata.
+---
+# Logs Ingestion - Loki
+
+Endpoint: `POST /api/{organization}/loki/api/v1/push`
+
+OpenObserve is compatible with the Grafana Loki push API. You can send logs using any Loki-compatible client (e.g. Promtail, Grafana Agent, Alloy) by pointing it at OpenObserve.
+
+> we use `o2_stream_name` label for custom stream name, default will push into `default` stream.
+
+## Request
+
+e.g. `POST /api/myorg/loki/api/v1/push`
+
+Content-Type: `application/json`
+
+```json
+{
+  "streams": [
+    {
+      "stream": {
+        "o2_stream_name": "custom_stream",
+        "kubernetes_namespace": "monitoring",
+        "kubernetes_pod_name": "prometheus-k8s-1",
+        "kubernetes_container_name": "prometheus"
+      },
+      "values": [
+        [
+          "1672149599212000000",
+          "ts=2022-12-27T14:09:59.212Z caller=klog.go:108 level=warn component=k8s_client_runtime msg=\"failed to list *v1.Pod\""
+        ],
+        [
+          "1672149600000000000",
+          "ts=2022-12-27T14:10:00.000Z caller=klog.go:116 level=error component=k8s_client_runtime msg=\"Failed to watch *v1.Pod\""
+        ]
+      ]
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `streams` | array | List of log streams to push. |
+| `streams[].stream` | object | Key-value label pairs that identify the stream. Labels are indexed and can be used for filtering. |
+| `streams[].values` | array | List of log entries. Each entry is a two-element array: `[timestamp, line]`. |
+| `streams[].values[][0]` | string | Unix timestamp in **nanoseconds** as a string. |
+| `streams[].values[][1]` | string | Log line content. |
+
+## Response
+
+```json
+{}
+```
+
+An empty JSON object `{}` with HTTP status `204 No Content` indicates success, matching the standard Loki push API behavior.
+
+## Authentication
+
+Pass your credentials using HTTP Basic Auth or via the `Authorization` header, the same as all other OpenObserve ingestion endpoints.
+
+```
+Authorization: Basic <base64(user:password)>
+```
+
+## Configuring Promtail
+
+Point Promtail at OpenObserve by setting the Loki push URL in your `promtail.yaml`:
+
+```yaml
+clients:
+  - url: https://<openobserve-host>/api/<organization>/loki/api/v1/push
+    basic_auth:
+      username: <user>
+      password: <password>
+```
+
+## Configuring Grafana Alloy
+
+```alloy
+loki.write "openobserve" {
+  endpoint {
+    url = "https://<openobserve-host>/api/<organization>/loki/api/v1/push"
+    basic_auth {
+      username = "<user>"
+      password = "<password>"
+    }
+  }
+}
+```

--- a/docs/api/ingestion/logs/otlp.md
+++ b/docs/api/ingestion/logs/otlp.md
@@ -1,0 +1,135 @@
+---
+description: >-
+  Ingest logs via OpenTelemetry Protocol (OTLP) at POST /api/{org}/v1/logs.
+  Supports OTLP JSON and Protobuf formats with resource attributes and log records.
+---
+# Logs Ingestion - OTLP
+
+Endpoint: `POST /api/{organization}/v1/logs`
+
+OpenObserve supports the OpenTelemetry Protocol (OTLP) for log ingestion. You can send logs from any OpenTelemetry-compatible collector or SDK by pointing it at OpenObserve.
+
+> we use custom http header `stream-name` for speciafic stream name, default will push into `default` stream.
+
+## Request
+
+e.g. `POST /api/myorg/v1/logs`
+
+Content-Type: `application/json` (JSON) or `application/x-protobuf` (Protobuf)
+
+```json
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": { "stringValue": "my-service" }
+          },
+          {
+            "key": "service.version",
+            "value": { "stringValue": "1.2.3" }
+          },
+          {
+            "key": "host.name",
+            "value": { "stringValue": "ip-10-2-50-35.us-east-2.compute.internal" }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "my-logger",
+            "version": "1.0.0"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1672149599212000000",
+              "observedTimeUnixNano": "1672149599212000000",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": {
+                "stringValue": "Request processed successfully"
+              },
+              "attributes": [
+                {
+                  "key": "http.method",
+                  "value": { "stringValue": "GET" }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": { "intValue": "200" }
+                },
+                {
+                  "key": "trace_id",
+                  "value": { "stringValue": "4bf92f3577b34da6a3ce929d0e0e4736" }
+                }
+              ],
+              "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+              "spanId": "00f067aa0ba902b7"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `resourceLogs` | array | List of resource log groups. |
+| `resourceLogs[].resource` | object | Resource describing the entity producing the logs (e.g. service, host). |
+| `resourceLogs[].resource.attributes` | array | Key-value pairs for resource-level metadata. |
+| `resourceLogs[].scopeLogs` | array | List of instrumentation scope log groups. |
+| `scopeLogs[].scope` | object | Instrumentation scope (library name and version). |
+| `scopeLogs[].logRecords` | array | List of individual log records. |
+| `logRecords[].timeUnixNano` | string | Log timestamp in **nanoseconds** since Unix epoch. |
+| `logRecords[].observedTimeUnixNano` | string | Time the log was observed by the collector, in nanoseconds. |
+| `logRecords[].severityNumber` | integer | Numeric severity level (1–24). See [OTLP severity levels](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber). |
+| `logRecords[].severityText` | string | Human-readable severity string (e.g. `INFO`, `WARN`, `ERROR`). |
+| `logRecords[].body` | object | Log message body. Typically a `stringValue`. |
+| `logRecords[].attributes` | array | Key-value pairs for log-level metadata. |
+| `logRecords[].traceId` | string | Trace ID associated with this log record (hex string). |
+| `logRecords[].spanId` | string | Span ID associated with this log record (hex string). |
+
+## Response
+
+```json
+{
+  "partialSuccess": {}
+}
+```
+
+HTTP status `200 OK` with an empty `partialSuccess` object indicates all records were accepted, matching the standard OTLP HTTP response format.
+
+## Authentication
+
+Pass your credentials using HTTP Basic Auth or via the `Authorization` header:
+
+```
+Authorization: Basic <base64(user:password)>
+```
+
+## Configuring OpenTelemetry Collector
+
+Configure the OTLP exporter in your OpenTelemetry Collector `config.yaml` to forward logs to OpenObserve:
+
+```yaml
+exporters:
+  otlphttp/openobserve:
+    endpoint: https://<openobserve-host>/api/<organization>
+    headers:
+      Authorization: "Basic <base64(user:password)>"
+      stream-name: "custom_stream"
+
+service:
+  pipelines:
+    logs:
+      receivers: [...]
+      processors: [...]
+      exporters: [otlphttp/openobserve]
+```

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -152,13 +152,6 @@ This is particularly useful when you have only one organization, as creating mul
 | ZO_JSON_LIMIT | 209715200 | The max payload size of JSON. |
 | ZO_PAYLOAD_LIMIT | 209715200 | The max payload size of http request body. |
 
-## Actix Server
-| Environment Variable | Default Value | Description |
-|---------------------|---------------|-------------|
-| ZO_ACTIX_REQ_TIMEOUT | 30 | Sets actix server client timeout in seconds for first request. |
-| ZO_ACTIX_KEEP_ALIVE | 30 | Sets actix server keep-alive preference in seconds. |
-| ZO_ACTIX_SHUTDOWN_TIMEOUT | | Sets timeout for graceful worker shutdown of actix workers. |
-
 ## Cookies
 | Environment Variable | Default Value | Description |
 |---------------------|---------------|-------------|
@@ -882,9 +875,6 @@ When set to false, nodes rely on slower failure detection mechanisms and continu
 | ZO_QUERY_ON_STREAM_SELECTION         |                            | No           |  |
 | ZO_ENABLE_INVERTED_INDEX             | false                      | No           |  |
 | ZO_IGNORE_FILE_RETENTION_BY_STREAM   |                            | No           |  |
-| ZO_ACTIX_REQ_TIMEOUT                 | 30                         | No           | Sets actix server client timeout in seconds for first request. |
-| ZO_ACTIX_KEEP_ALIVE                  | 30                         | No           | Sets actix server keep-alive preference in seconds.            |
-| ZO_ACTIX_SHUTDOWN_TIMEOUT            |                            | No           | Sets timeout for graceful worker shutdown of actix workers.    |
 | ZO_COOKIE_SAME_SITE_LAX              | true                       | No           | If true, same site "lax" cookie is set by the server while authentication. |
 | ZO_COOKIE_SECURE_ONLY                | false                      | No           | If true, secure flag is enabled for the cookie set by the server while authentication. |
 | ZO_DISTINCT_VALUES_INTERVAL          |                            | No           |  |


### PR DESCRIPTION
- Removed Actix server environment variables from the environment-variables.md file.
- Updated navigation and index files to include new Loki and OTLP ingestion documentation.
- Added detailed documentation for Loki and OTLP log ingestion APIs, including request/response formats and configuration examples.