### PR TITLE
docs: add comparison-with-alternatives section and per-page LLM actions

### DIFF
--- a/docs/js/llm-page-actions.js
+++ b/docs/js/llm-page-actions.js
@@ -1,0 +1,181 @@
+(function () {
+  "use strict";
+
+  var ICONS = {
+    copy:
+      '<svg viewBox="0 0 24 24" style="fill:none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>',
+    chevron:
+      '<svg viewBox="0 0 24 24" style="fill:none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>',
+    markdown:
+      '<svg viewBox="0 0 24 24"><path d="M20.56 18H3.44C2.65 18 2 17.37 2 16.59V7.41C2 6.63 2.65 6 3.44 6h17.12c.79 0 1.44.63 1.44 1.41v9.18c0 .78-.65 1.41-1.44 1.41M6.81 15.19v-3.66l1.92 2.35 1.92-2.35v3.66h1.93V8.81h-1.93l-1.92 2.35-1.92-2.35H4.89v6.38h1.92M19.69 12h-1.92V8.81h-1.92V12h-1.93l2.89 3.28L19.69 12Z"/></svg>',
+    chatgpt:
+      '<svg viewBox="0 0 24 24"><path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.0719.0719 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z"/></svg>',
+    claude:
+      '<svg viewBox="0 0 24 24"><path d="M17.304 3.541h-3.672l6.696 16.918H24L17.304 3.541ZM6.696 3.541 0 20.459h3.744l1.369-3.553h7.005l1.369 3.553h3.744L10.536 3.541H6.696Zm-.371 10.223 2.291-5.945 2.291 5.945H6.325Z"/></svg>',
+    external:
+      '<svg viewBox="0 0 24 24" class="llm-page-actions__ext" style="fill:none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7"/><path d="M8 7h9v9"/></svg>',
+  };
+
+  function getMarkdownPath() {
+    var path = window.location.pathname;
+    if (path === "/" || path === "") return "/index.md";
+    var stripped = path.endsWith("/") ? path.slice(0, -1) : path;
+    return stripped + ".md";
+  }
+
+  function getMarkdownUrl() {
+    return window.location.origin + getMarkdownPath();
+  }
+
+  function llmPrompt() {
+    return (
+      "Read this documentation page and help me with my questions: " +
+      getMarkdownUrl()
+    );
+  }
+
+  function buildMenu() {
+    var wrap = document.createElement("div");
+    wrap.className = "llm-page-actions";
+
+    var prompt = encodeURIComponent(llmPrompt());
+
+    wrap.innerHTML =
+      '<button type="button" class="llm-page-actions__trigger" aria-haspopup="menu" aria-expanded="false">' +
+      ICONS.copy +
+      "<span>Copy</span>" +
+      ICONS.chevron +
+      "</button>" +
+      '<div class="llm-page-actions__menu" role="menu" hidden>' +
+      '<button type="button" role="menuitem" data-action="copy-page">' +
+      '<span class="llm-page-actions__icon">' + ICONS.copy + "</span>" +
+      "<span>" +
+      '<span class="llm-page-actions__item-title">Copy page</span>' +
+      '<span class="llm-page-actions__item-desc">Copy page as Markdown for LLMs</span>' +
+      "</span></button>" +
+      '<a role="menuitem" target="_blank" rel="noopener" href="' + getMarkdownPath() + '">' +
+      '<span class="llm-page-actions__icon">' + ICONS.markdown + "</span>" +
+      "<span>" +
+      '<span class="llm-page-actions__item-title">View as Markdown' + ICONS.external + "</span>" +
+      '<span class="llm-page-actions__item-desc">View this page as plain text</span>' +
+      "</span></a>" +
+      '<hr role="separator">' +
+      '<a role="menuitem" target="_blank" rel="noopener" href="https://chatgpt.com/?q=' + prompt + '">' +
+      '<span class="llm-page-actions__icon">' + ICONS.chatgpt + "</span>" +
+      "<span>" +
+      '<span class="llm-page-actions__item-title">Open in ChatGPT' + ICONS.external + "</span>" +
+      '<span class="llm-page-actions__item-desc">Ask ChatGPT about this page</span>' +
+      "</span></a>" +
+      '<a role="menuitem" target="_blank" rel="noopener" href="https://claude.ai/new?q=' + prompt + '">' +
+      '<span class="llm-page-actions__icon">' + ICONS.claude + "</span>" +
+      "<span>" +
+      '<span class="llm-page-actions__item-title">Open in Claude' + ICONS.external + "</span>" +
+      '<span class="llm-page-actions__item-desc">Ask Claude about this page</span>' +
+      "</span></a>" +
+      "</div>";
+
+    return wrap;
+  }
+
+  function flashText(el, msg) {
+    var titleEl = el.querySelector(".llm-page-actions__item-title");
+    var original = titleEl.textContent;
+    titleEl.textContent = msg;
+    setTimeout(function () {
+      titleEl.textContent = original;
+    }, 1500);
+  }
+
+  async function copyPage(btn) {
+    try {
+      var resp = await fetch(getMarkdownPath());
+      if (!resp.ok) throw new Error("fetch " + resp.status);
+      var text = await resp.text();
+      await navigator.clipboard.writeText(text);
+      flashText(btn, "Copied!");
+    } catch (e) {
+      flashText(btn, "Copy failed");
+    }
+  }
+
+  var current = { wrap: null, trigger: null, menu: null, close: null };
+  var globalListenersInstalled = false;
+
+  function installGlobalListenersOnce() {
+    if (globalListenersInstalled) return;
+    globalListenersInstalled = true;
+    document.addEventListener("click", function (e) {
+      if (!current.wrap || !current.menu || !current.close) return;
+      if (current.menu.hidden) return;
+      if (!current.wrap.contains(e.target) && !current.menu.contains(e.target)) {
+        current.close();
+      }
+    });
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && current.close) current.close();
+    });
+  }
+
+  function init() {
+    var tocInner = document.querySelector(
+      ".md-sidebar--secondary .md-sidebar__inner"
+    );
+    if (!tocInner) return;
+    if (tocInner.querySelector(":scope > .llm-page-actions")) return;
+
+    document.querySelectorAll("body > .llm-page-actions__menu").forEach(
+      function (n) { n.remove(); }
+    );
+
+    var wrap = buildMenu();
+    tocInner.insertBefore(wrap, tocInner.firstChild);
+
+    var trigger = wrap.querySelector(".llm-page-actions__trigger");
+    var menu = wrap.querySelector(".llm-page-actions__menu");
+    document.body.appendChild(menu);
+
+    function positionMenu() {
+      var r = trigger.getBoundingClientRect();
+      menu.style.top = r.bottom + 4 + "px";
+      menu.style.right = window.innerWidth - r.right + "px";
+    }
+    function close() {
+      menu.hidden = true;
+      trigger.setAttribute("aria-expanded", "false");
+      window.removeEventListener("scroll", positionMenu, true);
+      window.removeEventListener("resize", positionMenu);
+    }
+    function open() {
+      menu.hidden = false;
+      trigger.setAttribute("aria-expanded", "true");
+      positionMenu();
+      window.addEventListener("scroll", positionMenu, true);
+      window.addEventListener("resize", positionMenu);
+    }
+
+    current.wrap = wrap;
+    current.trigger = trigger;
+    current.menu = menu;
+    current.close = close;
+
+    trigger.addEventListener("click", function (e) {
+      e.stopPropagation();
+      menu.hidden ? open() : close();
+    });
+
+    installGlobalListenersOnce();
+
+    var copyBtn = wrap.querySelector('[data-action="copy-page"]');
+    copyBtn.addEventListener("click", function () {
+      copyPage(copyBtn);
+    });
+  }
+
+  if (typeof window.document$ !== "undefined" && window.document$.subscribe) {
+    window.document$.subscribe(init);
+  } else if (document.readyState !== "loading") {
+    init();
+  } else {
+    document.addEventListener("DOMContentLoaded", init);
+  }
+})();

