### PR TITLE
docs: add ZO_HTTP_REAL_IP_SOURCE environment variable

### DIFF
--- a/docs/administration/configuration/environment-variables.md
+++ b/docs/administration/configuration/environment-variables.md
@@ -40,6 +40,7 @@ In high-load environments, alerts or reports might run large, resource-intensive
 | ZO_HTTP_IPV6_ENABLED | false | Set this to true to enable IPv6 support for HTTP. |
 | ZO_HTTP_WORKER_NUM | 0 | Number of threads for HTTP services. Default is equal to the number of CPU cores (cpu_num). |
 | ZO_HTTP_WORKER_MAX_BLOCKING | 1024 | Maximum number of blocking connections allowed per HTTP thread. |
+| ZO_HTTP_REAL_IP_SOURCE | XEnvoyExternalAddress,XRealIp,RightmostXForwardedFor | Comma-separated list of sources used to resolve the real client IP when OpenObserve runs behind a proxy or load balancer. Sources are tried in order and the first match wins, with the TCP peer always used as the final fallback. Supported values: `XEnvoyExternalAddress` (Envoy/Istio), `XRealIp` (nginx, Traefik), `RightmostXForwardedFor` (nginx/HAProxy/AWS ALB/GCP LB), `RightmostForwarded` (RFC 7239), `CfConnectingIp` (Cloudflare), `TrueClientIp` (Akamai/Cloudflare Enterprise), `FlyClientIp` (Fly.io), `CloudFrontViewerAddress` (AWS CloudFront), and `ConnectInfo` (TCP peer). Only list sources whose proxy actually sits in front of this server, since clients can spoof any trusted header. |
 | ZO_GRPC_PORT | 5081 | Port number on which the OpenObserve server listens for gRPC requests. |
 | ZO_GRPC_ADDR | | IP address on which the OpenObserve server listens for gRPC requests. |
 | ZO_GRPC_ORG_HEADER_KEY | organization | Header key for sending organization information in traces using OTLP over gRPC. |


### PR DESCRIPTION
## Summary

Documents the `ZO_HTTP_REAL_IP_SOURCE` environment variable in the **Network and Communication** section of the environment variables reference.

This variable controls how OpenObserve resolves the real client IP when running behind a proxy or load balancer. Details (default value, supported sources, and the spoofing caveat) were taken directly from the OpenObserve source (`config.rs` env_config and the `real_ip.rs` resolver).

- **Default:** `XEnvoyExternalAddress,XRealIp,RightmostXForwardedFor`
- Sources are tried in order, first match wins, with the TCP peer as the final fallback.
- Lists all supported values (Envoy/Istio, nginx, AWS ALB/CloudFront, Cloudflare, Fly.io, etc.) and the note that only trusted upstream proxies should be listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)