### PR TITLE
docs: add ZO_CORS_ALLOWED_ORIGINS environment variable

### DIFF
--- a/docs/administration/configuration/environment-variables.md
+++ b/docs/administration/configuration/environment-variables.md
@@ -48,6 +48,7 @@ In high-load environments, alerts or reports might run large, resource-intensive
 | ZO_GRPC_CONNECT_TIMEOUT | 5 | Timeout in seconds for connecting to the gRPC server. |
 | ZO_ROUTE_TIMEOUT | 600 | Timeout value for the router node in seconds. |
 | ZO_ROUTE_MAX_CONNECTIONS | 1024 | Sets the maximum number of simultaneous connections per type of scheme for the Router node role. |
+| ZO_CORS_ALLOWED_ORIGINS | | Comma-separated list of origins allowed to make cross-origin (CORS) requests to the OpenObserve server. When empty, all origins are allowed. Example: `https://app.example.com,https://admin.example.com`. |
 
 
 ## Data Storage and Directories


### PR DESCRIPTION
## Summary
Documents the `ZO_CORS_ALLOWED_ORIGINS` environment variable in the **Network and Communication** section of the environment variables reference.

This variable controls which origins are allowed to make cross-origin (CORS) requests to the OpenObserve server. When empty, all origins are allowed; otherwise it accepts a comma-separated list of origins.

## Changes
- Added `ZO_CORS_ALLOWED_ORIGINS` row to the Network and Communication table in `docs/administration/configuration/environment-variables.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)