### PR TITLE
fix: revamped remaining top traffic pages

### DIFF
--- a/docs/administration/maintenance/storage-management/storage.md
+++ b/docs/administration/maintenance/storage-management/storage.md
@@ -1,7 +1,10 @@
 ---
+title: Storage Management | OpenObserve
 description: >-
-  Learn how OpenObserve stores ingested stream data and the metadata for ingested date using disk, SQLite, Postgres, or S3-compatible object storage.
+  Learn how OpenObserve stores ingested stream data and the metadata for ingested data using disk, SQLite, Postgres, or S3-compatible object storage.
 ---
+# Storage
+
 This guide explains how to configure data and metadata storage in OpenObserve. The information applies to both the open-source and enterprise versions.
 
 ## Overview
@@ -13,22 +16,21 @@ There are 2 primary items that need to be stored in OpenObserve.
 By default: 
 
 - Metadata is always stored on disk using **SQLite** in **Local mode**.
-- Metadata is always stored on disk using **postgres** in **Cluster mode**.
-- Stream data can be stored on disk or object storage such as Amazon S3, minIO, Google GCS, Alibaba OSS, or Tencent COS.
+- Metadata is always stored on disk using **PostgreSQL** in **Cluster mode**.
+- Stream data can be stored on disk or object storage such as Amazon S3, MinIO, Google GCS, Alibaba OSS, or Tencent COS.
 
 ## Storage Modes
 
 - OpenObserve runs in **Local mode** by default.
-- To enable **Cluster mode**, set the environment variable `LOCAL_MODE=false`.
+- To enable **Cluster mode**, set the environment variable `ZO_LOCAL_MODE=false`.
 - In **Local mode**, stream data can be stored in S3 by setting `ZO_LOCAL_MODE_STORAGE=s3`.
-- GCS and OSS support the S3 SDK and can be treated as S3-compatible storages. Azure Blob storage is also supported.
+- GCS and OSS support the S3 SDK and can be treated as S3-compatible storages.
+- Azure Blob storage is supported via `ZO_S3_PROVIDER=azure`.
 
-## Data Storage Format
+### Data Storage Format
 
-Stream data is stored in Parquet format. Parquet is columnar storage format optimized for storage efficiency and query performance. 
-
+Stream data is stored in **Parquet** format, a columnar storage format optimized for storage efficiency and query performance.
 ## Stream Data Storage Options
-
 ### Disk
 
 Disk is default storage place for stream data. **Ensure that sufficient disk space is available for storing stream data.**
@@ -61,7 +63,7 @@ Then set the following environment variables:
 | ZO_S3_PROVIDER       | minio | ...                                             |
 
 
-### Openstack Swift
+### OpenStack Swift
 To use OpenStack Swift for storing stream data, first create the bucket in Swift.
 Then set the following environment variables:
 
@@ -72,7 +74,7 @@ Then set the following environment variables:
 | ZO_S3_ACCESS_KEY          | -     | Access key                                      |
 | ZO_S3_SECRET_KEY          | -     | Secret key                                      |
 | ZO_S3_BUCKET_NAME         | -     | Bucket name                                     |
-| ZO_S3_FEATURE_HTTP1_ONLY  | true  | 	Enables compatibility with Swift                                              |
+| ZO_S3_FEATURE_HTTP1_ONLY  | true  | Enables compatibility with Swift                |
 | ZO_S3_PROVIDER            | s3    | Enables S3-compatible API                           |
 | AWS_EC2_METADATA_DISABLED | true  | Disables EC2 metadata access, which is not supported by Swift |
 
@@ -80,7 +82,7 @@ Then set the following environment variables:
 ### Google GCS
 To use GCS for storing stream data, first create the bucket in GCS.
 
-**Using the S3-compatible API:**
+#### Using the S3-compatible API
 
 | Environment Variable     | Value  | Description                                                     |
 | ------------------------ | -------| --------------------------------------------------------------- |
