### PR TITLE
docs: Add LangChain and Ollama integration docs

### DIFF
--- a/docs/integration/ai/frameworks/.pages
+++ b/docs/integration/ai/frameworks/.pages
@@ -1,0 +1,5 @@
+nav:
+    - LangChain / LangGraph: langchain.md
+    - LiteLLM SDK: litellm.md
+    - Vercel AI SDK: vercel-ai.md
+    - CrewAI: crewai.md

--- a/docs/integration/ai/frameworks/langchain.md
+++ b/docs/integration/ai/frameworks/langchain.md
@@ -1,0 +1,145 @@
+---
+title: LangChain / LangGraph
+description: Instrument LangChain and LangGraph applications and send traces to OpenObserve via OpenTelemetry.
+---
+
+# **LangChain / LangGraph → OpenObserve**
+
+Automatically trace every chain execution, LLM call, tool invocation, and retrieval step in your LangChain or LangGraph application.
+
+## **Prerequisites**
+
+* Python 3.8+
+* An [OpenObserve](https://openobserve.ai/) account (cloud or self-hosted)
+* Your OpenObserve **organisation ID** and **Base64-encoded auth token**
+
+## **Installation**
+
+```shell
+pip install openobserve-telemetry-sdk opentelemetry-instrumentation-langchain python-dotenv
+```
+
+For LangGraph applications, also install LangGraph:
+
+```shell
+pip install langgraph
+```
+
+## **Configuration**
+
+Create a `.env` file in your project root:
+
+```
+# OpenObserve instance URL
+# Default for self-hosted: http://localhost:5080
+OPENOBSERVE_URL=https://api.openobserve.ai/
+
+# Your OpenObserve organisation slug or ID
+OPENOBSERVE_ORG=your_org_id
+
+# Basic auth token — Base64-encoded "email:password"
+OPENOBSERVE_AUTH_TOKEN="Basic <your_base64_token>"
+
+# LLM provider key (whichever backend LangChain is calling)
+OPENAI_API_KEY=your-openai-key
+```
+
+## **Instrumentation**
+
+Call `LangchainInstrumentor().instrument()` **before** importing any LangChain modules to ensure all chains, agents, and tools are captured automatically.
+
+### LangChain
+
+```python
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+from openobserve import openobserve_init
+
+LangchainInstrumentor().instrument()
+openobserve_init()
+
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+llm = ChatOpenAI(model="gpt-4o")
+
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "You are a helpful assistant."),
+    ("user", "{question}"),
+])
+
+chain = prompt | llm | StrOutputParser()
+
+response = chain.invoke({"question": "What is OpenTelemetry?"})
+print(response)
+```
+
+### LangGraph
+
+LangGraph builds on LangChain, so the same instrumentor covers graph executions, node transitions, and all nested LLM calls.
+
+```python
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+from openobserve import openobserve_init
+
+LangchainInstrumentor().instrument()
+openobserve_init()
+
+from langgraph.graph import StateGraph, END
+from langchain_openai import ChatOpenAI
+from typing import TypedDict
+
+llm = ChatOpenAI(model="gpt-4o")
+
+class State(TypedDict):
+    messages: list
+
+def call_model(state: State):
+    response = llm.invoke(state["messages"])
+    return {"messages": state["messages"] + [response]}
+
+graph = StateGraph(State)
+graph.add_node("model", call_model)
+graph.set_entry_point("model")
+graph.add_edge("model", END)
+app = graph.compile()
+
+result = app.invoke({"messages": [{"role": "user", "content": "Hello!"}]})
+print(result["messages"][-1].content)
+```
+
+## **What Gets Captured**
+
+| Attribute | Description |
+| ----- | ----- |
+| `langchain_request_type` | Span type: `llm`, `chain`, `tool`, `retriever` |
+| `gen_ai_request_model` | Model name (e.g. `gpt-4o`) |
+| `gen_ai_usage_input_tokens` | Input tokens consumed |
+| `gen_ai_usage_output_tokens` | Output tokens generated |
+| `llm_usage_tokens_total` | Total tokens |
+| `llm_usage_cost_input` | Estimated input cost in USD |
+| `llm_usage_cost_output` | Estimated output cost in USD |
+| `llm_usage_cost_total` | Estimated total cost in USD |
+| `langchain_retriever_query` | Query sent to a retriever |
+| `langchain_tool_name` | Name of the tool invoked |
+| `duration` | End-to-end span latency |
+| `error` | Exception details on failure |
+
+Each chain invocation produces a root span with child spans for every nested LLM call, tool use, and retrieval step.
+
+## **Viewing Traces**
+
+1. Log in to OpenObserve and navigate to **Traces** in the left sidebar
+2. Click any root span to expand the full chain execution tree
+3. Inspect token counts, latency, and retriever results at each step
+
+## **Next Steps**
+
+With LangChain instrumented, every chain execution is automatically recorded in OpenObserve — including all nested LLM calls, tool invocations, and retrieval steps. From here you can visualise the full execution tree, track token usage per chain run, and identify latency bottlenecks across your pipeline.
+
+## **Read More**
+
+- [LLM Observability Overview](../llm-applications.md)
+- [Traces Ingestion with Python](../../../ingestion/traces/python.md)
+- [Exploring Traces in OpenObserve](../../../user-guide/data-exploration/traces/)
+- [Building Dashboards](../../../user-guide/analytics/dashboards/)

--- a/docs/integration/ai/providers/ollama.md
+++ b/docs/integration/ai/providers/ollama.md
@@ -1,0 +1,132 @@
+---
+title: Ollama
+description: Instrument Ollama calls and send traces to OpenObserve via OpenTelemetry.
+---
+
+# **Ollama → OpenObserve**
+
+Automatically capture token usage, latency, and model metadata for every Ollama inference call in your Python application — no cloud API key required.
+
+## **Prerequisites**
+
+* Python 3.8+
+* [Ollama](https://ollama.com/) running locally (default: `http://localhost:11434`)
+* An [OpenObserve](https://openobserve.ai/) account (cloud or self-hosted)
+* Your OpenObserve **organisation ID** and **Base64-encoded auth token**
+
+Pull a model before running the examples:
+
+```shell
+ollama pull llama3.2
+```
+
+## **Installation**
+
+```shell
+pip install openobserve-telemetry-sdk opentelemetry-instrumentation-ollama ollama python-dotenv
+```
+
+## **Configuration**
+
+Create a `.env` file in your project root:
+
+```
+# OpenObserve instance URL
+# Default for self-hosted: http://localhost:5080
+OPENOBSERVE_URL=https://api.openobserve.ai/
+
+# Your OpenObserve organisation slug or ID
+OPENOBSERVE_ORG=your_org_id
+
+# Basic auth token — Base64-encoded "email:password"
+OPENOBSERVE_AUTH_TOKEN="Basic <your_base64_token>"
+
+# Ollama base URL (change if Ollama is running on a different host)
+OLLAMA_HOST=http://localhost:11434
+```
+
+## **Instrumentation**
+
+Call `OllamaInstrumentor().instrument()` **before** any Ollama client is created.
+
+```python
+from opentelemetry.instrumentation.ollama import OllamaInstrumentor
+from openobserve import openobserve_init
+
+# Instrument before importing the Ollama client
+OllamaInstrumentor().instrument()
+openobserve_init()
+
+import ollama
+
+# Chat completion
+response = ollama.chat(
+    model="llama3.2",
+    messages=[{"role": "user", "content": "Explain distributed tracing in one sentence."}],
+)
+print(response["message"]["content"])
+```
+
+### Streaming
+
+```python
+stream = ollama.chat(
+    model="llama3.2",
+    messages=[{"role": "user", "content": "Write a haiku about observability."}],
+    stream=True,
+)
+for chunk in stream:
+    print(chunk["message"]["content"], end="", flush=True)
+```
+
+### Using the OpenAI-compatible endpoint
+
+If you use Ollama's OpenAI-compatible API (`/v1/chat/completions`), instrument it with the OpenAI instrumentor instead:
+
+```python
+from opentelemetry.instrumentation.openai import OpenAIInstrumentor
+from openobserve import openobserve_init
+from openai import OpenAI
+
+OpenAIInstrumentor().instrument()
+openobserve_init()
+
+client = OpenAI(base_url="http://localhost:11434/v1", api_key="ollama")
+
+response = client.chat.completions.create(
+    model="llama3.2",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+```
+
+## **What Gets Captured**
+
+| Attribute | Description |
+| ----- | ----- |
+| `gen_ai_request_model` | Model name (e.g. `llama3.2`) |
+| `gen_ai_usage_input_tokens` | Tokens in the prompt |
+| `gen_ai_usage_output_tokens` | Tokens in the response |
+| `llm_usage_tokens_total` | Total tokens consumed |
+| `llm_usage_cost_input` | Estimated input cost in USD |
+| `llm_usage_cost_output` | Estimated output cost in USD |
+| `gen_ai_system` | `ollama` |
+| `duration` | End-to-end request latency |
+| `error` | Exception details if the request failed |
+
+## **Viewing Traces**
+
+1. Log in to OpenObserve and navigate to **Traces**
+2. Click any span to inspect token counts and full request metadata
+3. Use `gen_ai_request_model` to compare latency across different locally-hosted models
+
+## **Next Steps**
+
+With Ollama instrumented, every local inference call is automatically recorded in OpenObserve — no cloud API key required. From here you can compare token throughput across models, monitor latency for different prompt sizes, and benchmark locally-hosted models side by side.
+
+## **Read More**
+
+- [LLM Observability Overview](../llm-applications.md)
+- [Traces Ingestion with Python](../../../ingestion/traces/python.md)
+- [Exploring Traces in OpenObserve](../../../user-guide/data-exploration/traces/)
+- [Building Dashboards](../../../user-guide/analytics/dashboards/)


### PR DESCRIPTION
Add instrumentation pages for LangChain/LangGraph and Ollama providers with verified span attributes, Next Steps sections, and relevant Read More links to OpenObserve docs.