--- a/docs/overview/.pages
+++ b/docs/overview/.pages
@@ -1,4 +1,4 @@
 nav:
   - Introduction: index.md
   - Our Principles: guiding-principles.md
-  - Comparison with Alternatives: comparison.md
+  - Comparison with Alternatives: comparison-with-alternatives

--- a/docs/overview/comparison-with-alternatives/.pages
+++ b/docs/overview/comparison-with-alternatives/.pages
@@ -1,0 +1,5 @@
+nav:
+  - OpenObserve vs Elasticsearch: comparison.md
+  - OpenObserve vs Splunk: splunk-alternative.md
+  - OpenObserve vs New Relic: newrelic-alternative.md
+  - OpenObserve vs Datadog: datadog-alternative.md

--- a/docs/overview/comparison-with-alternatives/comparison.md
+++ b/docs/overview/comparison-with-alternatives/comparison.md
@@ -1,10 +1,9 @@
 ---
-title: Comparison with Alternatives | OpenObserve
+title: OpenObserve as an Elasticsearch Alternative | Comparison
 description: How OpenObserve compares with Elasticsearch on storage cost, query performance, and operational complexity for observability workloads.
 ---
-# Comparison with Alternatives
 
-## How Does OpenObserve Compare to Elasticsearch?
+# OpenObserve as an Elasticsearch Alternative
 
 Elasticsearch is a general-purpose search engine for both app search and log search use cases. OpenObserve is built specifically for log search, making it an excellent lightweight alternative to Elasticsearch.
 
