### PR TITLE
docs: remove ZO_COMPACT_OLD_DATA_MIN_RECORDS env var

### DIFF
--- a/docs/administration/configuration/environment-variables.md
+++ b/docs/administration/configuration/environment-variables.md
@@ -121,8 +121,7 @@ This is particularly useful when you have only one organization, as creating mul
 | ZO_COMPACT_OLD_DATA_STREAMS              | -             | Comma-separated stream list to treat as old data.                                              |
 | ZO_COMPACT_OLD_DATA_MAX_DAYS            | 7             | Maximum age of data to qualify as old in days.                                                 |
 | ZO_COMPACT_OLD_DATA_MIN_HOURS           | 2             | Minimum age of data to qualify as old in hours.                                                |
-| ZO_COMPACT_OLD_DATA_MIN_RECORDS         | 100           | Minimum record count to compact old data.                                                      |
-| ZO_COMPACT_OLD_DATA_MIN_FILES           | 10            | Minimum file count to compact old data.                                                        |
+| ZO_COMPACT_OLD_DATA_MIN_FILES           | 10            | Minimum number of files smaller than half of `ZO_COMPACT_MAX_FILE_SIZE` required in an hour to trigger old-data compaction. |
 | ZO_COMPACT_BATCH_SIZE                     | 0             | Batch size for fetching pending compaction jobs.                                               |
 | ZO_COMPACT_JOB_RUN_TIMEOUT               | 600           | Time limit for one compaction job in seconds. Jobs that exceed this time are marked as failed. |
 | ZO_COMPACT_JOB_CLEAN_WAIT_TIME          | 7200          | Minimum age of finished jobs before cleanup in seconds.                                        |


### PR DESCRIPTION
## Summary

- Remove the `ZO_COMPACT_OLD_DATA_MIN_RECORDS` row from the env var reference table.
- Refine the `ZO_COMPACT_OLD_DATA_MIN_FILES` description to clarify that "files" means files smaller than half of `ZO_COMPACT_MAX_FILE_SIZE`.

Tracks the code change in openobserve/openobserve#11638, which replaces the records-count heuristic with a file-size check derived from `ZO_COMPACT_MAX_FILE_SIZE`.

## Test plan

- [x] Render the env vars page locally and confirm the table renders cleanly with no orphan row
- [x] Confirm no other docs page still references `ZO_COMPACT_OLD_DATA_MIN_RECORDS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)