@@ -94,7 +96,7 @@ To use GCS for storing stream data, first create the bucket in GCS.
 
 Refer to [GCS AWS migration documentation](https://cloud.google.com/storage/docs/aws-simple-migration) for more information.
 
-**Using GCS directly:**
+#### Using GCS directly
 
 | Environment Variable     | Value  | Description                                                             |
 | ------------------------ | -------| ----------------------------------------------------------------------- |
@@ -106,7 +108,7 @@ Refer to [GCS AWS migration documentation](https://cloud.google.com/storage/docs
 
 OpenObserve uses the [object_store crate](https://docs.rs/object_store/0.10.1/object_store/gcp/struct.GoogleCloudStorageBuilder.html) to initialize the storage configuration. It calls the with_env() function by default. If the ZO_S3_ACCESS_KEY variable is set, OpenObserve additionally uses the with_service_account_path() function to load the GCP service account key.
 
-### Alibaba OSS (aliyun)
+### Alibaba OSS (Aliyun)
 To use Alibaba OSS for storing stream data, first create the bucket in Alibaba Cloud.
 Then set the following environment variables:
 
@@ -164,15 +166,15 @@ Refer to [Baidu BOS documentation](https://cloud.baidu.com/doc/BOS/s/xjwvyq9l4).
 
 ### Azure Blob
 
-OpenObserve can use azure blob for storing stream data. Following environment variables needs to be setup:
+OpenObserve can use Azure Blob for storing stream data. The following environment variables need to be set:
 
 | Environment Variable       | Value                | Description                                  |
 | -------------------------- | -------------------- | -------------------------------------------- |
-| ZO_S3_PROVIDER             | azure                | Enables Azure Blob storage support                   |
+| ZO_S3_PROVIDER             | azure                | Enables Azure Blob storage support           |
 | ZO_LOCAL_MODE_STORAGE      | s3                   | Required only if running in single node mode |
-| AZURE_STORAGE_ACCOUNT_NAME | Storage account name | Need to provide mandatorily                  |
-| AZURE_STORAGE_ACCOUNT_KEY  | Access key           | Need to provide mandatorily                  |
-| ZO_S3_BUCKET_NAME          | Blob Container name  | Need to provide mandatorily                  |
+| AZURE_STORAGE_ACCOUNT_NAME | Storage account name | Required                                     |
+| AZURE_STORAGE_ACCOUNT_KEY  | Access key           | Required                                     |
+| ZO_S3_BUCKET_NAME          | Blob Container name  | Required                                     |
 
 ### Hetzner Cloud Object Storage
 
@@ -215,17 +217,25 @@ OpenObserve supports multiple metadata store backends, configurable using the `Z
 ### PostgreSQL
 - Set `ZO_META_STORE=postgres`.
 - Recommended for production deployments due to reliability and scalability. 
-- The default Helm chart (after February 23, 2024) uses [cloudnative-pg](https://cloudnative-pg.io/) to create a postgres cluster (primary + replica) which is used as the meta store. These instances provide high availability and backup support.
+- The default Helm chart (after February 23, 2024) uses [cloudnative-pg](https://cloudnative-pg.io/) to create a PostgreSQL cluster (primary + replica) which is used as the meta store. These instances provide high availability and backup support.
 
 ### etcd (Removed)
 
 !!! warning "Removal notice"
-    Etcd support has been removed. Use NATS instead.
-    
-- Set `ZO_META_STORE=etcd`.
-- While etcd is used as the cluster coordinator, it was also the default metadata store in Helm charts released before 23 February 2024. This configuration is now deprecated. Helm charts released after 23 February 2024 use PostgreSQL as the default metadata store.
+    Etcd support has been removed. Use NATS as the cluster coordinator and PostgreSQL (or MySQL) as the metadata store. Helm charts released after 23 February 2024 already use PostgreSQL by default.
 
 ### MySQL (Deprecated)
 - Set `ZO_META_STORE=mysql`.
 - Deprecated. 
 - Use PostgreSQL instead.
+
+## Next steps
+
+- [HA deployment](../../deployment/ha-deployment.md): configure object storage and metadata store in a production cluster.
+- [Environment variables](../../configuration/environment-variables.md): full reference for `ZO_S3_*` and `ZO_META_*` settings.
+- [Capacity planning](../../../enterprise-setup/capacity-planning.md): sizing storage, compute, and memory for each component.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/enterprise-setup/performance.md
+++ b/docs/enterprise-setup/performance.md
@@ -45,13 +45,16 @@ If you have very high ingestion speed requirements (e.g. 100s of thousands of ev
 
 OpenObserve does not do full-text indexing like Elasticsearch. This results in very high compression ratio of ingested data. Coupled with object storage this can give you ~140x lower storage cost. However, this also means that search performance for full text queries in absence of full-text indexes might suffer. However log data has some unique properties that can be leveraged to improve search performance significantly. OpenObserve uses following techniques to improve search performance:
 
-### Column pruning 
+### Column pruning
+
 OpenObserve uses columnar storage format (parquet) which allows it to read only the columns that are required for a query. This reduces the amount of data that needs to be read from disk and improves search performance. This technique is called column pruning. It reduces the amount of data that needs to be read from disk. You must switch to SQL query mode for this and specify only the columns that you want to be returned.
 
-### Predicate pushdown: 
+### Predicate pushdown
 
-#### Standard Partitioning (KeyValue partitions) 
->Note: Use For low cardinality fields
+#### Standard Partitioning (KeyValue partitions)
+
+!!! note
+    Use for low cardinality fields.
 
 OpenObserve uses a technique called predicate pushdown to further reduce the amount of data that needs to be read from disk. This is done by pushing down the filters to the storage layer. By default OpenObserve will partition data by `org/stream/year/month/day/hour`. So when searching, if you know the time range for which you are searching for data you should specify it and OpenObserve will skip data not following in date range and will search across much less data. This will improve search performance and will utilize predicate pushdown. You can also enable additional partitioning for fields on any stream by going to stream settings. Some good candidates for partition keys are host and kubernetes namespace. You can have multiple partition keys for a stream. You can then specify partition keys in your query. e.g. `host='xyz' and kubernetes_namespace='abc'`. This will improve search performance and will utilize predicate pushdown.*** `DO NOT enable partitioning on all/many fields as it may result in many small underlying parquet files which will result in low compression, extremely poor search performance and high s3 storage costs` ***. As a rule of thumb you would want the size of each stored parquet file to be above 5 MB. Order of partitions does not matter. You can partition by `namespace, pod` or `pod, namespace`. 
 
@@ -116,12 +119,16 @@ For the above scenario, you can enable hash partitioning on namespace field with
 You can specify the number of buckets (8, 16, 32, 64, 128) in the index in stream setting when setting up hash partitioning for a particular field.
 
 #### Time range partition
->Note: Enabled by default and cannot be disabled
+
+!!! note
+    Enabled by default and cannot be disabled.
 
 OpenObserve partitions all data by time range by default in addition to any other partitions that you may have defined. It always makes sense to specify the shortest time range to search for. e.g. if you know that you are looking for data for last 15 minutes, you should specify that in your query by selecting it from the top right corner. This will improve search performance and will utilize predicate pushdown.
 
-### Bloom filter (available starting v0.8.0) (For high cardinality fields)
->Note: Use For high cardinality fields
+### Bloom filter
+
+!!! note
+    Use for high cardinality fields. Available starting v0.8.0.
 
 A bloom filter is a space efficient probabilistic data structure that allow you to check if a value exists in a set. It solves proverbial `needle in a haystack` problem. OpenObserve uses bloom filters to check if a value exists in a column. This allows OpenObserve to skip reading the data from disk if the value does not exist in the column. This improves search performance by reducing `search space`. You must specify bloom filter for the specific fields that you want to search.  Fields that are well suited for bloom filter are of very high cardinality .e.g. UUID, request_id, trace_id, device_id, etc. You can specify bloom filter for a field by going to stream settings. You can specify multiple fields for bloom filter. e.g. `request_id` and `trace_id`. You can then use the fields in your query that will utilize bloom filter. e.g. `request_id='abc' and trace_id='xyz'`. Enabling bloom filter on a field with low cardinality will not result in any performance improvement. 
 
@@ -133,7 +140,10 @@ Log search involves full text search. When you try to do a full text search it e
 1. Do not use `match_all` directly on full data set, but always use it in combination with one or more filters which can themselves be optimized by partitions or bloom filters. e.g. `host='host1' and match_all('error') ` or `k8s_namespace_name='ns1' and match_all('error')` or `bank_account_number='653456-54654-65' and match_all('error')`. In all of these examples using the filter reduces search space for `match_all`. Additionally if `host` and `k8s_namespace_name` fields are partitioned then you have reduced search space very well and will gain the improvements in full text search. `bank_account_number`, `request_id`, `trace_id`, `device_id` are good candidates for bloom filter and should be used together with `match_all` to improve full text search performance.
 1. Enable full text search only on the fields that you need. e.g. body, log, message etc. Fields like hostname, ip address, etc. are not good candidates for full text search and you should not enable full text search on these fields. You can enable full text search on a field by going to stream settings. You can specify multiple fields for full text search. e.g. `body` and `message`. You can then use the fields in your query that will utilize full text search. e.g. `host='host1' and match_all('error')`. 
 
-### Inverted Index (available starting v0.10.0)
+### Inverted Index
+
+!!! note
+    Available starting v0.10.0.
 
 Above mentioned partitioning schemes and bloom filters are good for fields where you are doing equality based searches. e.g. `request_id='abc'`. For full text search in fields that contain longer log lines, OpenObserve in its earlier releases relied on brute force search (how [grep](https://www.gnu.org/software/grep/manual/grep.html) works) which works well for most of the scenarios. However, for very large data sets this can be slow. You can enable inverted index to improve full text search performance for such fields. Do not enable inverted index for fields that are not used for full text search but are used for equality based searches. Bloom filters and hash partitions are better suited for equality based searches.
 
@@ -324,4 +334,16 @@ By enabling User-Defined Schemas (via `ZO_ALLOW_USER_DEFINED_SCHEMAS=true`), you
 **Example:** If you have 5,000 fields and select only 50 as part of the UDS, queries will now only consider these 50 fields directly, greatly improving performance. The remaining 4,950 fields will be combined into a single `_raw` field (a string), which won’t be searchable.  
 
 If you later need one of the fields from the `_raw` data to be searchable, simply add it to the UDS in the stream’s settings. After doing so, this field will become searchable going forward.
+
+## Next steps
+
+- [Capacity planning](capacity-planning.md): sizing CPU, memory, and storage for each component.
+- [HA deployment](../administration/deployment/ha-deployment.md): production-grade cluster setup.
+- [Architecture](../architecture.md): understand how the components interact.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)
+
 

--- a/docs/enterprise-setup/sre-agent.md
+++ b/docs/enterprise-setup/sre-agent.md
@@ -6,6 +6,8 @@ description: >-
 keywords: 'openobserve, sre agent, ai assistant, setup, configuration, incidents, rca'
 ---
 
+# O2 SRE Agent Setup
+
 ## Overview
 
 The O2 SRE Agent is a background service that powers AI-driven features in OpenObserve Enterprise. It handles AI request processing, tool execution, and intelligence for observability workflows.
@@ -13,7 +15,7 @@ The O2 SRE Agent is a background service that powers AI-driven features in OpenO
 
 ## Features Enabled by SRE Agent
 
-### 1. AI Assistant
+### AI Assistant
 - Natural language querying of logs, metrics, and traces
 - Automated SQL/PromQL/VRL query generation
 - Resource creation (dashboards, alerts) via chat
@@ -21,7 +23,7 @@ The O2 SRE Agent is a background service that powers AI-driven features in OpenO
 - Script generation (Python/VRL)
 - Query validation before execution
 
-### 2. Incident Management & RCA
+### Incident Management & RCA
 - Automated incident detection and grouping
 - AI-powered Root Cause Analysis
 - Alert correlation and event tracking
@@ -30,7 +32,8 @@ The O2 SRE Agent is a background service that powers AI-driven features in OpenO
 ## Prerequisites
 
 1. **OpenObserve Enterprise License** (v0.60.0+)
-2. **AI Provider API Key** 
+2. **AI Provider API Key** with available quota (Anthropic, OpenAI, or Google Gemini)
+3. **`O2_AI_ENABLED`** set to `"true"` in your OpenObserve configuration
 
 ## Configuration Methods
 
@@ -60,7 +63,7 @@ Update your `values.yaml` with the following configuration:
 enterprise:
   enabled: true
 
-  # IMPORTANT: Must be set to true if O2_AI_ENABLED is "true"
+  # Required when O2_AI_ENABLED is "true"
   sreagent:
     enabled: true
     config:
@@ -357,9 +360,9 @@ Restart OpenObserve services to apply changes.
 
 For detailed information about all available environment variables and their configurations, refer to the official documentation:
 
-- [SRE Agent Configuration](https://openobserve.ai/docs/environment-variables/#sre-agent-configuration)
-- [AI Integration](https://openobserve.ai/docs/environment-variables/#ai-integration)
-- [Incidents and RCA](https://openobserve.ai/docs/environment-variables/#incidents-and-rca)
+- [SRE Agent Configuration](../administration/configuration/environment-variables.md#sre-agent-configuration)
+- [AI Integration](../administration/configuration/environment-variables.md#ai-integration)
+- [Incidents and RCA](../administration/configuration/environment-variables.md#incidents-and-rca)
 
 ## AI Provider Selection
 
@@ -382,7 +385,7 @@ An AI Gateway provides rate limiting, response caching, load balancing, and usag
 
 ### Configuration Flows
 
-**Flow 1: OpenObserve Built-in Gateway (Recommended)**
+#### Flow 1: OpenObserve Built-in Gateway (Recommended)
 
 Uses the [O2 Envoy Gateway](https://github.com/openobserve/o2-envoy-gateway) for AI request management.
 
@@ -399,7 +402,7 @@ enterprise:
     # Gateway settings auto-configured
 ```
 
-**Flow 2: External/Self-hosted Gateway**
+#### Flow 2: External/Self-hosted Gateway
 
 ```yaml
 enterprise:
@@ -411,7 +414,7 @@ enterprise:
       # O2_AI_PROVIDER not needed
 ```
 
-**Flow 3: Direct API (No Gateway)**
+#### Flow 3: Direct API (No Gateway)
 
 ```yaml
 enterprise:
@@ -430,9 +433,7 @@ Model Context Protocol (MCP) handles communication between the SRE Agent and Ope
 **Recommended for Production:**
 - Enable all validation settings (`O2_MCP_VALIDATION_ENABLED: "true"`)
 
-- Use `hybrid` validation mode for 
-balanced security and flexibility
-
+- Use `hybrid` validation mode for balanced security and flexibility
 - Configure MCP authentication for multi-tenant environments
 
 **Development:** Can disable validation (`O2_MCP_VALIDATION_ENABLED: "false"`) for faster iteration.
@@ -485,103 +486,118 @@ Why is the database connection pool exhausted?
 
 ## Troubleshooting
 
-### 1. SRE Agent Pod Not Starting
+??? "Common issues and fixes"
 
-**Check pod status:**
-```bash
-kubectl get pods -n openobserve | grep sreagent
-kubectl logs -n openobserve deployment/openobserve-sreagent --tail=100
-```
+    1. **SRE Agent Pod Not Starting**
 
-**Common causes:**
-- Invalid API key
-- Incorrect AI provider name
-- Network connectivity issues
+        Check pod status:
 
-**Verify configuration:**
-```bash
-# Check API key exists
-kubectl get secret -n openobserve openobserve-auth -o jsonpath='{.data.O2_AI_API_KEY}' | base64 -d
+        ```bash
+        kubectl get pods -n openobserve | grep sreagent
+        kubectl logs -n openobserve deployment/openobserve-sreagent --tail=100
+        ```
 
-# Check environment variables
-kubectl exec -n openobserve deployment/openobserve-sreagent -- env | grep O2_
-```
+        Common causes:
 
-### 2. AI Assistant Not Responding
+        - Invalid API key
+        - Incorrect AI provider name
+        - Network connectivity issues
 
-**Check connectivity:**
-```bash
-# Health check
-kubectl exec -n openobserve deployment/openobserve-router -- \
-  curl -s http://openobserve-sreagent:8000/health
+        Verify configuration:
 
-# Check logs
-kubectl logs -n openobserve deployment/openobserve-sreagent --tail=50
-```
+        ```bash
+        # Check API key exists
+        kubectl get secret -n openobserve openobserve-auth -o jsonpath='{.data.O2_AI_API_KEY}' | base64 -d
 
-**Common causes:**
-- `O2_AI_ENABLED` not set to `"true"`
-- Network policy blocking communication
-- AI provider API rate limiting
-- Service misconfiguration
+        # Check environment variables
+        kubectl exec -n openobserve deployment/openobserve-sreagent -- env | grep O2_
+        ```
 
-### 3. MCP Tool Execution Failures
+    2. **AI Assistant Not Responding**
 
-**Verify MCP endpoint:**
-```bash
-# Check O2_TOOL_API_URL
-kubectl exec -n openobserve deployment/openobserve-sreagent -- env | grep O2_TOOL_API_URL
+        Check connectivity:
 
-# Test connectivity
-kubectl exec -n openobserve deployment/openobserve-sreagent -- \
-  curl -s http://openobserve-router:5080/api/default/mcp
-```
+        ```bash
+        # Health check
+        kubectl exec -n openobserve deployment/openobserve-router -- \
+          curl -s http://openobserve-sreagent:8000/health
 
-**Common causes:**
-- Incorrect `O2_TOOL_API_URL` format
-- Wrong organization name in URL
-- Missing MCP credentials
-- Service not reachable
+        # Check logs
+        kubectl logs -n openobserve deployment/openobserve-sreagent --tail=50
+        ```
 
-**Correct URL format:**
-```
-http://<service-name>.<namespace>.svc.cluster.local:<port>/api/<org-name>/mcp
-```
+        Common causes:
 
-### 4. AI Gateway Issues
+        - `O2_AI_ENABLED` not set to `"true"`
+        - Network policy blocking communication
+        - AI provider API rate limiting
+        - Service misconfiguration
 
-**Check gateway:**
-```bash
-# Verify gateway service
-kubectl get svc -n <gateway-namespace> | grep ai-gateway
+    3. **MCP Tool Execution Failures**
 
-# Test connectivity
-kubectl exec -n openobserve deployment/openobserve-sreagent -- \
-  curl -s http://ai-gateway:80
-```
+        Verify MCP endpoint:
 
-**Common causes:**
-- Gateway not deployed
-- Conflicting configuration (both `O2_AI_PROVIDER` and `O2_AI_GATEWAY_ENABLED` set)
-- Wrong gateway URL or port
+        ```bash
+        # Check O2_TOOL_API_URL
+        kubectl exec -n openobserve deployment/openobserve-sreagent -- env | grep O2_TOOL_API_URL
 
-**Fix:**
-- With gateway: Remove `O2_AI_PROVIDER`, set `O2_AI_GATEWAY_ENABLED="true"`
-- Without gateway: Remove all `O2_AI_GATEWAY_*` variables, set `O2_AI_PROVIDER`
+        # Test connectivity
+        kubectl exec -n openobserve deployment/openobserve-sreagent -- \
+          curl -s http://openobserve-router:5080/api/default/mcp
+        ```
 
-### 5. Incident Management Not Working
+        Common causes:
 
-**Check configuration:**
-```bash
-kubectl get configmap -n openobserve openobserve-config -o yaml | grep O2_INCIDENTS
-```
+        - Incorrect `O2_TOOL_API_URL` format
+        - Wrong organization name in URL
+        - Missing MCP credentials
+        - Service not reachable
 
-**Required settings (in OpenObserve, not SRE Agent):**
-```yaml
-O2_AI_ENABLED: "true"
-O2_INCIDENTS_ENABLED: "true"
-O2_INCIDENTS_RCA_ENABLED: "true"
-```
+        Correct URL format:
+
+        ```
+        http://<service-name>.<namespace>.svc.cluster.local:<port>/api/<org-name>/mcp
+        ```
+
+    4. **AI Gateway Issues**
+
+        Check gateway:
+
+        ```bash
+        # Verify gateway service
+        kubectl get svc -n <gateway-namespace> | grep ai-gateway
+
+        # Test connectivity
+        kubectl exec -n openobserve deployment/openobserve-sreagent -- \
+          curl -s http://ai-gateway:80
+        ```
+
+        Common causes:
+
+        - Gateway not deployed
+        - Conflicting configuration (both `O2_AI_PROVIDER` and `O2_AI_GATEWAY_ENABLED` set)
+        - Wrong gateway URL or port
+
+        Fix:
+
+        - With gateway: Remove `O2_AI_PROVIDER`, set `O2_AI_GATEWAY_ENABLED="true"`
+        - Without gateway: Remove all `O2_AI_GATEWAY_*` variables, set `O2_AI_PROVIDER`
+
+    5. **Incident Management Not Working**
+
+        Check configuration:
+
+        ```bash
+        kubectl get configmap -n openobserve openobserve-config -o yaml | grep O2_INCIDENTS
+        ```
+
+        Required settings (in OpenObserve, not SRE Agent):
+
+        ```yaml
+        O2_AI_ENABLED: "true"
+        O2_INCIDENTS_ENABLED: "true"
+        O2_INCIDENTS_RCA_ENABLED: "true"
+        ```
 
 ## Best Practices
 
@@ -593,27 +609,10 @@ O2_INCIDENTS_RCA_ENABLED: "true"
 - **Cost Optimization**: Use AI Gateway with caching to reduce API calls; choose cost-effective models for simple queries
 - **Updates**: Keep SRE Agent image updated; test in non-production environments first
 
-## Support
 
 
-- [Community Slack](https://short.openobserve.ai/community) 
+### Support diagnostics
 
-- [GitHub](https://github.com/openobserve/openobserve)
-
-
-
-**Before contacting support, verify:**
-- SRE Agent pod is running and healthy
-
-- AI API key is valid with available quota
-
-- `O2_AI_ENABLED="true"` in OpenObserve config
-
-- Services can communicate (SRE Agent ↔ OpenObserve)
-
-- No conflicting AI Gateway configuration
-
-**Support diagnostics:**
 ```bash
 # Check pod and logs
 kubectl get pods -n openobserve | grep sreagent
@@ -623,4 +622,15 @@ kubectl logs -n openobserve deployment/openobserve-sreagent --tail=100
 kubectl get configmap -n openobserve openobserve-config -o yaml | grep O2_
 ```
 
----
+
+## Next steps
+
+- [Model Context Protocol (MCP)](../integration/ai/mcp/index.md): connect IDEs and agents to OpenObserve through the SRE Agent.
+- [AI Integration env vars](../administration/configuration/environment-variables.md#ai-integration): full reference for AI-related settings.
+- [Incidents and RCA env vars](../administration/configuration/environment-variables.md#incidents-and-rca): tune incident detection and root cause analysis.
+
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/features/enterprise.md
+++ b/docs/features/enterprise.md
@@ -1,3 +1,7 @@
+---
+title: Enterprise Features | OpenObserve
+description: Capabilities included in the OpenObserve Enterprise tier - extended retention, federated search, BYOB storage, SSO, RBAC, cipher keys, query management, workload management, and audit trail. Free for up to 50 GB of ingestion per day.
+---
 # Enterprise Features
 
 ## Overview
@@ -6,16 +10,35 @@ Enterprise tier includes all standard features plus the following enterprise-spe
 ## Enterprise-Only Features
 
 ### Data Management
-- [**Extended Data Retention**](../user-guide/data-processing/streams/extended-retention.md) - Keep data longer than standard retention periods
-- [**Federated Search / Super Cluster**](../user-guide/data-exploration/federated-search/index.md) - Search across multiple OpenObserve clusters from a single interface
-- [**Bring Your Own Bucket (BYOB)**](../administration/maintenance/storage-management/bring-your-own-bucket.md) - Connect your own AWS S3 or Azure Blob storage to OpenObserve Cloud
+- [Extended Data Retention](../user-guide/data-processing/streams/extended-retention.md): keep data longer than standard retention periods.
+- [Federated Search / Super Cluster](../user-guide/data-exploration/federated-search/index.md): search across multiple OpenObserve clusters from a single interface.
+- [Bring Your Own Bucket (BYOB)](../administration/maintenance/storage-management/bring-your-own-bucket.md): connect your own AWS S3 or Azure Blob storage to OpenObserve Cloud.
 
 ### Security & Access
-- [**SSO (Single Sign On)**](../user-guide/account-administration/identity-and-access-management/sso.md) - Integrate with existing identity providers
-- [**Role-Based Access Control (RBAC)**](../user-guide/account-administration/identity-and-access-management/role-based-access-control.md) - Manage user permissions by role
-- [**Cipher Keys**](../user-guide/account-administration/management/cipher-keys.md) - Encryption and compliance support for HIPAA and PCI
+- [SSO (Single Sign On)](../user-guide/account-administration/identity-and-access-management/sso.md): integrate with existing identity providers.
+- [Role-Based Access Control (RBAC)](../user-guide/account-administration/identity-and-access-management/role-based-access-control.md): manage user permissions by role.
+- [Cipher Keys](../user-guide/account-administration/management/cipher-keys.md): encryption and compliance support for HIPAA and PCI.
 
 ### Operations
-- [**Query Management**](../user-guide/account-administration/management/query-management.md) - Optimize and manage query performance
-- [**Workload Management (QoS)**](../user-guide/account-administration/work-group.md) - Prioritize and allocate resources
-- [**Audit Trail**](../user-guide/account-administration/management/audit-trail.md) - Track all system activities and changes
+- [Query Management](../user-guide/account-administration/management/query-management.md): optimize and manage query performance.
+- [Workload Management (QoS)](../user-guide/account-administration/work-group.md): prioritize and allocate resources.
+- [Audit Trail](../user-guide/account-administration/management/audit-trail.md): track all system activities and changes.
+
+## Get started
+
+Ready to deploy OpenObserve Enterprise?
+
+- [Enterprise installation](../enterprise-setup/index.md): pick the install path for your cloud.
+- [HA deployment](../administration/deployment/ha-deployment.md): production-grade cluster setup with object storage.
+- [SRE Agent setup](../enterprise-setup/sre-agent.md): enable AI-driven features and Incidents/RCA.
+
+## Next steps
+
+- [Capacity planning](../enterprise-setup/capacity-planning.md): sizing CPU, memory, and storage.
+- [Architecture](../architecture.md): how the components fit together.
+- [Performance tuning](../enterprise-setup/performance.md): squeeze more out of large deployments.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -1,3 +1,7 @@
+---
+title: Metrics in OpenObserve | OpenObserve
+description: Collect, store, query, and visualize metrics at scale with OpenObserve. Prometheus remote-write, OTLP, PromQL and SQL, real-time dashboards, downsampling, and configurable retention.
+---
 # Metrics
 
 OpenObserve provides comprehensive metrics collection, storage, and visualization capabilities for monitoring your applications and infrastructure performance in real-time.
@@ -6,46 +10,45 @@ OpenObserve provides comprehensive metrics collection, storage, and visualizatio
 
 Metrics in OpenObserve enable you to track key performance indicators, monitor system health, and gain insights into your application's behavior over time. Designed for high-throughput environments, OpenObserve efficiently handles metrics ingestion, storage, and querying at scale while maintaining cost-effectiveness.
 
-![Metrics Page](../images/features/metrics-hero.png)
-*Metrics Page view*
+![Metrics Page view](../images/features/metrics-hero.png)
 
 ## Key Features
 
 ### Metrics Ingestion
 - **Multiple Formats**: Support for multiple formats including Prometheus remote-write and structured JSON metrics via HTTP ingestion.
 - **Push & Pull Models**: Supports push-based ingestion and integration with systems like Prometheus for pull-based scraping.
-- **High Throughput**: Handle millions of metrics per second with minimal latency
+- **High Throughput**: Handle millions of metrics per second with minimal latency.
 - **Optimized Processing**: Optimized ingestion pipelines for high-throughput environments.
 
-### Data Types & Structure
-- **Time Series Data**: Native support for time-series metrics with timestamp precision
-- **Multi-dimensional**: Handle metrics with multiple labels and dimensions for detailed analysis
-- **Aggregation Functions**: Built-in support for common aggregation functions (sum, avg, min, max, count)
-- **Custom Metrics**: Flexible schema for application-specific metrics and KPIs
+### Metric Structure
+- **Time Series Data**: Native support for time-series metrics with timestamp precision.
+- **Multi-dimensional**: Handle metrics with multiple labels and dimensions for detailed analysis.
+- **Aggregation Functions**: Built-in support for common aggregation functions (sum, avg, min, max, count).
+- **Custom Metrics**: Flexible schema for application-specific metrics and KPIs.
 
 ### Query & Analysis
 
-- **PromQL Support**: Full compatibility with Prometheus Query Language for familiar querying
+- **PromQL Support**: Full compatibility with Prometheus Query Language for familiar querying.
 
 ![PromQL Queries](../images/features/promql-queries.png)
 
-- **SQL Interface**: Use SQL syntax for complex metrics analysis and reporting
+- **SQL Interface**: Use SQL syntax for complex metrics analysis and reporting.
 
-- **Time Range Selection**: Flexible time range queries with support for relative and absolute time periods
+- **Time Range Selection**: Flexible time range queries with support for relative and absolute time periods.
 
 ![Time Range Selection](../images/features/metrics-time-selection.png)
 
-- **Mathematical Operations**: Perform calculations and transformations on metrics data
+- **Mathematical Operations**: Perform calculations and transformations on metrics data.
 
 ### Visualization & Dashboards
 
-- **Real-time Charts**: Interactive time-series visualizations with multiple chart types
+- **Real-time Charts**: Interactive time-series visualizations with multiple chart types.
 
 ![Metrics Visualization](../images/features/metrics-charts.png)
 
-- **Custom Dashboards**: Create comprehensive dashboards with multiple metrics panels
+- **Custom Dashboards**: Create comprehensive dashboards with multiple metrics panels.
 
-- **Alerting Integration**: Set up alerts based on metrics thresholds and conditions
+- **Alerting Integration**: Set up alerts based on metrics thresholds and conditions.
 
 ![Metrics Alerting](../images/features/metrics-alerts.png)
 
@@ -55,16 +58,36 @@ Metrics in OpenObserve enable you to track key performance indicators, monitor s
 
 ![Metrics Compression](../images/features/metrics-compression.png)
 
-- **Efficient Indexing**: High-performance indexing for fast query execution across large datasets
+- **Efficient Indexing**: High-performance indexing for fast query execution across large datasets.
 
-- **Downsampling**: Automatic data [downsampling](../user-guide/data-exploration/metrics/downsampling-metrics.md) for long-term storage optimization
+- **Downsampling**: Automatic data [downsampling](../user-guide/data-exploration/metrics/downsampling-metrics.md) for long-term storage optimization.
 
-- **Retention Policies**: [Configurable retention settings](../user-guide/data-processing/streams/extended-retention.md) to balance storage costs and data availability
+- **Retention Policies**: [Configurable retention settings](../user-guide/data-processing/streams/extended-retention.md) to balance storage costs and data availability.
 
 ![Metrics Retention](../images/features/metrics-retention.png)
 
 ### Integration & Compatibility
-- **Prometheus Compatible**: Full compatibility with Prometheus ecosystem and exporters
-- **OpenTelemetry Ecosystem**: Full compatibility with OpenTelemetry collectors and instrumentation libraries
-- **API Access**: RESTful APIs for programmatic access to metrics data
-- **Standard Exporters**: Support for popular metrics exporters (Node Exporter, cAdvisor, etc.)
+- **Prometheus Compatible**: Full compatibility with Prometheus ecosystem and exporters.
+- **OpenTelemetry Ecosystem**: Full compatibility with OpenTelemetry collectors and instrumentation libraries.
+- **API Access**: RESTful APIs for programmatic access to metrics data.
+- **Standard Exporters**: Support for popular metrics exporters (Node Exporter, cAdvisor, etc.).
+
+## Get started with metrics
+
+Ready to send your first metrics to OpenObserve?
+
+- [Quickstart](../getting-started.md): get OpenObserve running in 5 minutes.
+- [Prometheus remote-write](../ingestion/metrics/prometheus.md): the most common path for metrics ingestion.
+- [Telegraf](../ingestion/metrics/telegraf.md): collect metrics from Telegraf agents.
+
+## Next steps
+
+- [OpenTelemetry / OTLP](../ingestion/logs/otlp.md): unified ingestion for logs, metrics, and traces.
+- [Dashboards](../user-guide/analytics/dashboards/dashboards-in-openobserve.md): visualize metrics alongside logs and traces.
+- [Alerts](../user-guide/analytics/alerts/index.md): notify on metric thresholds and anomalies.
+- [Downsampling](../user-guide/data-exploration/metrics/downsampling-metrics.md): keep long-term metrics affordable.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/ingestion/logs/syslog.md
+++ b/docs/ingestion/logs/syslog.md
@@ -5,84 +5,91 @@ description: Configure syslog server integration for collecting system logs, ser
 # Syslog Server - System & Network Log Collection
 
 !!! warning "Deprecation Notice"
-    Built-in Syslog ingestion (via TCP/UDP on port 5514) has been **deprecated as of August 2025** and is no longer available in OpenObserve.  
+    Built-in Syslog ingestion (via TCP/UDP on port 5514) has been **deprecated as of August 2025** and is no longer available in OpenObserve.
 
-    **Recommended alternatives:**  
-    - [AxoSyslog](https://axoflow.com/docs/axosyslog-core/chapter-destinations/openobserve/)  
-    - [syslog-ng](https://www.syslog-ng.com/community/b/blog/posts/sending-logs-to-openobserve-using-syslog-ng)  
-    - [Vector](../logs/vector.md)  
-    - [Fluent Bit](../logs/fluent-bit.md)  
+    **Recommended alternatives:**
+
+    - [AxoSyslog](https://axoflow.com/docs/axosyslog-core/chapter-destinations/openobserve/)
+    - [syslog-ng](https://www.syslog-ng.com/community/b/blog/posts/sending-logs-to-openobserve-using-syslog-ng)
+    - [Vector](../logs/vector.md)
+    - [Fluent Bit](../logs/fluent-bit.md)
 
     We suggest using **AxoSyslog or syslog-ng** if you want protocol-native support for Syslog.
 
+??? "Legacy reference (pre-August 2025)"
 
-OpenObserve can act as a syslog server. This means that you can send logs to OpenObserve using the syslog protocol. OpenObserve supports both UDP and TCP syslog.
+    The configuration below is preserved for historical context. Use one of the alternatives above for new deployments.
 
-## Enable syslog
+    
+    OpenObserve can act as a syslog server. This means that you can send logs to OpenObserve using the syslog protocol. OpenObserve supports both UDP and TCP syslog.
 
-Before you can send logs to OpenObserve, you need to enable OpenObserve to act as a syslog server. This is done by enabling syslog in the `Ingestion > Logs > Syslog` section of the OpenObserve UI.
+    ### Enable syslog
 
-[![Enable syslog](./images/syslog.png)](./images/syslog.png)
+    Before you can send logs to OpenObserve, you need to enable OpenObserve to act as a syslog server. This is done by enabling syslog in the `Ingestion > Logs > Syslog` section of the OpenObserve UI.
 
-## Subnets to allow traffic from
+    [![Enable syslog](./images/syslog.png)](./images/syslog.png)
 
-OpenObserve will only accept syslog traffic from the subnets that you specify. You must specify a minimum of 3 things:
+    ### Subnets to allow traffic from
 
-- Organization
-- Stream name
-- Subnets
+    OpenObserve will only accept syslog traffic from the subnets that you specify. You must specify a minimum of 3 things:
 
-## Configuration
+    - Organization
+    - Stream name
+    - Subnets
 
-Default port: `5514`
+    ### Configuration
 
-You can change the default port number using the following environment variables:
+    Default port: `5514`
 
-- `ZO_TCP_PORT` - TCP port number to listen on. Default: `5514`
-- `ZO_UDP_PORT` - UDP port number to listen on. Default: `5514`
+    You can change the default port number using the following environment variables:
 
-You can also configure the TLS settings for syslog TCP server using the following environment variables:
+    - `ZO_TCP_PORT` - TCP port number to listen on. Default: `5514`
+    - `ZO_UDP_PORT` - UDP port number to listen on. Default: `5514`
 
-- `ZO_TCP_TLS_ENABLED` - Enable TLS for TCP syslog server. If enabled, `ZO_TCP_PORT` will be used for the TLS connection over TCP. Default: `false`
+    You can also configure the TLS settings for syslog TCP server using the following environment variables:
 
-If `ZO_TCP_TLS_ENABLED` is set to `true`, then ensure all the below variables are set:
+    - `ZO_TCP_TLS_ENABLED` - Enable TLS for TCP syslog server. If enabled, `ZO_TCP_PORT` will be used for the TLS connection over TCP. Default: `false`
 
-- `ZO_TCP_TLS_CERT_PATH` - Path to the TLS certificate file to be used on the server.
-- `ZO_TCP_TLS_KEY_PATH` - Path to the TLS key file to be used on the server.
-- `ZO_TCP_TLS_CA_CERT_PATH` - Path to the TLS CA certificate file to be used on the server.
+    If `ZO_TCP_TLS_ENABLED` is set to `true`, then ensure all the below variables are set:
 
-## Testing
+    - `ZO_TCP_TLS_CERT_PATH` - Path to the TLS certificate file to be used on the server.
+    - `ZO_TCP_TLS_KEY_PATH` - Path to the TLS key file to be used on the server.
+    - `ZO_TCP_TLS_CA_CERT_PATH` - Path to the TLS CA certificate file to be used on the server.
 
-Select an organization and stream. Then set the subnet to `0.0.0.0/0`. This config allows accepting syslog data from any IP address.
+    ### Testing
 
-You can then use the syslog generator script from [this repo](https://github.com/openobserve/syslog_log_generator) to test if you are able to accept syslog data in OpenObserve.
+    Select an organization and stream. Then set the subnet to `0.0.0.0/0`. This config allows accepting syslog data from any IP address.
 
-Steps:
+    You can then use the syslog generator script from [this repo](https://github.com/openobserve/syslog_log_generator) to test if you are able to accept syslog data in OpenObserve.
 
-### Clone the repo
+    Steps:
 
-```shell
-git clone https://github.com/openobserve/syslog_log_generator
-cd syslog_log_generator
-```
+    #### Clone the repo
 
-### Modify the script
+    ```bash
+    git clone https://github.com/openobserve/syslog_log_generator
+    cd syslog_log_generator
+    ```
 
-file `generate_logs.sh`
+    #### Modify the script
 
-```shell
-#!/bin/sh
-python syslog_gen.py --host 127.0.0.1 --port 5514 --file sample_logs.txt --count 1000
-```
+    file `generate_logs.sh`
 
-Modify the file with the appropriate IP address.
+    ```bash
+    #!/bin/sh
+    python syslog_gen.py --host 127.0.0.1 --port 5514 --file sample_logs.txt --count 1000
+    ```
 
-### Start generating test syslog data
+    Modify the file with the appropriate IP address.
 
-```shell
-./generate_logs.sh
-```
+    #### Start generating test syslog data
 
-Watch a youtube demo here:
+    ```bash
+    ./generate_logs.sh
+    ```
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/dF1IEEY-R54?si=tW8E-LFAqGkAP4ey" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/ingestion/logs/vector.md
+++ b/docs/ingestion/logs/vector.md
@@ -6,11 +6,17 @@ description: Configure Vector for high-performance log aggregation, transformati
 
 Vector is a high-performance observability data pipeline for log aggregation, transformation, and routing. Use Vector to collect logs from multiple sources, transform log data, and route logs to OpenObserve for centralized log management and analysis.
 
-( .toml format)
+Configuration below is in `.toml` format. Replace `{organization}` and `{stream}` with your OpenObserve organization and stream names.
+
+OpenObserve supports two Vector sink types:
+
+- **HTTP sink**: simpler, recommended for most setups.
+- **Elasticsearch sink**: useful if you're migrating from an existing Elasticsearch-shaped pipeline.
 
 ## HTTP output
 
-### NOTE: To ensure that Vector checks the health of the OpenObserve service specifically, set both `healthcheck.enabled = true` and provide a `healthcheck.uri` that points to the OpenObserve health check endpoint.
+!!! note
+    To ensure Vector checks the health of the OpenObserve service, set both `healthcheck.enabled = true` and provide a `healthcheck.uri` that points to the OpenObserve health-check endpoint.
 
 ```toml
 [sinks.openobserve]
@@ -24,7 +30,6 @@ auth.password = "password"
 compression = "gzip"
 encoding.codec = "json"
 encoding.timestamp_format = "rfc3339"
-# healthcheck.enabled = false
 
 # Enable healthcheck
 healthcheck.enabled = true
@@ -45,3 +50,18 @@ auth.password = "password"
 compression = "gzip"
 healthcheck.enabled = false
 ```
+
+## Verify ingestion
+
+Once Vector starts shipping data, open the OpenObserve UI, click **Logs** in the sidebar, and select your stream. New log entries should appear within a few seconds.
+
+## Next steps
+
+- [OpenTelemetry / OTLP](./otlp.md): the recommended modern ingestion path.
+- [Other log ingestion options](./index.md): Fluent Bit, Fluentd, syslog, language SDKs.
+- [Logs UI](../../user-guide/data-exploration/logs/logs.md): search and explore ingested logs.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/ingestion/traces/opentelemetry.md
+++ b/docs/ingestion/traces/opentelemetry.md
@@ -4,13 +4,39 @@ description: OpenTelemetry tracing guide for instrumenting applications with Ope
 ---
 # OpenTelemetry Distributed Tracing - APM Instrumentation
 
-Instrument your applications with OpenTelemetry SDKs for distributed tracing and application performance monitoring (APM). You can find examples of how to instrument your code to send traces to OpenObserve using OpenTelemetry SDKs below:
+Instrument your applications with OpenTelemetry SDKs for distributed tracing and application performance monitoring (APM).
 
-1. [Javascript (NodeJS)](./nodejs.md)
-1. [Typescript](./typescript.md)
+## Prerequisites
+
+- An OpenObserve instance (Cloud or self-hosted) and your login credentials.
+
+## Trace ingestion endpoint
+
+Configure your OpenTelemetry SDK or Collector to send traces to:
+
+```
+https://<your-openobserve-host>/api/<your-org>/v1/traces
+```
+
+For self-hosted instances on the default port, this is `http://localhost:5080/api/<your-org>/v1/traces`. Send the `Authorization: Basic <base64(email:password)>` header on each request.
+
+## SDK examples
+
+You can find examples of how to instrument your code to send traces to OpenObserve using OpenTelemetry SDKs below:
+
+1. [JavaScript (Node.js)](./nodejs.md)
+1. [TypeScript](./typescript.md)
 1. [Python](./python.md)
 1. [Go](./go.md)
 
+You can also follow the [OpenTelemetry documentation](https://opentelemetry.io/docs/instrumentation/) for more info.
 
-You can also follow the [Opentelemetry documentation](https://opentelemetry.io/docs/instrumentation/) for more info.
+## Next steps
 
+- [OpenTelemetry Collector / OTLP](../logs/otlp.md): unified ingestion for logs, metrics, and traces.
+- [Ingestion overview](../index.md): all ingestion paths for logs, metrics, and traces.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/integration/ai/mcp/index.md
+++ b/docs/integration/ai/mcp/index.md
@@ -1,4 +1,5 @@
 ---
+title: Model Context Protocol (MCP) | OpenObserve
 description: >-
   Connect AI agents and IDEs to OpenObserve using the Model Context Protocol (MCP).
   Query logs, metrics, and traces in natural language; create alerts; and explore stream metadata
@@ -15,7 +16,7 @@ You can connect your AI agents and IDEs to your OpenObserve instance to query lo
 - **Agentic operations** like alert creation as part of CI/CD pipelines
 - **AI-assisted troubleshooting** where an agent can pull stream data, correlate traces, and suggest root causes
 
-!!! note
+!!! note "Enterprise only"
     MCP is supported in the Enterprise edition of OpenObserve.
 
 ## Prerequisites
@@ -27,7 +28,7 @@ O2_TOOL_API_URL="http://localhost:5080"
 O2_AI_ENABLED="true"
 ```
 
-!!! note
+!!! note "About `O2_TOOL_API_URL`"
     `O2_TOOL_API_URL` is the address OpenObserve uses to call its own REST API internally. `http://localhost:5080` is correct for a local process. For containerized or remote deployments set it to the address at which the OpenObserve API is reachable from within the same environment (e.g. the service name in Docker Compose).
 
 Your MCP endpoint follows the pattern:
@@ -410,7 +411,7 @@ When connected, your MCP client will see the following tools. Tool names are pre
 
 ## Multi-organization workflows
 
-Each organization in your OpenObserve instance has its own MCP endpoint. You can register multiple servers in a single client to switch contexts:
+Each organization in your OpenObserve instance has its own MCP endpoint. You can register multiple servers in a single client to switch contexts. The example below uses the Claude Code CLI, but the same pattern applies to every client covered above: add one entry per org in the relevant config file (`mcp.json`, `claude_desktop_config.json`, etc.).
 
 ```bash
 claude mcp add o2-prod https://your-instance/api/production/mcp \
@@ -457,9 +458,14 @@ This is useful for keeping production data isolated from development queries, or
     - Verify the user has access to the target organization
     - Confirm the user has the necessary RBAC permissions for stream and alert operations
 
-## Resources
+## Next steps
 
-- [MCP Protocol Specification](https://modelcontextprotocol.io/)
-- [Claude Code MCP setup](claude.md): detailed walkthrough
-- [Community Slack](https://short.openobserve.ai/community)
-- [GitHub Issues](https://github.com/openobserve/openobserve/issues)
+- [Claude Code MCP setup](claude.md): step-by-step walkthrough for the Claude Code CLI.
+- [Building autonomous agents](#building-autonomous-agents): call the MCP server directly from your own agent runtime.
+- [MCP Protocol Specification](https://modelcontextprotocol.io/): the open standard behind every client and server.
+- [GitHub Issues](https://github.com/openobserve/openobserve/issues): file bugs or feature requests.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/overview/comparison.md
+++ b/docs/overview/comparison.md
@@ -1,3 +1,7 @@
+---
+title: Comparison with Alternatives | OpenObserve
+description: How OpenObserve compares with Elasticsearch on storage cost, query performance, and operational complexity for observability workloads.
+---
 # Comparison with Alternatives
 
 ## How Does OpenObserve Compare to Elasticsearch?
@@ -35,6 +39,11 @@ This cost comparison pertains only to storage. Amazon EBS storage volumes cost [
 - **Rust Performance:** Performs well and without Java Virtual Machine (JVM) challenges
 - **Purpose-Built:** Built from the ground up as an observability tool, not a general-purpose search engine
 
-## Elasticsearch Compatibility
+### Elasticsearch Compatibility
 
-The OpenObserve `_bulk` API endpoint is Elasticsearch-compatible and can be used by log forwarders like Fluent Bit, Fluentd, Filebeat and Vector.
+The OpenObserve `_bulk` API endpoint is Elasticsearch-compatible and can be used by log forwarders like Fluent Bit, Fluentd, Filebeat and Vector. This means you can swap OpenObserve in for Elasticsearch with minimal changes to your existing ingestion pipeline.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/reference/api/.pages
+++ b/docs/reference/api/.pages
@@ -1,4 +1,5 @@
 nav:
+    - Overview: index.md
     - Streams: stream
     - Ingestion: ingestion
     - Search: search

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -1,34 +1,52 @@
+---
+title: API Reference | OpenObserve
+description: Programmatic access to OpenObserve. HTTP basic-auth endpoints for streams, ingestion, search, functions, users, and metrics.
+---
 # API Index
 
 These APIs can be used to programmatically interact with OpenObserve.
 
 All APIs must have an authorization header. Authorization header can be created using base64 encoded values of user id and password. For the sake of simplicity it is HTTP basic authentication mechanism.
 
-
 Header creation mechanism:
 
-> Authorization: Basic base64("username:password")
+```
+Authorization: Basic base64("username:password")
+```
 
-e.g. Header:
+For example:
 
-> Authorization: Basic YWRtaW46Q29tcGxleHBhc3MjMTIz
+```
+Authorization: Basic YWRtaW46Q29tcGxleHBhc3MjMTIz
+```
 
 Make sure that you are sending the requests over HTTPS.
 
 ## API List
 
-1. [Stream](stream/)
-    1. [List](stream/list)
-    1. [Schema](stream/schema)
-    1. [Setting](stream/setting)
-1. [Ingestion](ingestion/)
-    1. [Bulk](ingestion/logs/bulk)
-    1. [Json](ingestion/logs/json)
-    1. [Multi](ingestion/logs/multi)
-1. [Search](search/)
-1. [Function](function/)
-1. [User](user/)
-    1. [Create](user/create)
-    1. [Delete](user/delete)
-    1. [List](user/list)
-1. [Metrics](metrics)
+1. [Stream](stream/index.md)
+    1. [List](stream/list.md)
+    1. [Schema](stream/schema.md)
+    1. [Setting](stream/setting.md)
+1. [Ingestion](ingestion/index.md)
+    1. [Bulk](ingestion/logs/bulk.md)
+    1. [Json](ingestion/logs/json.md)
+    1. [Multi](ingestion/logs/multi.md)
+1. [Search](search/index.md)
+1. [Function](function/index.md)
+1. [User](user/index.md)
+    1. [Create](user/create.md)
+    1. [Delete](user/delete.md)
+    1. [List](user/list.md)
+1. [Metrics](metrics.md)
+
+## Next steps
+
+- [Quickstart](../../getting-started.md): get OpenObserve running and grab your credentials.
+- [Ingestion](../../ingestion/index.md): start sending logs, metrics, and traces.
+- [OpenTelemetry / OTLP](../../ingestion/logs/otlp.md): the recommended modern ingestion path.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/reference/api/search/search.md
+++ b/docs/reference/api/search/search.md
@@ -1,4 +1,5 @@
 ---
+title: Search API | OpenObserve
 description: >-
   Search logs with SQL using POST /api/{org}/_search. Filter by time, size, and
   conditions. Supports full text, aggregations, and custom functions.
@@ -6,6 +7,8 @@ description: >-
 # Search
 
 Endpoint: `POST /api/{organization}/_search`
+
+Replace `{stream}` in the SQL examples below with your stream name (e.g. `default`).
 
 ## Request
 
@@ -99,7 +102,7 @@ Description
 
 Please refer to [PostgreSQL](https://www.postgresql.org/docs/current/sql-syntax.html) for SQL Syntax.
 
-Something need highlighted:
+Notes:
 
 - We have a build-in time field, `_timestamp` you can use it to do time range filter.
 - Field name can not start with `@`.
@@ -115,20 +118,6 @@ Something need highlighted:
 ## Examples
 
 Here list some common examples, if you want more example please create a issue tell us, we will add it.
-
-### Query latest 10 record logs with histogram aggregation
-
-```json
-{
-    "query": {
-        "sql": "SELECT * FROM {stream}",
-        "start_time": 1674789786006000,
-        "end_time": 1674789786006000,
-        "from": 0,
-        "size": 10
-    }
-}
-```
 
 ### Query latest 10 record logs
 
@@ -172,7 +161,7 @@ Here list some common examples, if you want more example please create a issue t
 }
 ```
 
-### Match on a filed (log)
+### Match on a field (log)
 
 ```json
 {
@@ -223,3 +212,15 @@ Here list some common examples, if you want more example please create a issue t
     }
 }
 ```
+
+## Next steps
+
+- [Example queries](../../../user-guide/data-exploration/example-queries.md): copy-paste SQL examples to try.
+- [Full-text search functions](../../sql-functions/full-text-search.md): `match_all`, `str_match`, `re_match`, and friends.
+- [Logs UI](../../../user-guide/data-exploration/logs/logs.md): run these queries interactively.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)
+

--- a/docs/reference/sql-functions/full-text-search.md
+++ b/docs/reference/sql-functions/full-text-search.md
@@ -1,90 +1,102 @@
 ---
 title: Full-Text Search Functions in OpenObserve
-description:  This page describes the full-text search functions supported in OpenObserve, including their syntax, behavior, and examples.
+description: This page describes the full-text search functions supported in OpenObserve, including their syntax, behavior, and examples.
 ---
-The full-text search functions allow you to filter records based on keyword or pattern matches within one or more fields. <br>This page lists the full-text search functions supported in OpenObserve, along with their usage formats, descriptions, and examples.
+# Full-text search functions
 
+The full-text search functions allow you to filter records based on keyword or pattern matches within one or more fields. This page lists the full-text search functions supported in OpenObserve, along with their usage formats, descriptions, and examples.
 
-### `str_match`
+## Function index
 
-**Syntax**: `str_match(field, 'value')` <br>
-**Alias**: `match_field(field, 'value')` 
->The alias is available in OpenObserve version 0.15.0 and later.
- 
-**Description**: <br>
+| Function | Purpose |
+|---|---|
+| [`str_match`](#str_match) | Case-sensitive exact-string match on a single field |
+| [`NOT str_match`](#not-str_match) | Inverse of `str_match` |
+| [`str_match_ignore_case`](#str_match_ignore_case) | Case-insensitive match on a single field |
+| [`match_all`](#match_all) | Case-insensitive keyword search across all full-text-indexed fields |
+| [`NOT match_all`](#not-match_all) | Inverse of `match_all` |
+| [`re_match`](#re_match) | Regular-expression match on a single field |
+| [`re_not_match`](#re_not_match) | Inverse of `re_match` |
 
-- Filters logs where the specified field contains the exact string value. 
-- The match is case-sensitive. 
-- Only logs that include the exact characters and casing specified will be returned. <br>
+## `str_match`
+
+**Syntax**: `str_match(field, 'value')`
+
+**Alias**: `match_field(field, 'value')` *(available in OpenObserve 0.15.0 and later)*
+
+**Description**:
+
+- Filters logs where the specified field contains the exact string value.
+- The match is case-sensitive.
+- Only logs that include the exact characters and casing specified will be returned.
 
 **Example**:
 ```sql
 SELECT * FROM "default" WHERE str_match(k8s_pod_name, 'main-openobserve-ingester-1')
 ```
 This query filters logs from the `default` stream where the `k8s_pod_name` field contains the exact string `main-openobserve-ingester-1`. It does not match values such as `Main-OpenObserve-Ingester-1`, `main-openobserve-ingester-0`, or any case variation.
-<br>
+
 ![str_match](../../images/sql-reference/str-match.png)
 
----
+## `NOT str_match`
 
-### `not str_match`
-**Syntax**: `not str_match(field, 'value')` <br>
-**Description**:<br>
+**Syntax**: `NOT str_match(field, 'value')`
+
+**Description**:
 
 - Filters logs where the specified field does NOT contain the exact string value.
 - The match is case-sensitive.
 - Only logs that do not include the exact characters and casing specified will be returned.
 - Can be combined with other conditions using AND/OR operators.
 
-**Example**: <br>
+**Example**:
 ```sql
 SELECT * FROM "default" WHERE NOT str_match(k8s_app_instance, 'dev2')
 ```
-![not str_match](../../images/sql-reference/not-str-match.png)
+![NOT str_match](../../images/sql-reference/not-str-match.png)
 
 **Combining multiple NOT conditions with AND:**
 ```sql
 SELECT * FROM "default" WHERE (NOT str_match(k8s_app_instance, 'dev2')) AND (NOT str_match(k8s_cluster, 'dev2'))
 ```
-![not str_match with AND operator](../../images/sql-reference/not-str-match-with-and.png)
+![NOT str_match with AND operator](../../images/sql-reference/not-str-match-with-and.png)
 
 **Combining NOT conditions with OR:**
 ```sql
 SELECT * FROM "default" WHERE NOT ((str_match(k8s_app_instance, 'dev2') OR str_match(k8s_cluster, 'dev2')))
 ```
-![not str_match with OR operator](../../images/sql-reference/not-str-match-with-or.png)
+![NOT str_match with OR operator](../../images/sql-reference/not-str-match-with-or.png)
 
----
-### `str_match_ignore_case`
+## `str_match_ignore_case`
 
-**Syntax**: `str_match_ignore_case(field, 'value')` <br>
-**Alias**: `match_field_ignore_case(field, 'value')` 
-> The alias is available in OpenObserve version 0.15.0 and later.
+**Syntax**: `str_match_ignore_case(field, 'value')`
 
-**Description**: <br>
+**Alias**: `match_field_ignore_case(field, 'value')` *(available in OpenObserve 0.15.0 and later)*
 
-- Filters logs where the specified field contains the string value. 
-- The match is case-insensitive. 
-- Logs are returned even if the casing of the value differs from what is specified in the query. <br>
+**Description**:
+
+- Filters logs where the specified field contains the string value.
+- The match is case-insensitive.
+- Logs are returned even if the casing of the value differs from what is specified in the query.
 
 **Example**:
 ```sql
 SELECT * FROM "default" WHERE str_match_ignore_case(k8s_pod_name, 'MAIN-OPENOBSERVE-INGESTER-1')
 ```
 This query filters logs from the `default` stream where the `k8s_pod_name` field contains any casing variation of `main-openobserve-ingester-1`, such as `MAIN-OPENOBSERVE-INGESTER-1`, `Main-OpenObserve-Ingester-1`, or `main-openobserve-ingester-1`.
-<br>
+
 ![str_match_ignore_case](../../images/sql-reference/str-ignore-case.png)
-<br>
----
 
-### `match_all`
-**Syntax**: `match_all('value')` <br>
-**Description**: <br>
+## `match_all`
 
-- Filters logs by searching for the keyword across all fields that have the Index Type set to Full Text Search in the [stream settings](../../user-guide/data-processing/streams/schema-settings.md). 
+**Syntax**: `match_all('value')`
+
+**Description**:
+
+- Filters logs by searching for the keyword across all fields that have the Index Type set to Full Text Search in the [stream settings](../../user-guide/data-processing/streams/schema-settings.md).
 - This function is case-insensitive and returns matches regardless of the keyword's casing.
 
-!!! Note 
+!!! note "Inverted index support"
     To enable support for fields indexed using the Inverted Index method, set the environment variable `ZO_ENABLE_INVERTED_INDEX` to true. Once enabled, you can configure the fields to use the Inverted Index by updating the [stream settings](../../user-guide/data-processing/streams/schema-settings.md) in the user interface or through the [setting API](../api/stream/setting.md).
 
     The `match_all` function searches through inverted indexed terms, which are internally converted to lowercase. Therefore, keyword searches using `match_all` are always case-insensitive.
@@ -94,37 +106,32 @@ This query filters logs from the `default` stream where the `k8s_pod_name` field
 SELECT * FROM "default" WHERE match_all('openobserve-querier')
 ```
 This query returns all logs in the `default` stream where the keyword `openobserve-querier` appears in any of the full-text indexed fields. It matches all casing variations, such as `OpenObserve-Querier` or `OPENOBSERVE-QUERIER`.
-<br>
+
 ![match_all](../../images/sql-reference/match-all.png)
 
+#### More pattern support
 
-**More pattern support**
 The `match_all` function also supports the following patterns for flexible searching:
 
-- **Prefix search**: Matches keywords that start with the specified prefix:
-```sql
-SELECT * FROM "default" WHERE match_all('ab*')
-```
-- **Postfix search**: Matches keywords that end with the specified suffix:
-```sql
-SELECT * FROM "default" WHERE match_all('*ab')
-```
-- **Contains search**: Matches keywords that contain the substring anywhere:
-```sql
-SELECT * FROM "default" WHERE match_all('*ab*')
-```
-- **Phrase prefix search**: Matches keywords where the last term uses prefix matching:
-```sql
-SELECT * FROM "default" WHERE match_all('key1 key2*')
-```
-### `not match_all`
-**Syntax**: `not match_all('value')`
-**Description**: <br>
+| Pattern | Example | Description |
+|---|---|---|
+| Prefix | `match_all('ab*')` | Matches keywords that start with `ab` |
+| Postfix | `match_all('*ab')` | Matches keywords that end with `ab` |
+| Contains | `match_all('*ab*')` | Matches keywords that contain `ab` anywhere |
+| Phrase prefix | `match_all('key1 key2*')` | Matches phrases where the last term uses prefix matching |
 
-- Filters logs by excluding records where the keyword appears in any field that has the Index Type set to Full Text Search in the stream settings. 
+## `NOT match_all`
+
+**Syntax**: `NOT match_all('value')`
+
+**Description**:
+
+- Filters logs by excluding records where the keyword appears in any field that has the Index Type set to Full Text Search in the stream settings.
 - This function is case-insensitive and excludes matches regardless of the keyword's casing.
-- **Important**: Only searches fields configured as Full Text Search fields. Other fields in the record are not evaluated.
 - Provides significant performance improvements when used with indexed fields.
+
+!!! warning "Only Full Text Search fields are evaluated"
+    `NOT match_all` only searches fields configured as Full Text Search fields. Other fields in the record are not evaluated.
 
 **Example**:
 ```sql
@@ -144,28 +151,24 @@ SELECT * FROM "default" WHERE NOT (str_match(f1, 'bar') OR match_all('foo'))
 ```
 This query returns logs where BOTH conditions are false: field `f1` does NOT contain `bar` AND no full-text indexed field contains `foo`. In other words, it excludes records that match either condition.
 
----
+## `re_match`
 
-### `re_match`
-**Syntax**: `re_match(field, 'pattern')` <br>
-**Description**: <br>
+**Syntax**: `re_match(field, 'pattern')`
 
-- Filters logs by applying a regular expression to the specified field. 
-- The function returns records where the field value matches the given pattern. 
+**Description**:
+
+- Filters logs by applying a regular expression to the specified field.
+- The function returns records where the field value matches the given pattern.
 - This function is useful for identifying complex patterns, partial matches, or multiple keywords in a single query.
-
-> You can use standard regular expression syntax as defined in the [Regex Documentation](https://docs.rs/regex/latest/regex/).
-
+- You can use standard regular expression syntax as defined in the [Regex documentation](https://docs.rs/regex/latest/regex/).
 
 **Example**:
-
 ```sql
 SELECT * FROM "default" WHERE re_match(k8s_container_name, 'openobserve-querier|controller|nats')
 ```
 This query returns logs from the `default` stream where the `k8s_container_name` field matches any of the strings `openobserve-querier`, `controller`, or `nats`. The match is case-sensitive.
-<br>
-![re_match](../../images/sql-reference/re-match.png)
 
+![re_match](../../images/sql-reference/re-match.png)
 
 To perform a case-insensitive search:
 
@@ -173,14 +176,14 @@ To perform a case-insensitive search:
 SELECT * FROM "default" WHERE re_match(k8s_container_name, '(?i)openobserve-querier')
 ```
 This query returns logs where the `k8s_container_name` field contains any casing variation of `openobserve-querier`, such as `OpenObserve-Querier` or `OPENOBSERVE-QUERIER`.
-<br>
+
 ![re_match_ignore_case](../../images/sql-reference/re-match-ignore-case.png)
 
----
+## `re_not_match`
 
-### `re_not_match`
-**Syntax**: `re_not_match(field, 'pattern')` <br>
-**Description**: <br>
+**Syntax**: `re_not_match(field, 'pattern')`
+
+**Description**:
 
 - Filters logs by applying a regular expression to the specified field and returns records that do not match the given pattern.
 - This function is useful when you want to exclude specific patterns or values from your search results.
@@ -190,6 +193,16 @@ This query returns logs where the `k8s_container_name` field contains any casing
 SELECT * FROM "default" WHERE re_not_match(k8s_container_name, 'openobserve-querier|controller|nats')
 ```
 This query returns logs from the `default` stream where the `k8s_container_name` field does not match any of the values `openobserve-querier`, `controller`, or `nats`. The match is case-sensitive.
-<br>
+
 ![re_not_match](../../images/sql-reference/re-not-match.png)
 
+## Next steps
+
+- [SQL functions reference](index.md): full list of functions you can use in queries.
+- [Example queries](../../user-guide/data-exploration/example-queries.md): copy-paste filters and SQL to try.
+- [Stream schema settings](../../user-guide/data-processing/streams/schema-settings.md): configure which fields are full-text indexed.
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/reference/sql-functions/index.md
+++ b/docs/reference/sql-functions/index.md
@@ -1,8 +1,23 @@
+---
+title: SQL Functions Reference | OpenObserve
+description: Reference for all SQL functions supported in OpenObserve, grouped by category - full-text search, secondary index, array, aggregate, and approximate aggregate functions.
+---
+# SQL Functions
+
 This section provides documentation for all SQL functions supported in OpenObserve. Functions are grouped by category to help you quickly find the one that fits your use case.
 
-Learn more: 
+## Function categories
 
-- [Full-Text Search](../sql-functions/full-text-search/)
-- [Array](../sql-functions/array)
-- [Aggregate](../sql-functions/aggregate)
-- [Approximate Aggregate](../sql-functions/approximate-aggregate)  
+- [Full-Text Search Functions](full-text-search.md)
+- [Secondary Index Functions](secondary-index.md)
+- [Array Functions](array.md)
+- [Aggregate Functions](aggregate.md)
+- [Approximate Aggregate Functions](approximate-aggregate/index.md)
+    - [Approximate Aggregate Overview](approximate-aggregate/index.md)
+    - [`approx_topk`](approximate-aggregate/approx-topk.md)
+    - [`approx_topk_distinct`](approximate-aggregate/approx-topk-distinct.md)
+
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,12 +1,20 @@
 ---
+title: Releases | OpenObserve
 description: >-
   Access OpenObserve binary and container releases, including stable builds and
   dev images with the latest features at GitHub and AWS ECR repositories.
 ---
 # Releases
 
-1. Binary releases are available at: <https://github.com/openobserve/openobserve/releases>
-1. Stable container images are available at: <https://gallery.ecr.aws/zinclabs/openobserve>
-1. Dev container releases for every PR are available at: <https://gallery.ecr.aws/zinclabs/openobserve-dev> (This has all the latest and greatest features, but things might be broken here.)
+OpenObserve binaries and container images are published to the locations below.
 
+| Type | Location | Notes |
+|---|---|---|
+| Binary releases | <https://github.com/openobserve/openobserve/releases> | Linux, macOS, and Windows builds |
+| Stable container images | <https://gallery.ecr.aws/zinclabs/openobserve> | Recommended for production |
+| Dev container releases | <https://gallery.ecr.aws/zinclabs/openobserve-dev> | Built for every PR; latest features but may be unstable |
 
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/user-guide/analytics/alerts/index.md
+++ b/docs/user-guide/analytics/alerts/index.md
@@ -1,15 +1,15 @@
 ---
+title: Alerts in OpenObserve | OpenObserve
 description: >-
   Learn how alerting works in OpenObserve. Supports scheduled, real-time, and
   anomaly detection alerts with a natural language condition builder, SQL mode,
   live preview, and flexible notification destinations.
 ---
+# Alerts
 
 Alerts enable continuous monitoring of log, metric, or trace data to detect critical issues or operational patterns that require attention. Define conditions using a natural language builder or custom SQL, receive notifications through webhooks such as Slack, email, or other endpoints, and trigger configured Actions automatically when an alert is activated.
 
 ![Alerts list page with folders, type filter tabs, and alert management table](../../../images/overview-alerts-list.png)
-
----
 
 ## Alert types
 
@@ -18,8 +18,6 @@ OpenObserve supports three types of alerts:
 - **Scheduled alerts**: Run at fixed intervals to evaluate aggregated or historical data. Use for routine monitoring and trend analysis. For example, every 10 minutes, the alert evaluates your data and checks if the average response time exceeds 500ms. If the condition is met, the alert sends a notification.
 - **Real-time alerts**: Monitor data continuously and trigger instantly when conditions are met. Use for critical events requiring instant action. For example, when a specific error pattern appears in your logs, the alert sends a notification within seconds.
 - **Anomaly detection** *(Enterprise and Cloud only)*: Use machine learning to detect unusual patterns in your data without manually setting thresholds. See [Anomaly Detection](anomaly-detection.md) for details.
-
----
 
 ## Alert creation layout
 
@@ -39,8 +37,6 @@ Top Bar: Alert name, Folder, Stream Type, Stream Name, Alert Type
 The right panel displays a live **Preview** of your alert evaluation and an auto-updating **Summary** of your configuration.
 
 ![Alert creation form showing the two-tab layout with condition sentence, preview, and summary panels](../../../images/add-alert-count-mode.png)
-
----
 
 ## Core components
 
@@ -95,16 +91,12 @@ The cooldown period prevents duplicate notifications by temporarily pausing aler
 
 Toggle this on to automatically create an incident in the **Incidents** page when the alert triggers. This enables incident tracking and correlation across multiple alerts.
 
----
-
 ## Live preview and summary
 
 The right panel provides real-time feedback as you configure your alert:
 
 - **Preview**: Evaluates your conditions against recent data and shows whether the alert would trigger. Displays the number of matching data points and whether the threshold is met.
 - **Summary**: Generates a human-readable description of your complete alert configuration. Auto-updates as you change any field. Clickable summary segments jump to the corresponding form field.
-
----
 
 ## Advanced settings
 
@@ -116,23 +108,24 @@ The **Advanced** tab provides additional configuration for scheduled alerts:
 
 ![Advanced tab showing Compare with Past, Deduplication, and Additional Settings sections](../../../images/add-alert-advanced-tab.png)
 
----
-
 ## Alert folders
 
 Use folders to organize alerts on the **Alerts** page. All alerts are stored in the **default** folder unless you assign them to a different folder.
 
 To create a folder, click **+** in the **Folders** panel on the Alerts page, enter a name and description, and click **Create**. Use the **Search Folder** input to find folders quickly, or toggle **All Folders** to search alerts across all folders.
 
----
+## Next steps
 
-## Learn more
+- [Scheduled Alerts](scheduled-alerts.md): create scheduled and SQL alerts with advanced configuration.
+- [Real-time Alerts](real-time-alerts.md): create alerts that trigger instantly on ingestion.
+- [Alert Conditions and Filters](alert-conditions.md): deep dive into condition modes, functions, and filters.
+- [Alert History](alert-history.md): view alert trigger history.
+- [Anomaly Detection](anomaly-detection.md): ML-based anomaly alerts.
+- [Import and Export Alerts](import-export-alerts.md): bulk alert management.
+- [Alert Destinations](../../account-administration/management/alert-destinations/index.md): configure notification channels.
+- [Templates](../../account-administration/management/templates/index.md): customize notification content.
 
-- [Scheduled Alerts](scheduled-alerts.md) — Create scheduled and SQL alerts with advanced configuration
-- [Real-time Alerts](real-time-alerts.md) — Create alerts that trigger instantly on ingestion
-- [Alert Conditions and Filters](alert-conditions.md) — Deep dive into condition modes, functions, and filters
-- [Alert History](alert-history.md) — View alert trigger history
-- [Anomaly Detection](anomaly-detection.md) — ML-based anomaly alerts
-- [Import and Export Alerts](import-export-alerts.md) — Bulk alert management
-- [Alert Destinations](../../account-administration/management/alert-destinations/) — Configure notification channels
-- [Templates](../../account-administration/management/templates/) — Customize notification content
+**Need some help?**
+
+- Join our [Community Slack](https://short.openobserve.ai/community) 
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/user-guide/data-processing/streams/stream-details.md
+++ b/docs/user-guide/data-processing/streams/stream-details.md
@@ -47,7 +47,7 @@ The **Configuration** tab provides options to configure stream-level limits and 
 ![stream-details-configuration](../../../images/stream-details-configuration.png)
 
 ### Data Retention in days
-Sets how long data is retained in this stream. If not configured, the global retention period applies. Default global is 30 days.
+Sets how long data is retained in this stream. If not configured, the global retention period applies. Default global is 3650 days.
 
 ### Max Query Range in hours
 Sets the maximum time span allowed per query. This can help reduce query load. Note that this is stream and org specific.   


### PR DESCRIPTION
## Summary

Applies a consistent gold-docs treatment across the highest-traffic pages in the docs. Focus is on **structure, correctness, and discoverability** — content meaning is preserved.

Patterns applied across every page:

- `title:` + `description:` frontmatter
- Single H1
- "Need some help?" footer block (Slack + support)
- Em dashes removed; body `---` section separators removed
- Internal links use `.md` extensions and `index.md` for directory targets
- Inline warning/note prose converted to `!!!` admonitions
- "Next steps" sections added to drive readers to logical follow-ups
- Video embeds wrapped in `!!! tip "Video walkthrough"` admonitions

## Pages touched

| Page | Key change |
|---|---|
| `docs/administration/maintenance/storage-management/storage.md` | H1, frontmatter title, quick-reference provider table, etcd dead-config removed, env var corrections (`ZO_LOCAL_MODE`), heading casing fixes (OpenStack Swift, Aliyun, Azure Blob), GCS bold pseudo-headings promoted to `####` |
| `docs/enterprise-setup/performance.md` | Trailing-colon and trailing-space cleanups on headings, version notes lifted out of headings into `!!! note` admonitions, all `>Note:` blockquotes converted to admonitions, Next steps added |
| `docs/enterprise-setup/sre-agent.md` | H1, numbered Feature headings unnumbered, broken bullet fixed, external doc URLs converted to internal relatives, Configuration Flows promoted to subheadings, whole Troubleshooting section wrapped in one `???` collapsible (5 numbered issues inside), Prerequisites enriched with quota note + `O2_AI_ENABLED` requirement, standard footer |
| `docs/features/enterprise.md` | Frontmatter, "Get started" CTA section, Next steps section, bold-inside-link cleanup on all feature links |
| `docs/features/metrics.md` | Frontmatter, italic caption merged into hero alt text, consistent bullet punctuation, "Metric Structure" heading rename, "Get started" CTA + Next steps |
| `docs/ingestion/logs/syslog.md` | Entire legacy syslog content wrapped in `??? "Legacy reference (pre-August 2025)"` so the deprecation warning leads the page, `shell` → `bash` fences, video in tip admonition |
| `docs/ingestion/logs/vector.md` | Stranded `( .toml format)` artifact removed, `### NOTE` heading-as-note converted to admonition, placeholder substitution + sink-type picker added, Verify Ingestion + Next steps sections |
| `docs/ingestion/traces/opentelemetry.md` | Brand-name typos fixed (`TypeScript`, `JavaScript (Node.js)`, `OpenTelemetry`), trace ingestion endpoint section added, Prerequisites, Next steps |
| `docs/integration/ai/mcp/index.md` | Frontmatter title, untitled `!!! note` admonitions retitled, multi-org section clarified for all clients, "Resources" replaced with proper Next steps + standard footer |
| `docs/overview/comparison.md` | Frontmatter, `## Elasticsearch Compatibility` standalone section folded into the Elasticsearch comparison with a sentence on why it matters |
| `docs/reference/api/.pages` | Added `Overview: index.md` so the API Reference landing page appears in the nav |
| `docs/reference/api/index.md` | Frontmatter, `>` blockquote-as-code auth examples converted to fenced code blocks, all sub-links given `.md` / `index.md` extensions, Next steps |
| `docs/reference/api/search/search.md` | Frontmatter title, `{stream}` placeholder note, duplicate "Query latest 10 record logs" example removed, English typos fixed (`filed` → `field`, `Something need highlighted:` → `Notes:`), Next steps |
| `docs/reference/sql-functions/full-text-search.md` | H1, 5 body `---` separators removed, all `<br>` tags stripped, function index table added at top, `!!! Note` → `!!! note`, MCP-style consistency tweaks, pattern types under `match_all` converted to a 3-column table, `**Important**` inline note promoted to `!!! warning`, Next steps |
| `docs/reference/sql-functions/index.md` | Frontmatter, H1, expanded function category list (Full-Text Search, Secondary Index, Array, Aggregate, Approximate Aggregate with nested links for Overview, `approx_topk`, `approx_topk_distinct`), proper link extensions, standard footer |
| `docs/releases.md` | Frontmatter title, three external links restructured into a Type / Location / Notes table |
| `docs/user-guide/analytics/alerts/index.md` | Frontmatter title, H1, all 8 em dashes in "Learn more" removed, all 7 body `---` separators removed, "Learn more" → `## Next steps`, trailing-slash directory paths fixed |

## Tests ran on local