@@ -24,7 +23,7 @@ Consider Uber, which [found that 80% of the queries in its production environmen
 
 To compare storage costs, we used Fluent Bit to send real-life log data from our Kubernetes cluster to both Elasticsearch and OpenObserve. The results speak for themselves:
 
-![OpenObserve Vs Elasticsearch storage](../images/zo_vs_es.png)
+![OpenObserve Vs Elasticsearch storage](../../images/zo_vs_es.png)
 
 In this scenario, OpenObserve offers a significant advantage of 140x lower storage costs than Elasticsearch. These figures don't even consider the possibility of unused EBS volume capacity or include monitoring overhead. Your actual results may vary depending on how compressible your specific log data is.
 

--- a/docs/overview/comparison-with-alternatives/datadog-alternative.md
+++ b/docs/overview/comparison-with-alternatives/datadog-alternative.md
@@ -1,0 +1,114 @@
+---
+title: OpenObserve as a Datadog Alternative | Comparison
+description: How OpenObserve compares to Datadog on per-host pricing, custom metrics fees, vendor lock-in, OpenTelemetry support, and data ownership. Feature comparison and migration guidance for teams moving off Datadog.
+---
+
+# OpenObserve as a Datadog Alternative
+
+Datadog is a capable, polished observability platform. For teams running at scale, the per-host pricing, the per-custom-metric fees, and the proprietary agent/format combo are the most common reasons to look at alternatives. This page summarizes how OpenObserve compares.
+
+If you're ready to plan a migration, see the [Datadog to OpenObserve Migration Guide](../../migration/migrate-from-datadog-to-openobserve/index.md) for step-by-step instructions covering metrics, traces, logs, dashboards, and monitors.
+
+## Why Teams Consider Moving Off Datadog
+
+### Per-host pricing
+
+Datadog's Infrastructure tier bills **per host per month**, with separate per-host fees for APM and other products. A few hundred hosts becomes a sizeable monthly invoice before any data volume is considered.
+
+OpenObserve has **no per-host fee**. Pricing is ingest-based only. Doubling your host count without changing telemetry volume doesn't change cost.
+
+### Custom metrics fees
+
+Datadog charges per **custom metric** (above the included quota). The fee is small per metric but multiplies quickly across high-cardinality services. Teams routinely rein in instrumentation to dodge metric-count overage.
+
+OpenObserve includes **unlimited custom metrics**. There is no per-metric line item.
+
+### Vendor lock-in
+
+Datadog's wire formats (the Agent HTTPS API, DogStatsD, the APM trace intake, the log intake) are proprietary. Once you've built dashboards, monitors, and integrations against them, the switching cost feels high.
+
+OpenObserve speaks open protocols end to end: **OpenTelemetry (OTLP)** for all signals, plus Prometheus Remote Write, Loki Push API, and JSON over HTTP. The instrumentation you do for OpenObserve works against any OTel-compatible backend.
+
+### Fragmented product SKUs
+
+Datadog is sold as a bundle of distinct products (Infrastructure, APM, Logs, RUM, Synthetics, CSPM, Watchdog), each priced separately, each with its own data model and quirks. In OpenObserve, logs/metrics/traces are stream types in one unified store with one UI and one query engine.
+
+### Data ownership
+
+In Datadog, raw telemetry lives on Datadog's cluster. You can query it through their UI and API but can't cheaply backfill, re-process, or join it against the rest of your data.
+
+In OpenObserve, raw events live as **Apache Parquet in your bucket**: S3, GCS, Azure Blob, MinIO, or local disk. Any tool that reads Parquet can read your telemetry data.
+
+## Feature Comparison
+
+| Feature | Datadog | OpenObserve |
+|---|---|---|
+| Logs | Yes | Yes |
+| Metrics | Yes | Yes |
+| Traces | Yes | Yes |
+| Open source | No | Yes |
+| Dashboards | Yes | Yes |
+| Alerts | Yes | Yes |
+| Pipelines | Yes | Yes |
+| OpenTelemetry native | Partial | Full |
+| Per-host pricing | $15 to $27 / host / month | $0 |
+| Custom metrics | Per-metric overage above quota | Unlimited, included |
+| Self-hosted option | No | Yes |
+| Bring your own storage | No | Yes (S3, GCS, Azure Blob, MinIO) |
+| IAM & SSO | Enterprise tier only | Included (SAML, OIDC, LDAP, role-based access) |
+
+## Architectural Differences
+
+| Layer | Datadog | OpenObserve |
+|---|---|---|
+| Ingest agents | Datadog Agent (proprietary) | OpenTelemetry Collector, OTel SDKs, Fluent Bit, Vector |
+| Custom metric protocol | DogStatsD (proprietary dialect) | OTLP, Prometheus Remote Write, OTel `statsd` receiver |
+| APM trace protocol | Datadog APM intake (`dd-trace-*`) | OTLP (with OTel Collector `datadog` receiver as a translation layer for existing `dd-trace` SDKs) |
+| Storage | Datadog-managed (opaque) | Apache Parquet on object storage |
+| Query | Datadog query DSL + log search syntax | SQL + PromQL |
+| Visualization | Datadog UI | OpenObserve UI (built-in) |
+| Deployment | SaaS only | Self-host or OpenObserve Cloud |
+
+## Cost Profile
+
+Datadog cost is dominated by **per-host + per-product + per-custom-metric** line items, with ingest-based add-ons for logs. Adding hosts or custom dimensions to a metric increases cost without any change in data volume.
+
+OpenObserve cost is dominated by **ingest + object storage + query compute**. There are no per-host, per-user, or per-metric fees. The architecture is designed so that:
+
+- Long retention is cheap (object storage rates)
+- High host counts don't multiply cost
+- High-cardinality custom metrics don't multiply cost
+
+## What Stays the Same
+
+Migrating off Datadog typically does **not** require re-instrumenting your applications:
+
+- **DogStatsD clients** keep sending UDP to port `8125`. The OTel Collector's `statsd` receiver listens on the same port and translates to OTLP.
+- **`dd-trace-*` APM SDKs** keep sending spans on port `8126`. The OTel Collector's `datadog` receiver translates the payloads into OTLP traces.
+- **Datadog Agent** can stay during the migration window. Repoint its `dd_url` at the local OTel Collector and it continues collecting host and integration metrics without any other change.
+- **Log shippers** (Fluent Bit, Vector) only need a one-line output swap.
+
+The OpenTelemetry Collector with the appropriate receivers acts as a Datadog-to-OTLP translation layer, so the application surface area stays untouched.
+
+## Migration Shape
+
+A typical move off Datadog runs in three steps:
+
+1. **Stand up an OTel Collector** alongside the existing Datadog Agent fleet. Configure it with the `statsd`, `datadog`, and (optionally) log receivers so it accepts the same wire formats Datadog uses.
+2. **Run dual-write.** Point apps (or the Datadog Agent itself) at both Datadog and the Collector for a validation window. Compare metrics, traces, and logs side by side.
+3. **Cut over.** Migrate dashboards and monitors to OpenObserve (the AI Assistant translates Datadog query DSL to PromQL/SQL), then decommission the Datadog Agent.
+
+Teams already on OpenTelemetry can start ingesting into OpenObserve within hours. A full Datadog Agent-based fleet usually completes the move in days to a few weeks.
+
+For the detailed, step-by-step procedure, see the [Datadog to OpenObserve Migration Guide](../../migration/migrate-from-datadog-to-openobserve/index.md):
+
+- [Architecture & Terminology](../../migration/migrate-from-datadog-to-openobserve/architecture.md)
+- [Migrating Metrics](../../migration/migrate-from-datadog-to-openobserve/metrics.md): DogStatsD, Datadog Agent, OTel
+- [Migrating Traces](../../migration/migrate-from-datadog-to-openobserve/traces.md): Datadog APM to OTLP
+- [Migrating Logs](../../migration/migrate-from-datadog-to-openobserve/logs.md)
+- [Migrating Dashboards & Monitors](../../migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md)
+
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/overview/comparison-with-alternatives/newrelic-alternative.md
+++ b/docs/overview/comparison-with-alternatives/newrelic-alternative.md
@@ -1,0 +1,99 @@
+---
+title: OpenObserve as a New Relic Alternative | Comparison
+description: How OpenObserve compares to New Relic on pricing model, query language, OpenTelemetry support, deployment options, and data ownership. Feature comparison and migration guidance for teams moving off New Relic.
+---
+
+# OpenObserve as a New Relic Alternative
+
+New Relic is a long-established APM and observability platform. For teams running at scale, the per-user pricing, the proprietary query language (NRQL), and the SaaS-only model are the most common reasons to evaluate alternatives. This page covers how OpenObserve compares and what changes if you migrate.
+
+## Why Teams Consider Moving Off New Relic
+
+### Per-user pricing
+
+New Relic's pricing model combines ingest with **per-user fees**, with the higher tiers charging several hundred dollars per user per month. For an org with even a moderate engineering team, the per-seat line item often outpaces the ingest line item.
+
+OpenObserve charges **$0 per seat**. Pricing is purely ingest-based, so adding engineers to the platform is free.
+
+### NRQL, a proprietary query language
+
+NRQL is specific to New Relic. Every dashboard, alert condition, and saved query is written in NRQL, so leaving New Relic means rewriting them.
+
+OpenObserve uses **SQL** for logs and traces and **PromQL** for metrics. Both are widely known and portable.
+
+### Vendor lock-in
+
+New Relic uses proprietary agents and a proprietary data model. Migrating off the platform requires re-evaluating your instrumentation strategy.
+
+OpenObserve is **OpenTelemetry-native** end to end. Instrumentation done with OTel SDKs and the OTel Collector ports cleanly to any backend, so you're never locked into OpenObserve either.
+
+### SaaS-only
+
+New Relic is delivered as a cloud service only. For workloads with data-residency, air-gap, or regulated-environment requirements, that can be a blocker.
+
+OpenObserve runs as **self-hosted** (single binary or Helm chart) or **OpenObserve Cloud**. Self-hosted means raw telemetry stays in your bucket (S3, GCS, Azure Blob, MinIO, or local disk).
+
+### APM agent overhead
+
+The New Relic APM agents are proprietary, language-specific, and heavier than the OpenTelemetry SDK + Collector combination.
+
+## Feature Comparison
+
+| Feature | New Relic | OpenObserve |
+|---|---|---|
+| Logs | Yes | Yes, real-time analytics without traditional indexing overhead |
+| Metrics | Yes | Yes, full Prometheus / PromQL compatibility |
+| Traces / APM | Yes | Yes, first-class OpenTelemetry support |
+| Dashboards | Yes | Yes, prebuilt dashboards, UI builder, custom mode |
+| Alerts | Yes | Yes, SQL/PromQL-based alerting |
+| Frontend monitoring (RUM) | Yes | Yes |
+| Pipelines / data transforms | Yes | Yes (Vector Remap Language) |
+| Query language | NRQL (proprietary) | SQL + PromQL |
+| Pricing model | Per user + per GB ingest | Ingest-based only |
+| OpenTelemetry native | Partial | Full |
+| Self-hosted option | No | Yes |
+| Monthly per-seat cost | Per-user fees on higher tiers | $0 |
+| Bring your own storage | No | Yes (S3, GCS, Azure Blob, MinIO) |
+| Open source | No | Yes |
+
+## Architectural Differences
+
+| Layer | New Relic | OpenObserve |
+|---|---|---|
+| Ingest agents | New Relic APM agents (per language) + Infrastructure agent | OpenTelemetry Collector, OTel SDKs, Fluent Bit, Vector |
+| Wire protocol | Proprietary New Relic ingest APIs | OTLP, Prometheus Remote Write, Loki Push API, JSON over HTTP |
+| Storage | New Relic-managed (opaque) | Apache Parquet on object storage (S3/GCS/Azure/MinIO/local) |
+| Query | NRQL to New Relic backend | SQL/PromQL to stateless queriers reading Parquet |
+| Visualization | New Relic One | OpenObserve UI (built-in) |
+| Deployment | SaaS only | Self-host or OpenObserve Cloud |
+
+## Data Ownership
+
+In New Relic, your raw telemetry lives on their cluster. You can query it through their UI and API, but you can't cheaply backfill, re-process, or join it against the rest of your data.
+
+In OpenObserve, raw events live in **your** object storage as Parquet. You can query it from OpenObserve, but the data is also accessible directly from any tool that reads Parquet (Athena, Spark, DuckDB, Trino), so it stays usable beyond the observability use case.
+
+## What Stays the Same
+
+Migrating off New Relic does not require re-instrumenting your applications when you've already adopted OpenTelemetry:
+
+- **OTel SDKs** in your code keep emitting OTLP. Only the exporter endpoint changes.
+- **OTel Collectors** keep their receivers and processors. Swap the `newrelic` exporter for `otlphttp` pointed at OpenObserve.
+- **Prometheus scrapers** keep working unchanged. Add an OpenObserve `remote_write` target.
+
+If you still rely on New Relic APM agents, you can either keep them temporarily (with a Collector translation layer) or move incrementally to OpenTelemetry SDKs, language by language.
+
+## Migration Shape
+
+A typical move off New Relic runs in three steps:
+
+1. **Point collectors at OpenObserve.** Update OTel Collector exporter endpoints to OpenObserve. No re-instrumentation required for apps already using OTel. Run dual-write for a window to validate.
+2. **Rebuild dashboards and translate alerts.** Convert NRQL queries to SQL/PromQL. The OpenObserve AI Assistant handles the bulk of NRQL to SQL/PromQL translation automatically.
+3. **Cut over and optimize.** Shift production workloads gradually, starting with non-critical services. Validate retention and query latency before decommissioning the New Relic side.
+
+Teams already on OpenTelemetry can start ingesting into OpenObserve within hours. Full cutover usually lands in days to a few weeks, dominated by dashboard and alert rebuild rather than data movement.
+
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/overview/comparison-with-alternatives/splunk-alternative.md
+++ b/docs/overview/comparison-with-alternatives/splunk-alternative.md
@@ -1,0 +1,99 @@
+---
+title: OpenObserve as a Splunk Alternative | Comparison
+description: How OpenObserve compares to Splunk on cost, query language, architecture, and operational complexity. Feature comparison, pain points, and migration guidance for teams considering a move off Splunk.
+---
+
+# OpenObserve as a Splunk Alternative
+
+Splunk is a mature platform with broad enterprise adoption, but for teams running at scale the cost curve, the operational footprint, and the proprietary query language often become real constraints. This page summarizes how OpenObserve compares, what changes if you migrate, and the typical migration shape.
+
+## Why Teams Consider Moving Off Splunk
+
+### Licensing & total cost of ownership
+
+Splunk's pricing is volume-based (per ingested GB) with additional per-host and per-feature line items. Once ingest grows past a modest baseline, the license becomes the dominant cost, often well before infrastructure does. Indexer-tier storage is also expensive because indexers are stateful hosts with hot data on attached storage.
+
+OpenObserve stores raw events as Apache Parquet on object storage (S3, GCS, Azure Blob, or local disk). Storage runs **up to 140x more efficient** than typical indexed-tier observability backends, and there is no per-host or per-user licensing.
+
+### Operational complexity
+
+A production Splunk deployment has multiple distinct components: universal/heavy forwarders, indexers, search heads, deployment servers, license master, cluster master. Each has its own scaling profile, failure modes, and upgrade choreography. Splunk Enterprise typically requires dedicated platform engineers.
+
+OpenObserve runs as a single Rust binary (or one Helm chart). Storage is stateless on object storage, so scaling out is horizontal. Add ingester or querier replicas as needed.
+
+### SPL, a proprietary query language
+
+SPL is specific to Splunk. Dashboards, alerts, and saved searches are all SPL expressions, so leaving Splunk means rewriting them in something else.
+
+OpenObserve uses **SQL** for logs and traces and **PromQL** for metrics. Both are widely known, with no Splunk-specific dialect to learn or carry around.
+
+### Retention tied to expensive storage
+
+In Splunk, retaining data longer means scaling indexers: paying for more compute and attached storage to keep cold data queryable. SmartStore helps but doesn't change the licensing math.
+
+OpenObserve decouples compute from storage entirely. Long retention costs object-storage rates, not indexer-host rates.
+
+## Feature Comparison
+
+| Feature | Splunk | OpenObserve |
+|---|---|---|
+| Logs | Yes | Yes, real-time analytics without traditional indexing overhead |
+| Metrics | Yes | Yes, full Prometheus / PromQL compatibility |
+| Traces | Add-on (Splunk APM) | Yes, first-class OpenTelemetry support |
+| Dashboards | Yes | Yes, prebuilt dashboards, UI builder, custom mode |
+| Alerts | Yes | Yes, SQL/PromQL-based alerting |
+| Pipelines / data transforms | Yes | Yes, simpler transforms with Vector Remap Language (VRL) |
+| Query language | SPL (proprietary) | SQL + PromQL |
+| Storage model | Indexer hosts with attached storage | Object storage (S3 / GCS / Azure Blob / MinIO / local disk) |
+| Manageability | Multi-component, typically a dedicated team | Single binary or Helm chart, stateless |
+| Data retention | Tied to indexer storage cost | Object-storage rates, long retention is cheap |
+| Open source | No | Yes |
+| IAM & SSO | Yes | Yes (SAML, OIDC, LDAP, role-based access) |
+| Deployment | Self-host or Splunk Cloud | Self-host or OpenObserve Cloud |
+
+## Architectural Differences
+
+| Layer | Splunk | OpenObserve |
+|---|---|---|
+| Ingest agents | Universal / Heavy Forwarders | OpenTelemetry Collector, Fluent Bit, Vector, Filebeat (via `_bulk`), JSON over HTTP |
+| Wire protocol | HEC (Splunk HTTP Event Collector) and forwarder protocol | OTLP, Prometheus Remote Write, Loki Push API, JSON over HTTP, Elasticsearch `_bulk` |
+| Storage | Indexers with hot/warm/cold tiers, SmartStore for cold | Apache Parquet on object storage; no tier distinction |
+| Query | SPL to search heads | SQL/PromQL to stateless queriers reading Parquet |
+| Visualization | Splunk dashboards / Web | OpenObserve UI (built-in) |
+
+## Cost Profile
+
+Splunk cost is dominated by **license + indexer infrastructure**. Doubling ingest typically doubles both.
+
+OpenObserve cost is dominated by **object storage + compute for active queries**. Doubling ingest roughly doubles storage (which is cheap) without doubling compute, because queriers are sized for working-set query load rather than the total dataset.
+
+For most teams, the gap widens as data volume grows. The per-GB ingest premium and the indexer footprint compound in Splunk in a way they don't in OpenObserve.
+
+## What Stays the Same
+
+Migrating off Splunk does not mean re-instrumenting your applications:
+
+- **HEC clients** that POST JSON to Splunk's HTTP Event Collector can be repointed to OpenObserve's JSON ingest endpoint with a one-line URL change.
+- **Forwarder-collected files** (syslog, app logs) can be picked up by Fluent Bit, Vector, or the OpenTelemetry Collector reading the same paths.
+- **Elasticsearch-style `_bulk` ingestion** works against OpenObserve unchanged. Filebeat, Fluent Bit's `es` output, and Vector's `elasticsearch` sink all work.
+
+## Migration Shape
+
+A typical move off Splunk runs in three phases:
+
+1. **Stand up OpenObserve in parallel.** Configure your collectors to fan out to both Splunk and OpenObserve so you can compare side by side. No code changes in your applications.
+2. **Translate SPL to SQL/PromQL.** Rebuild dashboards and alerts in OpenObserve. The OpenObserve AI Assistant can convert SPL searches to SQL, which is fastest for the bulk of straightforward `search ... | stats ... by` patterns.
+3. **Cut over.** Shift non-critical workloads first, validate retention and query latency, then complete the move and decommission Splunk indexers.
+
+Rough sizing of a parallel-run window:
+
+- Small footprint (< 100 GB/day): 4 to 8 weeks
+- Medium (100 GB to 1 TB/day): 2 to 4 months
+- Large (> 1 TB/day): 4 to 6 months
+
+The dominant variable is dashboard/alert count, not data volume.
+
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/overview/comparison-with-alternatives/splunk-alternative.md
+++ b/docs/overview/comparison-with-alternatives/splunk-alternative.md
@@ -13,7 +13,7 @@ Splunk is a mature platform with broad enterprise adoption, but for teams runnin
 
 Splunk's pricing is volume-based (per ingested GB) with additional per-host and per-feature line items. Once ingest grows past a modest baseline, the license becomes the dominant cost, often well before infrastructure does. Indexer-tier storage is also expensive because indexers are stateful hosts with hot data on attached storage.
 
-OpenObserve stores raw events as Apache Parquet on object storage (S3, GCS, Azure Blob, or local disk). Storage runs **up to 140x more efficient** than typical indexed-tier observability backends, and there is no per-host or per-user licensing.
+OpenObserve stores raw events as Apache Parquet on object storage (S3, GCS, Azure Blob, or local disk). Storage is **up to 140x more efficient, and therefore cheaper**, than typical indexed-tier observability backends, and there is no per-host or per-user licensing.
 
 ### Operational complexity
 

--- a/docs/stylesheets/llm-page-actions.css
+++ b/docs/stylesheets/llm-page-actions.css
@@ -1,0 +1,130 @@
+.llm-page-actions {
+  position: relative;
+  display: block;
+  margin: 0 0 0.8rem 0;
+  padding: 0 0.6rem;
+  user-select: none;
+}
+
+.llm-page-actions__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.32rem 0.4rem 0.32rem 0.55rem;
+  border: 1px solid var(--md-default-fg-color--lightest, rgba(0, 0, 0, 0.08));
+  border-radius: 0.3rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  font: inherit;
+  font-size: 0.7rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.llm-page-actions__trigger:hover {
+  border-color: var(--md-default-fg-color--light);
+}
+
+.llm-page-actions__trigger svg {
+  width: 0.85rem;
+  height: 0.85rem;
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
+.llm-page-actions__menu {
+  position: fixed;
+  min-width: 17rem;
+  padding: 0.3rem;
+  background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest, rgba(0, 0, 0, 0.08));
+  border-radius: 0.35rem;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08), 0 1px 4px rgba(0, 0, 0, 0.04);
+  z-index: 1000;
+}
+
+.llm-page-actions__menu[hidden] {
+  display: none;
+}
+
+.llm-page-actions__menu > button,
+.llm-page-actions__menu > a {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.5rem 0.55rem;
+  border: 0;
+  border-radius: 0.25rem;
+  background: transparent;
+  text-align: left;
+  text-decoration: none;
+  color: var(--md-default-fg-color);
+  font: inherit;
+  cursor: pointer;
+}
+
+.llm-page-actions__menu > button:hover,
+.llm-page-actions__menu > a:hover,
+.llm-page-actions__menu > button:focus-visible,
+.llm-page-actions__menu > a:focus-visible {
+  background: var(--md-default-fg-color--lightest);
+  outline: none;
+}
+
+.llm-page-actions__menu hr {
+  margin: 0.3rem 0.1rem;
+  border: 0;
+  border-top: 1px solid var(--md-default-fg-color--lightest, rgba(0, 0, 0, 0.08));
+}
+
+.llm-page-actions__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.llm-page-actions__icon svg {
+  width: 1rem;
+  height: 1rem;
+  fill: currentColor;
+}
+
+.llm-page-actions__item-title {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+  font-size: 0.72rem;
+  line-height: 1.2;
+}
+
+.llm-page-actions__ext {
+  width: 0.65rem !important;
+  height: 0.65rem !important;
+  opacity: 0.55;
+}
+
+.llm-page-actions__item-desc {
+  display: block;
+  margin-top: 0.15rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.62rem;
+  line-height: 1.3;
+}
+
+[data-md-color-scheme="slate"] .llm-page-actions__trigger,
+[data-md-color-scheme="slate"] .llm-page-actions__menu {
+  border-color: hsla(0, 0%, 100%, 0.12);
+}
+
+[data-md-color-scheme="slate"] .llm-page-actions__menu {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4), 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+@media print {
+  .llm-page-actions { display: none; }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ plugins:
         Reference:
           - reference/*.md
         Migration:
-          - migration/*.md
+          - migration/**/*.md
         Releases:
           - releases.md
 # nav:
@@ -41,6 +41,7 @@ plugins:
 extra_css:
   - stylesheets/extra.css
   - stylesheets/feedback.css
+  - stylesheets/llm-page-actions.css
   - css/output.css
   - css/landing-page.css
 extra_javascript:
@@ -51,6 +52,7 @@ extra_javascript:
   - js/search-close-minimal.js
   - js/search-tracking.js
   - js/theme.js
+  - js/llm-page-actions.js
   # - js/toc-highlight.js
   - https://buttons.github.io/buttons.js
   # - js/reo.js


### PR DESCRIPTION
- Restructure docs/overview into a Comparison with Alternatives section with four pages: Elasticsearch (existing, unchanged), Splunk, New Relic, and Datadog
- Add a per-page Copy / View / ChatGPT / Claude dropdown in the right TOC (docs/js/llm-page-actions.js + docs/stylesheets/llm-page-actions.css), hardened against Material instant-navigation orphan-menu accumulation
- Fix the mkdocs-llmstxt Migration glob to recurse (migration/**/*.md) so nested migration guides are picked up