### PR TITLE
docs: add Datadog to OpenObserve migration guide

### DIFF
--- a/docs/migration/.pages
+++ b/docs/migration/.pages
@@ -2,3 +2,4 @@ nav:
 - Migrate database: migrate-database.md
 - Migrate file list partition: migrate-file-list-partition.md
 - Migrate from Grafana: migrate-from-grafana-to-openobserve
+- Migrate from Datadog: migrate-from-datadog-to-openobserve

--- a/docs/migration/migrate-from-datadog-to-openobserve/.pages
+++ b/docs/migration/migrate-from-datadog-to-openobserve/.pages
@@ -1,0 +1,7 @@
+nav:
+    - Overview: index.md
+    - Architecture & Terminology: architecture.md
+    - Migrating Metrics: metrics.md
+    - Migrating Traces: traces.md
+    - Migrating Logs: logs.md
+    - Migrating Dashboards & Monitors: dashboards-and-alerts.md

--- a/docs/migration/migrate-from-datadog-to-openobserve/architecture.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/architecture.md
@@ -105,4 +105,7 @@ Datadog and OpenTelemetry use different vocabularies for metric types. The OTel 
 - [Migrating Logs](logs.md): migrate log sources from Datadog
 
 
-[Back to Overview](index.md) | Next: [Migrating Metrics](metrics.md)
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/migration/migrate-from-datadog-to-openobserve/architecture.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/architecture.md
@@ -1,0 +1,108 @@
+---
+title: Datadog vs OpenObserve Architecture - Migration Path & Terminology | OpenObserve
+description: How Datadog Agent, DogStatsD, and APM components map to OpenObserve. Architecture comparison, terminology reference, and protocol compatibility for migrating off Datadog.
+---
+
+# Architecture & Terminology
+
+## Architecture: Datadog vs OpenObserve
+
+### Before: Datadog
+
+A typical Datadog deployment looks like this:
+
+- **Datadog Agent** runs on every host (or as a DaemonSet on Kubernetes). It collects host metrics, integration metrics, logs, traces (via APM), and process data.
+- **DogStatsD**, embedded in the Agent on UDP port `8125`, accepts custom application metrics.
+- **APM tracers** (`dd-trace-java`, `dd-trace-py`, `dd-trace-go`, etc.) embedded in your apps send spans to the Agent over port `8126`.
+- The Agent ships everything to the **Datadog SaaS backend** via Datadog-proprietary HTTPS APIs.
+- **Dashboards, monitors, notebooks, and SLOs** are managed in the Datadog UI.
+
+Components to operate: the Agent fleet, plus whatever shipping/log forwarders you've layered on top (Vector, Fluent Bit, custom forwarders). All ingestion and storage is owned by Datadog.
+
+### After: OpenObserve
+
+The migration introduces an **OpenTelemetry Collector** as a translation layer in front of OpenObserve. The Collector accepts data in Datadog wire formats (DogStatsD, Datadog Agent API, Datadog APM) and exports it to OpenObserve in OTLP.
+
+- **Datadog Agent** (optionally retained) continues to collect host and integration data, but now forwards to the local OTel Collector instead of Datadog SaaS.
+- **DogStatsD clients** in your apps emit metrics unchanged. The OTel Collector's `statsd` receiver listens on port `8125` just like the Datadog Agent did.
+- **APM tracers** continue to emit spans; the Collector's `datadog` receiver translates them into OTLP.
+- **OpenTelemetry Collector** translates everything into OTLP and exports to OpenObserve.
+- **OpenObserve** stores everything as columnar Parquet in your own object storage (S3/GCS/Azure Blob/local disk).
+
+Components to operate: **2**, the OTel Collector and OpenObserve. The Datadog Agent can stay during migration or be replaced by the OTel Collector entirely.
+
+### What Changes and What Doesn't
+
+**Your application code does not change.** DogStatsD calls, APM tracer instrumentation, and log emission stay exactly as they are. Only the destination endpoints change.
+
+| Layer | Changes? | Details |
+|---|---|---|
+| Applications (your code) | No | `dd-trace-*` libraries and `statsd` clients keep working unchanged |
+| Datadog Agent | Optional | Can stay during dual-write; eventually replaced by OTel Collector |
+| OTel Collector | New | Acts as the Datadog-to-OTLP translator |
+| Backend (Datadog SaaS) | Replaced | By OpenObserve |
+| Visualization (Datadog UI) | Replaced | By OpenObserve's built-in UI |
+
+
+## Terminology Mapping
+
+If you're coming from Datadog, most concepts have direct equivalents in OpenObserve. The mapping isn't always 1:1. Datadog has many product-named features that become generic capabilities in OpenObserve.
+
+### Concepts
+
+| Datadog Concept | OpenObserve Equivalent | Notes |
+|---|---|---|
+| Datadog Agent | OpenTelemetry Collector (or OpenObserve Collector) | OTel Collector with Datadog receivers handles ingestion. Or use the OpenObserve Collector for an OTel-native setup |
+| DogStatsD | OTel Collector `statsd` receiver | Same UDP port `8125`, same line protocol, no app changes |
+| Datadog APM | OTel Collector `datadog` receiver to OTLP traces | `dd-trace-*` SDKs keep working; traces become OTLP downstream |
+| Datadog Logs | OpenObserve Logs (built-in stream type) | Ingested via OTLP, Loki Push API, JSON, Fluent Bit, Vector, etc. |
+| Datadog Metrics | OpenObserve Metrics (built-in stream type) | PromQL-compatible |
+| Datadog Traces | OpenObserve Traces (built-in stream type) | OTLP-native |
+| Datadog Dashboards | OpenObserve Dashboards | Built-in dashboard builder with 18+ chart types |
+| Datadog Monitors | OpenObserve Alerts | PromQL or SQL-based; Slack/PagerDuty/Email/Webhook destinations |
+| Datadog Notebooks | OpenObserve Dashboards + SQL queries | Combine narrative panels with live queries |
+| Datadog SLOs | Scheduled pipelines + alerts | Pre-aggregate the SLI, alert on burn rate |
+| Datadog Watchdog | Manual alerts (no AI auto-detect today) | Watchdog is Datadog-proprietary; configure explicit thresholds in OpenObserve |
+| Datadog Hosts | Streams + service.name field | OpenObserve doesn't charge per host; there is no host concept in billing |
+| Datadog Tags | Labels / fields | Tags become labels on metrics (PromQL) or columns on logs/traces (SQL) |
+| Custom Metrics | Same, sent via DogStatsD or OTLP | No per-metric pricing |
+| Datadog Pipelines (log processing) | OpenObserve Pipelines (VRL-based) | Parse, enrich, route, and transform logs in-flight |
+| Datadog Live Tail | OpenObserve Logs Live Mode | Real-time log streaming in the Logs explorer |
+| Organization / Account | Organization | OpenObserve uses orgs for multi-tenancy (default org is `default`) |
+
+### Protocol Compatibility
+
+**OpenObserve can accept Datadog's wire formats through the OTel Collector**, and it natively speaks open ingestion protocols. You're not changing how data is collected; you're routing it through a translation layer.
+
+| Protocol | Datadog Endpoint | OpenObserve / Collector Endpoint |
+|---|---|---|
+| DogStatsD | `localhost:8125` (UDP, Agent) | `localhost:8125` (UDP, OTel Collector `statsd` receiver) |
+| Datadog APM (trace intake) | `localhost:8126` (Agent) | `localhost:8126` (OTel Collector `datadog` receiver) |
+| Datadog Agent metrics API | `https://api.datadoghq.com/api/v1/series` | OTel Collector `datadogreceiver` to OTLP to OpenObserve |
+| OTLP HTTP | (Datadog supports OTLP) | `http://openobserve:5080/api/default/` |
+| OTLP gRPC | (Datadog supports OTLP) | `openobserve:5081` |
+| Prometheus Remote Write | N/A in Datadog | `http://openobserve:5080/api/default/prometheus/api/v1/write` |
+| Loki Push API | N/A in Datadog | `http://openobserve:5080/api/{org}/loki/api/v1/push` |
+| JSON over HTTP | N/A in Datadog | `http://openobserve:5080/api/default/<stream>/_json` |
+
+### Metric Type Mapping
+
+Datadog and OpenTelemetry use different vocabularies for metric types. The OTel Collector handles the translation, but it helps to know what becomes what:
+
+| Datadog Type | OpenTelemetry Type | Notes |
+|---|---|---|
+| Gauge | Gauge | Same semantics |
+| Count | Sum (monotonic, cumulative) | Datadog Count maps to OTel cumulative Sum |
+| Rate | Sum (monotonic, delta) | Datadog Rate maps to OTel delta Sum |
+| Distribution | Exponential Histogram | Datadog Distributions become OTel Exponential Histograms |
+| Histogram (timing) | Histogram | Configurable bucket strategy in the `statsd` receiver |
+
+
+## Next Steps
+
+- [Migrating Metrics](metrics.md): start with metrics, the most common Datadog signal
+- [Migrating Traces](traces.md): migrate Datadog APM to OTLP
+- [Migrating Logs](logs.md): migrate log sources from Datadog
+
+
+[Back to Overview](index.md) | Next: [Migrating Metrics](metrics.md)

--- a/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
@@ -79,7 +79,7 @@ Datadog log search to SQL examples for log panels:
 | `service:api status:error` | `SELECT * FROM default WHERE service = 'api' AND level = 'error'` |
 | `service:api "timeout"` | `SELECT * FROM default WHERE service = 'api' AND match_all('timeout')` |
 | `service:payments @duration:>500` | `SELECT * FROM default WHERE service = 'payments' AND duration > 500` |
-| `service:api status:error | count by status_code` | `SELECT status_code, count(*) FROM default WHERE service = 'api' AND level = 'error' GROUP BY status_code` |
+| `service:api status:error \| count by status_code` | `SELECT status_code, count(*) FROM default WHERE service = 'api' AND level = 'error' GROUP BY status_code` |
 
 !!! tip "Use the AI Assistant"
     Instead of translating queries by hand, use the **AI Assistant** in the OpenObserve UI. Paste a Datadog query and ask: *"Convert this Datadog query to OpenObserve PromQL"* (for metrics) or *"...to OpenObserve SQL"* (for logs). It handles tag-name normalization, function mapping, and aggregation syntax in one shot, which is especially useful for complex multi-condition queries.

--- a/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
@@ -1,0 +1,183 @@
+---
+title: Migrate Dashboards & Monitors from Datadog to OpenObserve
+description: Migrate Datadog dashboards and monitors to OpenObserve. Translate Datadog query syntax to PromQL and SQL, set up notification channels, and use the OpenObserve AI Assistant to speed up migration.
+---
+
+# Migrating Dashboards & Monitors
+
+## Overview
+
+There is no automatic converter for Datadog dashboards or monitors; both need to be recreated in OpenObserve. That said, the effort is lower than it sounds:
+
+- **Most metric panels port over cleanly.** Datadog `avg:metric{tag:value}` expressions have direct PromQL equivalents. Once you know the pattern, most panels translate mechanically.
+- For logs, OpenObserve uses SQL with full-text functions (`match_all()`, `str_match()`, `re_match()`).
+- **Monitor types become alert rules.** PromQL-based or SQL-based alerts cover all the Datadog monitor types (metric, log, anomaly threshold, composite) you actually use day to day.
+- **The AI Assistant can translate queries for you.** Paste a Datadog query into the OpenObserve AI Assistant and ask for the PromQL or SQL equivalent. That removes the main friction point.
+
+Think of this as a forced cleanup. Datadog dashboards and monitor lists tend to accumulate panels and rules that nobody looks at anymore. Recreating from scratch is a good opportunity to keep only what's genuinely useful.
+
+
+## Export Your Datadog Configuration First
+
+Before you start rebuilding, pull a static snapshot of what you have. Both endpoints are part of the Datadog public API:
+
+```bash
+# Dashboards
+curl -X GET "https://api.datadoghq.com/api/v1/dashboard" \
+  -H "DD-API-KEY: $DD_API_KEY" \
+  -H "DD-APPLICATION-KEY: $DD_APP_KEY" > dashboards.json
+
+# Monitors
+curl -X GET "https://api.datadoghq.com/api/v1/monitor" \
+  -H "DD-API-KEY: $DD_API_KEY" \
+  -H "DD-APPLICATION-KEY: $DD_APP_KEY" > monitors.json
+```
+
+Now you have a static record to work from. The JSON contains the title, query, and notification config for every dashboard and monitor.
+
+
+## Migrating Dashboards
+
+### What Changes
+
+| Element | Datadog | OpenObserve |
+|---|---|---|
+| Metric panels | Datadog query DSL (`avg:metric{tag}`) | PromQL |
+| Log panels | Datadog log search syntax | SQL with `match_all()` / `str_match()` |
+| Trace panels | APM Trace Analytics | Built-in trace explorer + SQL |
+| Dashboard builder | Datadog UI (timeseries, toplist, heatmap, etc.) | OpenObserve built-in dashboard builder, 18+ chart types |
+| Template variables | Datadog template variables | OpenObserve dashboard variables |
+| Notebooks | Datadog Notebooks | Dashboard + SQL panels |
+
+### How to Approach It
+
+**Step 1: Inventory your dashboards**
+
+Walk the exported `dashboards.json`. For each dashboard:
+
+- Which widgets are actually used (drop the rest; most dashboards have at least one stale panel)
+- Which data type each widget queries (metric / log / trace)
+- Which Datadog tags are referenced; these become PromQL labels or SQL columns
+
+**Step 2: Translate queries**
+
+Datadog-to-PromQL examples for metric panels:
+
+| Datadog | OpenObserve PromQL |
+|---|---|
+| `avg:system.cpu.user{*}` | `avg(system_cpu_user)` |
+| `avg:system.cpu.user{host:web-01}` | `avg(system_cpu_user{host="web-01"})` |
+| `sum:http.requests{service:api}.as_rate()` | `sum(rate(http_requests{service="api"}[1m]))` |
+| `sum:http.requests{*} by {status_code}.as_rate()` | `sum by (status_code)(rate(http_requests[1m]))` |
+| `p95:trace.servlet.request{*}` | `histogram_quantile(0.95, sum by (le)(rate(trace_servlet_request_bucket[5m])))` |
+| `top(avg:cpu.user{*} by {host}, 10, 'mean', 'desc')` | `topk(10, avg by (host)(cpu_user))` |
+
+Datadog log search to SQL examples for log panels:
+
+| Datadog log query | OpenObserve SQL |
+|---|---|
+| `service:api status:error` | `SELECT * FROM default WHERE service = 'api' AND level = 'error'` |
+| `service:api "timeout"` | `SELECT * FROM default WHERE service = 'api' AND match_all('timeout')` |
+| `service:payments @duration:>500` | `SELECT * FROM default WHERE service = 'payments' AND duration > 500` |
+| `service:api status:error | count by status_code` | `SELECT status_code, count(*) FROM default WHERE service = 'api' AND level = 'error' GROUP BY status_code` |
+
+!!! tip "Use the AI Assistant"
+    Instead of translating queries by hand, use the **AI Assistant** in the OpenObserve UI. Paste a Datadog query and ask: *"Convert this Datadog query to OpenObserve PromQL"* (for metrics) or *"...to OpenObserve SQL"* (for logs). It handles tag-name normalization, function mapping, and aggregation syntax in one shot, which is especially useful for complex multi-condition queries.
+
+**Step 3: Recreate in OpenObserve**
+
+OpenObserve has a built-in drag-and-drop dashboard builder. For each panel:
+
+1. Open **Dashboards** → **New Dashboard** in the OpenObserve UI.
+2. Add a panel and select the signal type (Logs, Metrics, or Traces).
+3. Paste your translated query.
+4. Configure the visualization type, axes, thresholds, and any dashboard variables.
+
+For template variables, set them up as dashboard variables and reference them in queries with `$variable_name`, the same pattern as Datadog.
+
+
+## Migrating Monitors
+
+### What Changes
+
+| Monitor Type | Datadog | OpenObserve |
+|---|---|---|
+| Metric monitor | Datadog query DSL with threshold | PromQL alert with threshold |
+| Log monitor | Log search + threshold | SQL-based scheduled alert |
+| APM / Trace monitor | APM query | PromQL on RED metrics or SQL on traces |
+| Anomaly / Forecast | Datadog Watchdog/Anomaly | Manual thresholds (no AI auto-detect today) |
+| Composite | Logical AND/OR of monitors | Composite alert in OpenObserve |
+| Notification channels | Slack, PagerDuty, email, webhook (configured per monitor) | Built-in destinations (Slack, Email, PagerDuty, Webhook), configured once and reused |
+
+### Step 1: Inventory Your Current Monitors
+
+Walk the exported `monitors.json`. For each monitor, note:
+
+- The query (Datadog query DSL)
+- Threshold and comparison operator
+- Evaluation interval / window
+- Notification channel(s)
+- Whether the monitor still fires usefully (now is a great time to drop the ones that never trigger or always fire)
+
+### Step 2: Set Up Notification Destinations
+
+Set up notification destinations in OpenObserve **before** recreating rules, so you can test end-to-end as you go.
+
+OpenObserve supports: **Slack, Email, PagerDuty, and Webhook**.
+
+See the [OpenObserve Alerts Documentation](https://openobserve.ai/docs/user-guide/alerts/) for setup instructions.
+
+### Step 3: Recreate Alert Rules
+
+**Metric monitor to PromQL alert:**
+
+| Datadog Monitor | OpenObserve Alert |
+|---|---|
+| `avg(last_5m):avg:system.load.5{*} > 4` | PromQL: `avg_over_time(system_load_5[5m]) > 4` |
+| `sum(last_5m):sum:http.requests{status_code:5xx}.as_rate() > 0.1` | PromQL: `sum(rate(http_requests{status_code=~"5.."}[5m])) > 0.1` |
+| `avg(last_15m):p95:trace.servlet.request{service:api} > 1s` | PromQL: `histogram_quantile(0.95, sum by (le)(rate(trace_servlet_request_bucket{service="api"}[5m]))) > 1` |
+
+**Log monitor to SQL-based scheduled alert:**
+
+| Datadog Monitor | OpenObserve Alert |
+|---|---|
+| `logs("service:api status:error").index("*").rollup("count").last("5m") > 100` | SQL: `SELECT count(*) FROM default WHERE service = 'api' AND level = 'error'` with threshold > 100 over 5m |
+| `logs("service:payments \"timeout\"").rollup("count").last("5m") > 50` | SQL: `SELECT count(*) FROM default WHERE service = 'payments' AND match_all('timeout')` with threshold > 50 over 5m |
+
+**Composite monitor:**
+
+Datadog composite monitors combine other monitors with `&&` / `||`. In OpenObserve, create a **composite alert** that references the constituent alerts the same way.
+
+!!! tip "Use the AI Assistant"
+    The same AI Assistant that converts dashboard queries works here. Paste a Datadog monitor query and threshold and ask it to produce the OpenObserve PromQL or SQL equivalent. This is faster and less error-prone than translating complex multi-condition queries by hand.
+
+### Step 4: Verify Alerts
+
+1. Open **Alerts** in the OpenObserve UI and confirm each rule shows an **Active** status.
+2. Check the **Last Evaluated** timestamp; rules should update on their configured interval.
+3. Temporarily lower a threshold to force a firing condition, or send a test notification to confirm the destination works end-to-end.
+4. Cross-reference your `monitors.json` against the recreated alerts to confirm nothing was missed.
+
+**Troubleshooting:**
+
+- **Rule never fires:** Run the SQL or PromQL query directly in the Logs/Metrics explorer first to confirm it returns data.
+- **No notification received:** Test the notification destination independently (e.g., the Slack webhook URL) before attaching it to a rule.
+- **PromQL returns no data:** Confirm metric and label names in the Metrics explorer. Datadog uses `.` in metric names, OpenObserve uses `_`. Same for tags with dashes.
+- **Spurious fires after migration:** Datadog monitors often have implicit `no_data_timeframe` and `notify_no_data` behavior. Configure the equivalent in OpenObserve so a missing-data state doesn't immediately page.
+
+
+## SLOs & Watchdog
+
+- **SLOs:** Datadog SLO objects don't have a direct equivalent. Use OpenObserve **scheduled pipelines** to pre-aggregate the SLI (e.g., `good_events / total_events`), then alert on a burn-rate threshold.
+- **Watchdog (anomaly auto-detect):** Watchdog is a Datadog-proprietary ML feature with no direct OpenObserve equivalent today. Migrate Watchdog alerts to explicit threshold rules. In practice most teams find the explicit rules clearer once they're forced to define what "anomaly" actually means.
+
+
+## Next Steps
+
+- [OpenObserve Alerts Documentation](https://openobserve.ai/docs/user-guide/alerts/): full reference for alert rule types, conditions, and notification channels
+- [OpenObserve Dashboards Documentation](https://openobserve.ai/docs/user-guide/dashboards/): dashboard builder, panel types, and variables
+- [OpenObserve Full-Text Search Functions](https://openobserve.ai/docs/sql-functions/full-text-search/): SQL function reference for log queries (`match_all()`, `str_match()`, `re_match()`)
+- [OpenObserve Scheduled Pipelines](https://openobserve.ai/docs/user-guide/pipelines/create-and-use-scheduled-pipeline/): pre-aggregate expensive queries for SLOs and dashboards
+
+
+[Back to Overview](index.md) | Previous: [Migrating Logs](logs.md)

--- a/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
@@ -180,4 +180,7 @@ Datadog composite monitors combine other monitors with `&&` / `||`. In OpenObser
 - [OpenObserve Scheduled Pipelines](https://openobserve.ai/docs/user-guide/pipelines/create-and-use-scheduled-pipeline/): pre-aggregate expensive queries for SLOs and dashboards
 
 
-[Back to Overview](index.md) | Previous: [Migrating Logs](logs.md)
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/migration/migrate-from-datadog-to-openobserve/index.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/index.md
@@ -72,17 +72,17 @@ A migration path exists for every one of these. See the per-signal pages.
 
 Before migrating signal by signal, get OpenObserve running:
 
-> "OpenObserve Cloud"
+=== "OpenObserve Cloud"
 
-Sign up at [cloud.openobserve.ai](https://cloud.openobserve.ai). No infrastructure to manage.
+    Sign up at [cloud.openobserve.ai](https://cloud.openobserve.ai). No infrastructure to manage.
 
-After logging in, navigate to **Data Sources** to find your ingestion credentials and endpoint URLs.
+    After logging in, navigate to **Data Sources** to find your ingestion credentials and endpoint URLs.
 
-> "Self-Hosted"
+=== "Self-Hosted"
 
-Download OpenObserve for your platform from the [downloads page](https://openobserve.ai/downloads/).
+    Download OpenObserve for your platform from the [downloads page](https://openobserve.ai/downloads/).
 
-After installation, access the UI at `http://localhost:5080` and navigate to **Data Sources** to find your ingestion credentials and ready-to-use configuration snippets.
+    After installation, access the UI at `http://localhost:5080` and navigate to **Data Sources** to find your ingestion credentials and ready-to-use configuration snippets.
 
 ## Migration Strategy
 

--- a/docs/migration/migrate-from-datadog-to-openobserve/index.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/index.md
@@ -1,0 +1,103 @@
+---
+title: Migrate from Datadog to OpenObserve | Complete Migration Guide
+description: Step-by-step guide to migrate metrics, traces, logs, dashboards, and monitors from Datadog to OpenObserve. Use the OpenTelemetry Collector to route Datadog Agent, DogStatsD, APM, and log data into OpenObserve without rewriting your applications.
+---
+
+# Migrate from Datadog to OpenObserve
+
+If you're running Datadog today (Datadog Agent shipping metrics, traces, and logs to the Datadog SaaS) and you want to move to OpenObserve, this guide walks you through the entire migration, signal by signal, source by source.
+
+The goal is to switch the backend with minimal disruption: in most cases the Datadog Agent stays in place and only the destination changes, routed through an OpenTelemetry Collector that translates Datadog protocols into OTLP.
+
+## Table of Contents
+
+1. [Overview](index.md): why migrate and what changes
+2. [Architecture & Terminology](architecture.md): how Datadog concepts map to OpenObserve
+3. [Migrating Metrics](metrics.md): migrate Datadog Agent, DogStatsD, and OTel-based metric sources
+4. [Migrating Traces](traces.md): migrate Datadog APM to OTLP
+5. [Migrating Logs](logs.md): migrate Datadog Agent logs, Fluent Bit, and Vector
+6. [Migrating Dashboards & Monitors](dashboards-and-alerts.md): recreate Datadog dashboards and monitors
+
+
+## Why Migrate?
+
+Datadog is a capable platform, but for teams running at scale the cost curve, the lock-in, and the operational opacity become real constraints. Migrating to OpenObserve typically comes down to a few drivers.
+
+### Cost at scale
+
+Datadog bills per host, per ingested GB of logs, per custom metric, per APM span, and per indexed log. Once you cross even a moderate footprint (a few hundred hosts, a few TB of logs per month, a few thousand custom metrics), the monthly invoice climbs faster than the value most teams get from it. Reserved hosts, log retention tiers, and Watchdog all add line items.
+
+OpenObserve runs on Apache Parquet over object storage (S3, GCS, Azure Blob, local disk). Storage is up to 140x cheaper than typical hosted observability backends, and there are no per-metric, per-span, or per-host fees.
+
+### Vendor lock-in
+
+Datadog's wire formats (the Agent HTTPS API, the trace intake, the log intake), the DogStatsD dialect, the monitor DSL, and the dashboard JSON are all proprietary. Once you've built dashboards, monitors, and integrations against them, switching costs feel high.
+
+OpenObserve speaks open protocols: **OpenTelemetry (OTLP)** for metrics, traces, and logs, plus **Prometheus Remote Write**, **Loki Push API**, and **plain JSON over HTTP**. If you ever want to leave OpenObserve, your collectors keep working. Only the endpoint changes.
+
+### Data ownership
+
+In Datadog your raw telemetry lives on their cluster. You can query it through their UI and API, but you can't cheaply backfill, re-process, or join it with the rest of your data. OpenObserve stores raw events as Parquet in your own bucket. You can query it from OpenObserve, but you can also read it directly from any tool that speaks Parquet (Athena, Spark, DuckDB, Trino). The data is yours.
+
+### One system instead of many product SKUs
+
+Datadog is sold as a bundle of products (Infrastructure, APM, Logs, RUM, Synthetics, CSPM, Watchdog), each priced separately and each with its own data model and quirks. In OpenObserve, logs/metrics/traces are stream types in one unified store, queried with the same UI and the same query engine.
+
+## What OpenObserve Changes
+
+| | Datadog | OpenObserve |
+|---|---|---|
+| **Pricing model** | Per-host, per-GB, per-custom-metric, per-span | Storage + compute only, no per-host or per-metric fees |
+| **Storage backend** | Datadog-managed (opaque) | Apache Parquet on S3 / GCS / Azure Blob / local disk |
+| **Storage cost** | High at scale, retention tiers | Up to 140x lower storage cost |
+| **Query languages** | Datadog query DSL + log search syntax | SQL + PromQL |
+| **Wire protocols** | DogStatsD, Datadog Agent API, trace intake | OTLP (HTTP/gRPC), Prometheus Remote Write, Loki Push API, JSON over HTTP |
+| **Lock-in** | Proprietary formats end-to-end | Open standards; your data sits in your bucket as Parquet |
+| **Deployment** | SaaS only | Self-host (single binary or Helm chart) or OpenObserve Cloud |
+| **Multi-signal correlation** | Yes, within Datadog | Yes, unified UI across logs, metrics, traces |
+
+## Before You Start
+
+Before changing any configs, inventory what you're running:
+
+- **Datadog Agents:** how many, and which integrations are enabled per host (look in `/etc/datadog-agent/conf.d/`).
+- **DogStatsD usage:** which applications emit custom metrics via DogStatsD (port `8125` by default).
+- **APM tracers:** which services use `dd-trace-*` libraries (Java, Python, Node.js, Go, Ruby, .NET, PHP).
+- **Log pipelines:** how logs reach Datadog today, whether Agent log collection, Fluent Bit/Vector with Datadog output, direct API ingest, or cloud integrations (CloudWatch, Azure Monitor).
+- **Dashboards & monitors:** export them via the Datadog API now so you have a static record to recreate against.
+
+A migration path exists for every one of these. See the per-signal pages.
+
+## Set Up OpenObserve
+
+Before migrating signal by signal, get OpenObserve running:
+
+> "OpenObserve Cloud"
+
+Sign up at [cloud.openobserve.ai](https://cloud.openobserve.ai). No infrastructure to manage.
+
+After logging in, navigate to **Data Sources** to find your ingestion credentials and endpoint URLs.
+
+> "Self-Hosted"
+
+Download OpenObserve for your platform from the [downloads page](https://openobserve.ai/downloads/).
+
+After installation, access the UI at `http://localhost:5080` and navigate to **Data Sources** to find your ingestion credentials and ready-to-use configuration snippets.
+
+## Migration Strategy
+
+The recommended order:
+
+1. **Stand up an OpenTelemetry Collector** alongside your existing Datadog Agent fleet. The Collector becomes the translation layer between Datadog wire formats (DogStatsD, Datadog Agent API, Datadog APM intake) and OTLP.
+2. **Dual-write for a short period.** Point the Datadog Agent and OTel Collector at the same applications so you can compare metrics side by side in Datadog and OpenObserve. This catches any mapping issues (counter vs. sum, histogram bucketing) before you cut over.
+3. **Migrate signal by signal**, starting with metrics, then traces, then logs. Each signal is independent, so you can finish one before starting the next.
+4. **Recreate dashboards and monitors** in OpenObserve. There is no automatic converter, but PromQL/SQL equivalents are direct in most cases, and the OpenObserve AI Assistant can translate query syntax for you.
+5. **Decommission Datadog Agents** once dashboards, monitors, and on-call workflows have been moved over.
+
+## Next Steps
+
+- [Architecture & Terminology](architecture.md): how the stack maps across and what terminology changes
+- [Migrating Metrics](metrics.md): Datadog Agent, DogStatsD, OTel Collector
+- [Migrating Traces](traces.md): migrate Datadog APM to OTLP
+- [Migrating Logs](logs.md): migrate Datadog Agent logs and shipper-based pipelines
+- [Migrating Dashboards & Monitors](dashboards-and-alerts.md): recreate Datadog dashboards and monitors

--- a/docs/migration/migrate-from-datadog-to-openobserve/index.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/index.md
@@ -27,7 +27,7 @@ Datadog is a capable platform, but for teams running at scale the cost curve, th
 
 Datadog bills per host, per ingested GB of logs, per custom metric, per APM span, and per indexed log. Once you cross even a moderate footprint (a few hundred hosts, a few TB of logs per month, a few thousand custom metrics), the monthly invoice climbs faster than the value most teams get from it. Reserved hosts, log retention tiers, and Watchdog all add line items.
 
-OpenObserve runs on Apache Parquet over object storage (S3, GCS, Azure Blob, local disk). Storage is up to 140x cheaper than typical hosted observability backends, and there are no per-metric, per-span, or per-host fees.
+OpenObserve runs on Apache Parquet over object storage (S3, GCS, Azure Blob, local disk). Storage is **up to 140x more efficient, and therefore cheaper**, than typical hosted observability backends, and there are no per-metric, per-span, or per-host fees.
 
 ### Vendor lock-in
 
@@ -49,7 +49,7 @@ Datadog is sold as a bundle of products (Infrastructure, APM, Logs, RUM, Synthet
 |---|---|---|
 | **Pricing model** | Per-host, per-GB, per-custom-metric, per-span | Storage + compute only, no per-host or per-metric fees |
 | **Storage backend** | Datadog-managed (opaque) | Apache Parquet on S3 / GCS / Azure Blob / local disk |
-| **Storage cost** | High at scale, retention tiers | Up to 140x lower storage cost |
+| **Storage cost** | High at scale, retention tiers | Up to 140x efficient storage |
 | **Query languages** | Datadog query DSL + log search syntax | SQL + PromQL |
 | **Wire protocols** | DogStatsD, Datadog Agent API, trace intake | OTLP (HTTP/gRPC), Prometheus Remote Write, Loki Push API, JSON over HTTP |
 | **Lock-in** | Proprietary formats end-to-end | Open standards; your data sits in your bucket as Parquet |

--- a/docs/migration/migrate-from-datadog-to-openobserve/index.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/index.md
@@ -101,3 +101,9 @@ The recommended order:
 - [Migrating Traces](traces.md): migrate Datadog APM to OTLP
 - [Migrating Logs](logs.md): migrate Datadog Agent logs and shipper-based pipelines
 - [Migrating Dashboards & Monitors](dashboards-and-alerts.md): recreate Datadog dashboards and monitors
+
+
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/migration/migrate-from-datadog-to-openobserve/logs.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/logs.md
@@ -223,4 +223,7 @@ You can normalize these with an OpenObserve **Pipeline** (VRL) at ingest time so
 - [OpenObserve Pipelines](https://openobserve.ai/docs/user-guide/pipelines/): parse, enrich, route, and transform logs at ingest
 
 
-[Back to Overview](index.md) | Previous: [Migrating Traces](traces.md) | Next: [Migrating Dashboards & Monitors](dashboards-and-alerts.md)
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/migration/migrate-from-datadog-to-openobserve/logs.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/logs.md
@@ -44,30 +44,11 @@ Common ways logs reach Datadog:
 
 ### From Datadog Agent
 
-If the Datadog Agent is collecting logs (`logs_enabled: true` in `datadog.yaml`, with `logs:` blocks defined per-integration), you have two clean paths:
+If the Datadog Agent is collecting logs (`logs_enabled: true` in `datadog.yaml`, with `logs:` blocks defined per-integration), the Agent will need to be replaced for logs. The Datadog Agent's logs forwarder speaks a proprietary TCP framed protocol that the upstream OTel `datadog` receiver does not accept, so simply repointing `logs_dd_url` at the Collector will not work.
 
-**Option A: Repoint the Agent at a local OTel Collector.** Keep the Agent's `logs:` configs, but ship them to the Collector instead of Datadog SaaS:
+The recommended replacement is **Fluent Bit** (or the [OpenObserve Collector](https://github.com/openobserve/openobserve-helm-chart/blob/main/charts/openobserve-collector/README.md)) tailing the same files that the Agent was tailing. The `logs:` configs from `datadog.yaml` map cleanly to Fluent Bit `INPUT tail` sections — same paths, same parsing rules. See the Fluent Bit section below for the output config that ships to OpenObserve.
 
-```yaml
-# /etc/datadog-agent/datadog.yaml
-logs_enabled: true
-logs_config:
-  logs_dd_url: localhost:8126
-  logs_no_ssl: true
-```
-
-The Collector accepts the payloads via the `datadog` receiver and exports via `otlphttp` to OpenObserve. See the metrics page for the receiver/exporter config; the same Collector can handle logs by adding a `logs` pipeline:
-
-```yaml
-service:
-  pipelines:
-    logs:
-      receivers: [datadog]
-      processors: [batch]
-      exporters: [otlphttp/openobserve]
-```
-
-**Option B: Replace Datadog Agent log collection with Fluent Bit** (or the [OpenObserve Collector](https://github.com/openobserve/openobserve-helm-chart/blob/main/charts/openobserve-collector/README.md)) tailing the same files. This is a cleaner long-term path because it drops a Datadog-specific dependency. See the Fluent Bit section below.
+You can keep the Datadog Agent running for metrics and APM (as described in the [metrics](metrics.md) and [traces](traces.md) sections) while Fluent Bit handles logs in parallel. Once logs are flowing to OpenObserve, set `logs_enabled: false` in `datadog.yaml` to stop the Agent's log collector.
 
 
 ### From Fluent Bit

--- a/docs/migration/migrate-from-datadog-to-openobserve/logs.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/logs.md
@@ -1,0 +1,245 @@
+---
+title: Migrate Logs from Datadog to OpenObserve (Agent, Fluent Bit, Vector)
+description: Migrate logs from Datadog to OpenObserve. Migration paths for the Datadog Agent log collector, Fluent Bit, Vector, OpenTelemetry Collector, Kubernetes container logs, AWS CloudWatch, and Azure Monitor logs.
+---
+
+# Migrating Logs
+
+## Overview
+
+This section walks you through migrating logs from Datadog to OpenObserve. You will:
+
+1. Assess how logs currently reach Datadog
+2. Identify the migration path for each source type
+3. Update configs so logs flow into OpenObserve
+4. Validate that logs are flowing correctly
+
+OpenObserve accepts logs via OTLP, the Loki Push API, Fluent Bit's HTTP output, Vector's HTTP sink, or plain JSON over HTTP. You can keep your existing log shipper. Only the destination changes.
+
+## Step 1: Assess Your Current Log Sources
+
+Common ways logs reach Datadog:
+
+- **Datadog Agent log collection** tailing files declared in `logs:` blocks (Kubernetes integrations, host files, container stdout/stderr)
+- **Fluent Bit** with the `datadog` output plugin
+- **Vector** with the `datadog_logs` sink
+- **OpenTelemetry Collector** with the `datadog` exporter
+- **Cloud integrations** (AWS CloudWatch Logs, Azure Diagnostic Settings, GCP Logging)
+- **Direct API ingest**, where applications POST to `https://http-intake.logs.datadoghq.com/api/v2/logs`
+
+## Step 2: Categorize Your Sources
+
+| Source Type | Migration Path |
+|---|---|
+| **Datadog Agent log collection** | [Repoint Agent at OTel Collector or replace with Fluent Bit](#from-datadog-agent) |
+| **Fluent Bit with `datadog` output** | [Switch output to `http` (or `loki`)](#from-fluent-bit) |
+| **Vector with `datadog_logs` sink** | [Switch sink to `http` (or `loki`)](#from-vector) |
+| **OTel Collector with `datadog` exporter** | [Swap exporter to `otlphttp`](#from-otel-collector) |
+| **Direct API ingest** | [Repoint apps at OpenObserve `_json` endpoint](#from-direct-api-ingest) |
+| **Kubernetes container logs** | [Use OpenObserve Collector Helm chart](#from-kubernetes-container-logs) |
+| **AWS CloudWatch logs** | [See dedicated guide](#from-aws-cloudwatch-logs) |
+| **Azure Monitor logs** | [See dedicated guide](#from-azure-monitor-logs) |
+
+## Step 3: Migrate Each Source
+
+### From Datadog Agent
+
+If the Datadog Agent is collecting logs (`logs_enabled: true` in `datadog.yaml`, with `logs:` blocks defined per-integration), you have two clean paths:
+
+**Option A: Repoint the Agent at a local OTel Collector.** Keep the Agent's `logs:` configs, but ship them to the Collector instead of Datadog SaaS:
+
+```yaml
+# /etc/datadog-agent/datadog.yaml
+logs_enabled: true
+logs_config:
+  logs_dd_url: localhost:8126
+  logs_no_ssl: true
+```
+
+The Collector accepts the payloads via the `datadog` receiver and exports via `otlphttp` to OpenObserve. See the metrics page for the receiver/exporter config; the same Collector can handle logs by adding a `logs` pipeline:
+
+```yaml
+service:
+  pipelines:
+    logs:
+      receivers: [datadog]
+      processors: [batch]
+      exporters: [otlphttp/openobserve]
+```
+
+**Option B: Replace Datadog Agent log collection with Fluent Bit** (or the [OpenObserve Collector](https://github.com/openobserve/openobserve-helm-chart/blob/main/charts/openobserve-collector/README.md)) tailing the same files. This is a cleaner long-term path because it drops a Datadog-specific dependency. See the Fluent Bit section below.
+
+
+### From Fluent Bit
+
+**Current config:**
+
+```ini
+[OUTPUT]
+    Name datadog
+    Match *
+    Host http-intake.logs.datadoghq.com
+    TLS on
+    apikey <DD_API_KEY>
+```
+
+**Updated config.** Switch to the `http` output and point it at OpenObserve:
+
+```ini
+[OUTPUT]
+    Name http
+    Match *
+    URI /api/default/default/_json
+    Host <your-openobserve-host>
+    Port 443
+    tls on
+    Format json
+    Json_date_key _timestamp
+    Json_date_format iso8601
+    HTTP_User admin@example.com
+    HTTP_Passwd Complexpass#123
+    Header Content-Type application/json
+```
+
+Copy the exact Fluent Bit configuration from the **Data Sources UI** in OpenObserve.
+
+
+### From Vector
+
+**Current config:**
+
+```toml
+[sinks.datadog]
+  type = "datadog_logs"
+  inputs = ["logs"]
+  default_api_key = "${DD_API_KEY}"
+```
+
+**Updated config.** Switch to the `http` sink:
+
+```toml
+[sinks.openobserve]
+  type = "http"
+  inputs = ["logs"]
+  uri = "https://<your-openobserve-host>/api/default/default/_json"
+  encoding.codec = "json"
+  auth.strategy = "basic"
+  auth.user = "admin@example.com"
+  auth.password = "Complexpass#123"
+  request.headers.Content-Type = "application/json"
+```
+
+Copy the exact Vector configuration from the **Data Sources UI** in OpenObserve.
+
+
+### From OTel Collector
+
+If logs already flow through an OTel Collector with the `datadog` exporter, the swap is the same as for metrics and traces.
+
+**Current config:**
+
+```yaml
+exporters:
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: datadoghq.com
+```
+
+**Updated config:**
+
+```yaml
+exporters:
+  otlphttp/openobserve:
+    endpoint: https://<your-openobserve-host>/api/<org_id>
+    headers:
+      Authorization: Basic <base64-creds>
+```
+
+Update the `logs` pipeline's `exporters` list and restart.
+
+
+### From Direct API Ingest
+
+If applications POST JSON logs directly to `https://http-intake.logs.datadoghq.com/api/v2/logs`, repoint them at OpenObserve's `_json` ingest endpoint:
+
+```
+POST https://<your-openobserve-host>/api/{org}/{stream}/_json
+Authorization: Basic <base64-creds>
+Content-Type: application/json
+
+[
+  { "_timestamp": "2026-05-26T12:00:00Z", "level": "info", "message": "hello", "service": "api" }
+]
+```
+
+The endpoint accepts a JSON array of records and auto-creates the stream on first write.
+
+
+### From Kubernetes Container Logs
+
+If the Datadog Agent DaemonSet is tailing container logs in your cluster, the simplest replacement is the OpenObserve Collector Helm chart:
+
+```bash
+helm repo add openobserve https://charts.openobserve.ai
+helm upgrade --install o2c openobserve/openobserve-collector \
+  --set exporters.openobserve.endpoint=https://<your-openobserve-host> \
+  --set exporters.openobserve.auth=<base64-creds> \
+  -n monitoring --create-namespace
+```
+
+Copy the exact installation command from the **Data Sources UI** in OpenObserve. Once logs are flowing and dashboards look right, scale the Datadog Agent DaemonSet down.
+
+
+### From AWS CloudWatch Logs
+
+> **Dedicated guide:** [AWS CloudWatch Logs → OpenObserve](https://openobserve.ai/blog/how-to-send-aws-cloudwatch-logs-to-s3-using-kinesis-data-firehose/)
+
+
+### From Azure Monitor Logs
+
+> **Dedicated guide:** [Azure Monitor → OpenObserve](https://openobserve.ai/blog/azure-monitor-metrics/)
+
+
+## Step 4: How to Verify
+
+### Check in the UI
+
+1. Open the OpenObserve UI → **Logs** in the left sidebar.
+2. Confirm each log stream from your Datadog inventory appears in the stream list.
+3. Run a test query against a known stream: `SELECT * FROM "default"`.
+4. Verify field names look correct, especially that structured fields (`level`, `service`, `trace_id`) are parsed as columns, not buried in a raw string.
+
+### Field parsing
+
+If your apps log JSON, OpenObserve auto-parses them into columns. Check that expected fields appear as filterable columns in the Logs explorer. If a field is missing, check whether the raw log line is actually valid JSON.
+
+### Datadog reserved attributes → OpenObserve fields
+
+| Datadog attribute | OpenObserve field |
+|---|---|
+| `@timestamp` / `timestamp` | `_timestamp` |
+| `service` | `service` |
+| `host` | `host` |
+| `status` (Datadog log status) | `level` (conventional) |
+| `dd.trace_id` | `trace_id` |
+| `dd.span_id` | `span_id` |
+| `ddtags` (comma-separated) | individual columns (after parsing) |
+
+You can normalize these with an OpenObserve **Pipeline** (VRL) at ingest time so existing log queries don't need to change.
+
+### Troubleshooting
+
+- **No streams visible:** Check the shipper's output logs for HTTP errors. Confirm the URI path matches your org (`/api/default/<stream>/_json` for the default org).
+- **Fields not parsed:** If logs aren't JSON, add a parser before the exporter (Fluent Bit `parsers.conf`, Vector `remap` transform, OTel `logstransform` processor).
+- **`_timestamp` is wrong:** Map your timestamp field to `_timestamp` explicitly (`Json_date_key _timestamp` in Fluent Bit; or a Pipeline `vrl` step in OpenObserve).
+- **Auth errors:** Regenerate the Base64 credential string; whitespace in the original input will break it.
+
+## Next Steps
+
+- [OpenObserve Logs User Guide](https://openobserve.ai/docs/user-guide/logs/): exploring streams, running queries, and configuring stream settings in the UI
+- [OpenObserve Full-Text Search Functions](https://openobserve.ai/docs/sql-functions/full-text-search/): reference for `match_all()`, `str_match()`, `re_match()`, and more
+- [OpenObserve Pipelines](https://openobserve.ai/docs/user-guide/pipelines/): parse, enrich, route, and transform logs at ingest
+
+
+[Back to Overview](index.md) | Previous: [Migrating Traces](traces.md) | Next: [Migrating Dashboards & Monitors](dashboards-and-alerts.md)

--- a/docs/migration/migrate-from-datadog-to-openobserve/metrics.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/metrics.md
@@ -318,4 +318,7 @@ Functions like `rate()`, `histogram_quantile()`, `sum by()`, and label matchers 
 - [Migrating Logs](logs.md): migrate your log sources
 
 
-[Back to Overview](index.md) | Previous: [Architecture & Terminology](architecture.md) | Next: [Migrating Traces](traces.md)
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/migration/migrate-from-datadog-to-openobserve/metrics.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/metrics.md
@@ -79,7 +79,6 @@ exporters:
     endpoint: https://<your-openobserve-host>/api/<org_id>
     headers:
       Authorization: Basic <base64-creds>
-      stream-name: default
 
 service:
   pipelines:
@@ -89,23 +88,17 @@ service:
       exporters: [otlphttp/openobserve]
 ```
 
-**Cutover options:**
+**Cutover:** Stop the Datadog Agent's DogStatsD listener (set `use_dogstatsd: false` in `/etc/datadog-agent/datadog.yaml`) and start the OTel Collector on UDP port `8125`. Apps continue to send to `localhost:8125`, but the Collector receives instead of the Agent. No app changes.
 
-- **Stop the Datadog Agent's DogStatsD listener** and start the OTel Collector on port `8125`. Apps now send to the Collector directly.
-- **Or forward through the Agent during dual-write**, by setting `dogstatsd_forward_host`/`dogstatsd_forward_port` in `datadog.yaml` to mirror DogStatsD traffic to the Collector while you validate:
+If you want to dual-write to both Datadog and OpenObserve during validation, run the Collector's `statsd` receiver on a **different port** (e.g., `18125`) and forward DogStatsD packets from the Agent to that port:
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml
-use_dogstatsd: true
-dogstatsd_port: 8125
-dogstatsd_non_local_traffic: true
-bind_host: 0.0.0.0
-
 dogstatsd_forward_host: localhost
-dogstatsd_forward_port: 8126   # forward port that the OTel Collector listens on
+dogstatsd_forward_port: 18125
 ```
 
-(Forward DogStatsD on a different port than the receive port so the Agent doesn't loop into itself.)
+Then update the Collector's `statsd` receiver endpoint to `0.0.0.0:18125` to match.
 
 **Datadog-to-OpenTelemetry metric-type mapping** (handled automatically by the receiver):
 
@@ -132,6 +125,8 @@ If the Datadog Agent is doing more than DogStatsD (host metrics, integrations li
 
 **Collector config:**
 
+The contrib `datadog` receiver listens on a single HTTP endpoint and accepts both the Agent's metric series API and the APM trace intake. Wire it into both a `metrics` and a `traces` pipeline:
+
 ```yaml
 receivers:
   datadog:
@@ -154,19 +149,22 @@ service:
       receivers: [datadog]
       processors: [batch]
       exporters: [otlphttp/openobserve]
+    traces:
+      receivers: [datadog]
+      processors: [batch]
+      exporters: [otlphttp/openobserve]
 ```
 
 **Repoint the Datadog Agent at the local Collector.** Edit `/etc/datadog-agent/datadog.yaml`:
 
 ```yaml
-# Send metrics/traces/logs to the local OTel Collector instead of Datadog SaaS
+# Send metrics and APM traces to the local OTel Collector instead of Datadog SaaS
 dd_url: http://localhost:8126
 apm_config:
   apm_dd_url: http://localhost:8126
-logs_config:
-  logs_dd_url: localhost:8126
-  logs_no_ssl: true
 ```
+
+The Datadog Agent's logs forwarder uses a separate TCP framed protocol that the OTel `datadog` receiver does not accept. For logs, use Fluent Bit, Vector, or the OpenObserve Collector instead. See [Migrating Logs](logs.md).
 
 Restart the Agent:
 

--- a/docs/migration/migrate-from-datadog-to-openobserve/metrics.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/metrics.md
@@ -1,0 +1,323 @@
+---
+title: Migrate Metrics from Datadog to OpenObserve (Agent, DogStatsD, OTel)
+description: Migrate Datadog metrics to OpenObserve using the OpenTelemetry Collector. Covers DogStatsD, Datadog Agent forwarding, OTel Collector swaps, Kubernetes (Datadog Helm chart), AWS CloudWatch, and Azure Monitor.
+---
+
+# Migrating Metrics
+
+## Overview
+
+This section walks you through migrating metrics from Datadog to OpenObserve. You will:
+
+1. Assess what metric sources you currently have
+2. Identify the migration path for each source type
+3. Update configs so metrics flow into OpenObserve (via the OpenTelemetry Collector when needed)
+4. Validate that metrics are flowing correctly
+
+The recommended pattern is to introduce an **OpenTelemetry Collector** in front of OpenObserve. The Collector accepts Datadog wire formats (DogStatsD, Datadog Agent API) and exports OTLP to OpenObserve. Application code does not change.
+
+## Step 1: Assess Your Current Metric Sources
+
+Group your Datadog metrics by how they're emitted today:
+
+| Source Type | Examples | Migration Path |
+|---|---|---|
+| **DogStatsD from applications** | Custom counters/gauges/histograms via `statsd` clients | [Point apps at OTel Collector `statsd` receiver](#from-dogstatsd) |
+| **Datadog Agent (host + integrations)** | `system.cpu.user`, integration metrics, custom checks | [Use the OTel Collector `datadog` receiver](#from-datadog-agent) |
+| **APM / dd-trace metrics** | Runtime metrics from `dd-trace-*` SDKs | [Switch to OTel SDK or keep Agent and Collector](#from-dd-trace-runtime-metrics) |
+| **Kubernetes (Datadog Helm chart)** | DaemonSet Agent, Cluster Agent | [Repoint Agent or replace with OTel Collector](#from-kubernetes-datadog-helm-chart) |
+| **OTel Collector already in use** | `datadog` exporter sending to Datadog | [Swap exporter to `otlphttp`](#from-otel-collector) |
+| **AWS CloudWatch metrics** | Datadog AWS integration | [Ingest CloudWatch directly into OpenObserve](#from-aws-cloudwatch) |
+| **Azure Monitor metrics** | Datadog Azure integration | [Ingest Azure Monitor directly into OpenObserve](#from-azure-monitor) |
+
+## Step 2: Stand Up an OpenTelemetry Collector
+
+Install the **contrib** distribution (the upstream `otelcol-contrib` binary), which includes the `statsd`, `datadog`, and `otlphttp` components you need.
+
+```bash
+curl --proto '=https' --tlsv1.2 -fOL \
+  https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.115.1/otelcol-contrib_0.115.1_linux_amd64.tar.gz
+
+tar -xvf otelcol-contrib_0.115.1_linux_amd64.tar.gz
+sudo mv otelcol-contrib /usr/local/bin/
+otelcol-contrib --version
+```
+
+Get the exact `Authorization` header and endpoint URL for the OTLP exporter from the OpenObserve UI under **Data Sources > Custom > Metrics > OTel Collector**.
+
+## Step 3: Migrate Each Source
+
+### From DogStatsD
+
+This is the most common Datadog custom-metrics path. Your apps emit lines like `my.counter:1|c|#env:prod` over UDP `8125`. The Datadog Agent listens on that port today; the OTel Collector's `statsd` receiver listens on the same port and translates to OTLP. Your application code does not change.
+
+**Collector config:**
+
+```yaml
+receivers:
+  statsd:
+    endpoint: "0.0.0.0:8125"
+    aggregation_interval: 60s
+    enable_metric_type: true
+    timer_histogram_mapping:
+      - statsd_type: "timing"
+        observer_type: "histogram"
+        histogram:
+          max_size: 100
+      - statsd_type: "histogram"
+        observer_type: "histogram"
+        histogram:
+          max_size: 100
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 10000
+
+exporters:
+  otlphttp/openobserve:
+    endpoint: https://<your-openobserve-host>/api/<org_id>
+    headers:
+      Authorization: Basic <base64-creds>
+      stream-name: default
+
+service:
+  pipelines:
+    metrics:
+      receivers: [statsd]
+      processors: [batch]
+      exporters: [otlphttp/openobserve]
+```
+
+**Cutover options:**
+
+- **Stop the Datadog Agent's DogStatsD listener** and start the OTel Collector on port `8125`. Apps now send to the Collector directly.
+- **Or forward through the Agent during dual-write**, by setting `dogstatsd_forward_host`/`dogstatsd_forward_port` in `datadog.yaml` to mirror DogStatsD traffic to the Collector while you validate:
+
+```yaml
+# /etc/datadog-agent/datadog.yaml
+use_dogstatsd: true
+dogstatsd_port: 8125
+dogstatsd_non_local_traffic: true
+bind_host: 0.0.0.0
+
+dogstatsd_forward_host: localhost
+dogstatsd_forward_port: 8126   # forward port that the OTel Collector listens on
+```
+
+(Forward DogStatsD on a different port than the receive port so the Agent doesn't loop into itself.)
+
+**Datadog-to-OpenTelemetry metric-type mapping** (handled automatically by the receiver):
+
+| DogStatsD | OpenTelemetry |
+|---|---|
+| Gauge (`g`) | Gauge |
+| Count (`c`) | Sum (monotonic, cumulative) |
+| Rate | Sum (monotonic, delta) |
+| Distribution (`d`) | Exponential Histogram |
+| Timing / Histogram (`ms`, `h`) | Histogram |
+
+**Test:**
+
+```bash
+echo "test.metric:42|c|#myKey:myVal" | nc -w 1 -u localhost 8125
+```
+
+The metric `test_metric` (DogStatsD `.` becomes `_` in PromQL) should appear in OpenObserve under the configured stream.
+
+
+### From Datadog Agent
+
+If the Datadog Agent is doing more than DogStatsD (host metrics, integrations like Postgres, Redis, Nginx, custom checks), keep the Agent for now and use the OTel Collector's `datadog` receiver to accept the Agent's outbound payloads.
+
+**Collector config:**
+
+```yaml
+receivers:
+  datadog:
+    endpoint: "0.0.0.0:8126"
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 10000
+
+exporters:
+  otlphttp/openobserve:
+    endpoint: https://<your-openobserve-host>/api/<org_id>
+    headers:
+      Authorization: Basic <base64-creds>
+
+service:
+  pipelines:
+    metrics:
+      receivers: [datadog]
+      processors: [batch]
+      exporters: [otlphttp/openobserve]
+```
+
+**Repoint the Datadog Agent at the local Collector.** Edit `/etc/datadog-agent/datadog.yaml`:
+
+```yaml
+# Send metrics/traces/logs to the local OTel Collector instead of Datadog SaaS
+dd_url: http://localhost:8126
+apm_config:
+  apm_dd_url: http://localhost:8126
+logs_config:
+  logs_dd_url: localhost:8126
+  logs_no_ssl: true
+```
+
+Restart the Agent:
+
+```bash
+sudo systemctl restart datadog-agent
+```
+
+The Agent will keep collecting integration data, but now ships it to the Collector instead of `api.datadoghq.com`. The Collector translates to OTLP and forwards to OpenObserve.
+
+
+### From dd-trace Runtime Metrics
+
+`dd-trace-*` SDKs emit runtime metrics (heap, GC, goroutines, threadpool) alongside spans. These are normally collected by the Agent on port `8125` (DogStatsD).
+
+Two options:
+
+1. **Keep the SDK, route through the Collector.** The same `statsd` receiver above ingests these metrics. No code changes.
+2. **Switch to the OpenTelemetry SDK.** Use `opentelemetry-*` libraries to emit OTLP metrics directly. This is the longer-term direction once your dashboards and alerts work against OpenObserve.
+
+
+### From Kubernetes (Datadog Helm chart)
+
+If you deployed the Datadog Agent as a DaemonSet via the `datadog/datadog` Helm chart, the simplest path is to keep the chart and repoint the Agent at an in-cluster OTel Collector.
+
+**Deploy an OTel Collector DaemonSet** in the same namespace:
+
+```bash
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm upgrade --install otel-collector open-telemetry/opentelemetry-collector \
+  --set mode=daemonset \
+  --values otel-values.yaml \
+  -n monitoring
+```
+
+`otel-values.yaml` uses the `statsd` + `datadog` receivers and the `otlphttp` exporter shown above.
+
+**Update Datadog Helm values** to send the Agent's traffic to the Collector service:
+
+```yaml
+datadog:
+  apiKey: "any-string-will-do"  # required by chart, not used downstream
+  dd_url: "http://otel-collector.monitoring.svc.cluster.local:8126"
+  apm:
+    enabled: true
+    apm_dd_url: "http://otel-collector.monitoring.svc.cluster.local:8126"
+```
+
+```bash
+helm upgrade datadog datadog/datadog -f values.yaml -n monitoring
+```
+
+Alternatively, replace the Datadog Agent DaemonSet entirely with the [OpenObserve Collector Helm chart](https://github.com/openobserve/openobserve-helm-chart/blob/main/charts/openobserve-collector/README.md).
+
+
+### From OTel Collector
+
+If you already run an OpenTelemetry Collector that ships to Datadog via the `datadog` exporter, the migration is a one-exporter swap.
+
+**Current config:**
+
+```yaml
+exporters:
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: datadoghq.com
+```
+
+**Updated config:**
+
+```yaml
+exporters:
+  otlphttp/openobserve:
+    endpoint: https://<your-openobserve-host>/api/<org_id>
+    headers:
+      Authorization: Basic <base64-creds>
+```
+
+Update the pipeline `exporters:` list to point at `otlphttp/openobserve` and restart the Collector. Copy the exact configuration from the **Data Sources UI** in OpenObserve.
+
+
+### From AWS CloudWatch
+
+The Datadog AWS integration mirrors CloudWatch metrics into Datadog. To migrate, ingest CloudWatch directly into OpenObserve:
+
+> **Dedicated guide:** [AWS CloudWatch Metrics → OpenObserve](https://openobserve.ai/blog/monitor-aws-rds-with-cloudwatch-metrics/)
+
+
+### From Azure Monitor
+
+The Datadog Azure integration mirrors Azure Monitor metrics into Datadog. To migrate, ingest Azure Monitor directly into OpenObserve:
+
+> **Dedicated guide:** [Azure Monitor Metrics → OpenObserve](https://openobserve.ai/blog/azure-monitor-metrics/)
+
+
+## Step 4: How to Verify
+
+### Check in the UI
+
+1. Open the OpenObserve UI → **Metrics** in the left sidebar.
+2. Confirm each metric from your Datadog inventory appears. DogStatsD metrics have `.` translated to `_` (e.g. `my.counter` → `my_counter`).
+3. Run a test PromQL query (e.g. `sum(rate(my_counter[1m]))`) and compare values to the equivalent Datadog query.
+4. Confirm tags (Datadog) come through as labels (OpenObserve).
+
+### Dual-write comparison
+
+During the migration window, keep the Datadog Agent active and send the same metrics to both backends. Plot the same series side by side and watch for:
+
+- **Counter vs. cumulative-sum drift.** Datadog Rate maps to OTel delta Sum; Datadog Count maps to OTel cumulative Sum. Most dashboards Just Work, but recording rules that assume specific aggregation may need tweaks.
+- **Histogram bucket shape.** Distributions become Exponential Histograms; percentile values match closely but won't be bit-identical.
+- **Tag-to-label name normalization.** Datadog tags with dashes or dots become labels with underscores.
+
+### Troubleshooting
+
+- **No data:** Check the Collector logs for receiver errors or auth failures. Confirm the OTLP exporter endpoint and `Authorization` header.
+- **Buffer overflow / dropped batches:** Increase batch size and timeout:
+
+  ```yaml
+  processors:
+    batch:
+      send_batch_size: 20000
+      timeout: 20s
+  ```
+- **Verify connectivity:**
+
+  ```bash
+  nc -zv localhost 8125
+  ```
+- **Inspect DogStatsD traffic at the Agent:**
+
+  ```bash
+  sudo tail -f /var/log/datadog/dogstatsd.log
+  ```
+- **Case mismatch in PromQL:** OpenObserve label matching is case-sensitive. Confirm tag values match exactly as ingested.
+
+## PromQL Compatibility
+
+OpenObserve supports PromQL for metrics queries. Common Datadog-equivalent patterns:
+
+| Datadog query | OpenObserve PromQL |
+|---|---|
+| `avg:system.cpu.user{*}` | `avg(system_cpu_user)` |
+| `sum:http.requests{service:api}.as_rate()` | `sum(rate(http_requests{service="api"}[1m]))` |
+| `p95:trace.servlet.request{*}` | `histogram_quantile(0.95, sum by (le)(rate(trace_servlet_request_bucket[5m])))` |
+
+Functions like `rate()`, `histogram_quantile()`, `sum by()`, and label matchers work as expected.
+
+## Next Steps
+
+- [Migrating Traces](traces.md): migrate Datadog APM next
+- [Migrating Logs](logs.md): migrate your log sources
+
+
+[Back to Overview](index.md) | Previous: [Architecture & Terminology](architecture.md) | Next: [Migrating Traces](traces.md)

--- a/docs/migration/migrate-from-datadog-to-openobserve/traces.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/traces.md
@@ -1,0 +1,177 @@
+---
+title: Migrate Traces from Datadog APM to OpenObserve
+description: Migrate Datadog APM traces to OpenObserve. Use the OpenTelemetry Collector's datadog receiver to accept dd-trace spans, or switch application SDKs to OpenTelemetry. Step-by-step examples and verification.
+---
+
+# Migrating Traces
+
+## Overview
+
+This section walks you through migrating distributed traces from Datadog APM to OpenObserve. You will:
+
+1. Assess how traces currently reach Datadog
+2. Choose between keeping `dd-trace` SDKs (translate via OTel Collector) or switching to OpenTelemetry SDKs
+3. Update configs so traces flow into OpenObserve
+4. Validate that traces are intact
+
+The fastest path is to **keep your `dd-trace-*` SDKs unchanged** and use the OpenTelemetry Collector's `datadog` receiver as a translation layer. No application redeploys, no code changes.
+
+## Step 1: Assess Your Current Trace Sources
+
+Datadog APM traces typically reach Datadog one of two ways:
+
+- **`dd-trace-*` SDK in the app** sends spans to the local Datadog Agent on port `8126` (Datadog trace intake protocol). The Agent batches and forwards to Datadog SaaS.
+- **OpenTelemetry SDK in the app** sends OTLP spans to the Datadog Agent (Datadog has accepted OTLP since 2023) or directly to Datadog via OTLP HTTP.
+
+Note the SDKs and instrumented services. You can usually find them by grepping deployment manifests for `dd-trace-*`, `DD_AGENT_HOST`, `DD_TRACE_*`, or `OTEL_EXPORTER_OTLP_ENDPOINT`.
+
+## Step 2: Categorize Your Sources
+
+| Source Type | Migration Path |
+|---|---|
+| **`dd-trace` SDK → Datadog Agent on 8126** | [Route Agent (or apps) at the OTel Collector `datadog` receiver](#from-dd-trace-sdks) |
+| **OpenTelemetry SDK → Datadog Agent (OTLP)** | [Switch SDK endpoint to OpenObserve OTLP](#from-opentelemetry-sdks) |
+| **OTel Collector with `datadog` exporter** | [Swap the exporter to `otlphttp`](#from-otel-collector) |
+
+## Step 3: Migrate Each Source
+
+### From dd-trace SDKs
+
+The OpenTelemetry Collector's `datadog` receiver listens for Datadog APM trace payloads (the protocol that `dd-trace-*` SDKs and the Datadog Agent both speak) and converts them into OTLP spans.
+
+**Collector config:**
+
+```yaml
+receivers:
+  datadog:
+    endpoint: "0.0.0.0:8126"
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 10000
+
+exporters:
+  otlphttp/openobserve:
+    endpoint: https://<your-openobserve-host>/api/<org_id>
+    headers:
+      Authorization: Basic <base64-creds>
+
+service:
+  pipelines:
+    traces:
+      receivers: [datadog]
+      processors: [batch]
+      exporters: [otlphttp/openobserve]
+```
+
+**Two ways to wire it up:**
+
+**Option A: Point apps directly at the Collector.** Set `DD_AGENT_HOST`/`DD_TRACE_AGENT_PORT` on each service so `dd-trace` ships spans to the Collector instead of the Datadog Agent:
+
+```bash
+DD_AGENT_HOST=otel-collector.local
+DD_TRACE_AGENT_PORT=8126
+```
+
+The application code does not change. Only the env vars do. Restart the service to pick up the new agent endpoint.
+
+**Option B: Keep the Datadog Agent, repoint it.** If many services point at the local Datadog Agent and changing env vars across the fleet is awkward, repoint the Agent's APM forwarder at the local Collector:
+
+```yaml
+# /etc/datadog-agent/datadog.yaml
+apm_config:
+  apm_dd_url: http://localhost:8126
+```
+
+In this setup the Collector runs on a different port than the Agent (e.g. Agent on `8126`, Collector on `18126`) and the Agent forwards to the Collector, which forwards to OpenObserve.
+
+!!! tip "Send all signals through one Collector"
+    If you're also migrating metrics and logs, you can consolidate everything through a single OTel Collector with one `otlphttp/openobserve` exporter: one endpoint, one auth header, all signals.
+
+
+### From OpenTelemetry SDKs
+
+If your services already use OpenTelemetry SDKs and ship OTLP, the migration is just an endpoint change. Update the `OTEL_EXPORTER_OTLP_ENDPOINT` env var (or the equivalent in your SDK config) to point at OpenObserve:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-openobserve-host>
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64-creds>,stream-name=default"
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+For full per-language examples:
+
+- [Go traces ingestion guide](https://openobserve.ai/docs/ingestion/traces/go/)
+- [Node.js traces ingestion guide](https://openobserve.ai/docs/ingestion/traces/nodejs/)
+- [Python traces ingestion guide](https://openobserve.ai/docs/ingestion/traces/python/)
+- [Rust traces ingestion guide](https://openobserve.ai/docs/ingestion/traces/rust/)
+
+
+### From OTel Collector
+
+If you already run an OpenTelemetry Collector with the `datadog` exporter shipping to Datadog, replace it with `otlphttp` pointed at OpenObserve.
+
+**Current config:**
+
+```yaml
+exporters:
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: datadoghq.com
+```
+
+**Updated config:**
+
+```yaml
+exporters:
+  otlphttp/openobserve:
+    endpoint: https://<your-openobserve-host>/api/<org_id>
+    headers:
+      Authorization: Basic <base64-creds>
+```
+
+Update the `traces` pipeline's `exporters` list to use `otlphttp/openobserve` and restart the Collector.
+
+
+## Step 4: How to Verify
+
+### Check in the UI
+
+1. Open the OpenObserve UI → **Traces** in the left sidebar.
+2. Select the trace stream and set a recent time range.
+3. Filter by `service.name` to find your services. `dd-trace`'s `service` tag becomes `service.name` after translation.
+4. Click into a trace to verify spans, durations, and attributes are intact.
+
+### Span attribute mapping
+
+When `dd-trace` spans are translated to OTLP, the following mapping applies:
+
+| Datadog field | OpenTelemetry attribute |
+|---|---|
+| `service` | `service.name` |
+| `resource` | `resource.name` (and span name) |
+| `operation` | Span name |
+| `env` | `deployment.environment` |
+| `version` | `service.version` |
+| Custom tags | Span attributes (same key) |
+
+### Troubleshooting
+
+- **No traces visible:** Check Collector logs for receiver errors and the OTLP exporter for HTTP errors. Confirm endpoint and `Authorization` header.
+- **Service missing from the service list:** Ensure spans carry `service.name` after translation. If `dd-trace` was misconfigured (`DD_SERVICE` unset), spans will land but the service list will be sparse.
+- **Trace appears split:** Check that the trace ID and parent span ID propagation headers (`x-datadog-trace-id`, `traceparent`) are flowing through your service mesh / load balancer.
+- **Auth errors (401):** Regenerate the Base64 credential string and confirm it has no whitespace.
+
+## Dual-write during migration
+
+For the same reason you'd dual-write metrics, you can dual-write traces. `dd-trace` agents ship to the Datadog Agent on `8126`, and you can run the OTel Collector on a different port and have applications send to both via env-var per pod / deployment slice. Once dashboards and on-call workflows work against OpenObserve traces, drop the Datadog leg.
+
+## Next Steps
+
+- [Migrating Logs](logs.md): migrate your log sources next
+- [OpenObserve Traces Documentation](https://openobserve.ai/docs/user-guide/traces/): exploring traces, filtering spans, and configuring trace settings in the UI
+
+
+[Back to Overview](index.md) | Previous: [Migrating Metrics](metrics.md) | Next: [Migrating Logs](logs.md)

--- a/docs/migration/migrate-from-datadog-to-openobserve/traces.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/traces.md
@@ -76,15 +76,22 @@ DD_TRACE_AGENT_PORT=8126
 
 The application code does not change. Only the env vars do. Restart the service to pick up the new agent endpoint.
 
-**Option B: Keep the Datadog Agent, repoint it.** If many services point at the local Datadog Agent and changing env vars across the fleet is awkward, repoint the Agent's APM forwarder at the local Collector:
+**Option B: Keep the Datadog Agent, repoint it.** If many services point at the local Datadog Agent and changing env vars across the fleet is awkward, repoint the Agent's APM forwarder at the local Collector. Because the Agent is already bound to `:8126`, the Collector's `datadog` receiver has to listen on a different port. Bind it to `:18126`:
+
+```yaml
+# OTel Collector
+receivers:
+  datadog:
+    endpoint: "0.0.0.0:18126"
+```
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml
 apm_config:
-  apm_dd_url: http://localhost:8126
+  apm_dd_url: http://localhost:18126
 ```
 
-In this setup the Collector runs on a different port than the Agent (e.g. Agent on `8126`, Collector on `18126`) and the Agent forwards to the Collector, which forwards to OpenObserve.
+The Agent receives `dd-trace` spans on `8126` as before and forwards them to the Collector on `18126`, which translates and ships to OpenObserve.
 
 !!! tip "Send all signals through one Collector"
     If you're also migrating metrics and logs, you can consolidate everything through a single OTel Collector with one `otlphttp/openobserve` exporter: one endpoint, one auth header, all signals.
@@ -96,7 +103,7 @@ If your services already use OpenTelemetry SDKs and ship OTLP, the migration is 
 
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-openobserve-host>
-OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64-creds>,stream-name=default"
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64-creds>"
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 ```
 

--- a/docs/migration/migrate-from-datadog-to-openobserve/traces.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/traces.md
@@ -181,4 +181,7 @@ For the same reason you'd dual-write metrics, you can dual-write traces. `dd-tra
 - [OpenObserve Traces Documentation](https://openobserve.ai/docs/user-guide/traces/): exploring traces, filtering spans, and configuring trace settings in the UI
 
 
-[Back to Overview](index.md) | Previous: [Migrating Metrics](metrics.md) | Next: [Migrating Logs](logs.md)
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)


### PR DESCRIPTION
## Summary

- New section under `docs/migration/migrate-from-datadog-to-openobserve/` (6 pages: overview, architecture & terminology, metrics, traces, logs, dashboards & monitors) covering a full Datadog to OpenObserve migration path
- The recommended pattern is an OpenTelemetry Collector in front of OpenObserve translating Datadog wire formats (DogStatsD, Datadog APM intake, Datadog Agent series API) into OTLP, so application code does not change
- Per-signal Collector configs, Datadog Agent repointing snippets, port assignments, and a Datadog to OTel metric-type mapping
- Includes a query-translation reference for moving Datadog dashboards and monitors to PromQL / SQL, plus a section on exporting the existing Datadog dashboards and monitors via the public API before recreating them in OpenObserve
- Registered in the migration nav via `docs/migration/.pages`

## Notes for reviewers

- This PR is **scoped to the migration content only**. The "OpenObserve vs Datadog" comparison page and the per-page Copy / View / ChatGPT / Claude dropdown ship separately in `comparison-and-datadog-pages`. That comparison page deep-links into this folder, so once that PR merges its links will resolve only after this PR also merges.
- `mkdocs.yml` is unchanged on this branch. The `llmstxt` plugin's `Migration: migration/*.md` glob is non-recursive, so until that fix lands (it's in the comparison branch) the new pages here will not appear in the generated `llms.txt`. Order of merge matters: comparison branch first.
- Per-host pricing, custom-metric, and span-based billing claims about Datadog reflect their public pricing pages as of this PR's authoring; please flag any that have drifted.
- The `datadog` receiver in OTel Collector contrib accepts Agent metric series + APM trace intake on the same HTTP listener. It does **not** accept the Agent's TCP-framed logs forwarder protocol; that's called out explicitly in `logs.md` and `metrics.md` (logs are routed via Fluent Bit / Vector / OpenObserve Collector instead).

## Test plan

- [ ] Run `mkdocs serve` locally; confirm all six pages render without build errors or broken cross-links
- [ ] Walk the metrics page: stand up an OTel Collector with the `statsd` receiver, send a test DogStatsD packet (`echo "test.metric:42|c|#k:v" | nc -w 1 -u localhost 8125`), confirm the metric appears in OpenObserve
- [ ] Walk the traces page Option B (Agent on `:8126`, Collector on `:18126`): point a `dd-trace`-instrumented app at the Agent, confirm spans arrive in OpenObserve with `service.name` populated
- [ ] Walk the logs page: deploy Fluent Bit with the `http` output pointed at OpenObserve, confirm a stream is created and JSON fields parse as columns
- [ ] Open the dashboards & monitors page; confirm the Datadog to PromQL / SQL translation tables render correctly (the row with the escaped `\|` was previously breaking the table parse)
- [ ] Confirm the OpenObserve Cloud / Self-Hosted tabs in `index.md` render as Material tabs, not blockquotes