### PR TITLE
docs: add LLM Evaluations and Model Pricing pages

### DIFF
--- a/docs/integration/ai/llm-evaluations.md
+++ b/docs/integration/ai/llm-evaluations.md
@@ -1,0 +1,146 @@
+# LLM Evaluations
+
+LLM Evaluations let you automatically score the quality of your LLM traces using an LLM-as-judge pipeline, with results surfaced per trace inside OpenObserve.
+
+> **Enterprise feature.** LLM Evaluations and Eval Templates are available in OpenObserve Enterprise.
+
+## Overview
+
+LLM Evaluations build on [LLM Observability](llm-applications.md). Once your application is exporting LLM traces to OpenObserve, an evaluation pipeline can grade each LLM response against criteria such as correctness, relevance, or safety. A second LLM acts as the judge, so you get continuous, automated quality scoring without manual review or a separate evaluation tool.
+
+This is for teams running LLM-powered applications in production who need to monitor not just latency, tokens, and cost, but also the quality of the responses their models produce. Evaluations run server-side as part of a traces pipeline, so they apply to live traffic as it arrives.
+
+At a high level, the feature has three parts: an **LLM-evaluation pipeline node** that runs the judge on incoming traces, **Eval Templates** that define what the judge evaluates and how, and an **Evaluations** view in the trace detail page where you read the results.
+
+## How evaluations work
+
+An LLM evaluation runs as a node inside a pipeline attached to a traces stream:
+
+1. You add an LLM-evaluation node to a pipeline whose source is a traces stream that contains LLM spans.
+2. As traces arrive, the node identifies LLM spans, optionally samples them, and sends them to the LLM judge.
+3. The judge scores each trace using an Eval Template. OpenObserve either uses a template you select by name or auto-resolves one by `response_type`.
+4. The evaluation results are written to a separate output stream named `<stream>_evaluations`. For example, evaluating a stream called `default` produces a `default_evaluations` stream.
+5. Per-trace results appear in an **Evaluations** tab in the trace detail view. This tab is shown only for LLM traces that have associated evaluation records.
+
+Only LLM spans are evaluated. The pipeline pre-filters incoming spans and keeps LLM spans, tool spans, and root spans, dropping pure infrastructure spans (such as HTTP, database, or cache spans) that would never be evaluated.
+
+## Setting up an evaluation pipeline
+
+### Prerequisites
+
+- LLM traces are being ingested into a traces stream. See [LLM Observability](llm-applications.md) to instrument your application.
+- An OpenObserve Enterprise instance with the LLM judge configured.
+- Optionally, an Eval Template created in advance (see [Eval Templates](#eval-templates)). If you do not select one, OpenObserve auto-resolves a template by `response_type`.
+
+### Add an LLM-evaluation node
+
+1. Create or open a pipeline whose source is the traces stream that contains your LLM spans.
+2. Add an **LLM Evaluation** node to the pipeline.
+3. Configure the node parameters described below.
+4. Save the pipeline. The node begins evaluating traces as new data is ingested.
+
+### Node parameters
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| **`enable_llm_judge`** | Turns LLM-as-judge evaluation on for the node. | `true` |
+| **`sampling_rate`** | Fraction of LLM traces to evaluate, from `0.0` to `1.0`. Use a lower rate to control cost on high-volume streams. A value of `0.0` disables sampling. | `0.01` |
+| **`llm_span_identifier`** | Span field used to detect LLM spans. Only spans that contain this field with a non-empty value are treated as LLM spans. | `llm_input` |
+| **`eval_template`** | Optional template to use for evaluation, selected by name. When set, it overrides auto-resolution by `response_type`. Leave empty to auto-resolve. | None |
+
+> **Tip**: Start with a low `sampling_rate` on busy production streams to validate your template and judge configuration before scaling up to evaluate every trace.
+
+When you update a pipeline that contains an LLM-evaluation node, OpenObserve refreshes the running evaluation so changes such as a new `eval_template` take effect on the next batch of ingested traces.
+
+## Eval Templates
+
+An Eval Template defines what the LLM judge evaluates and how it scores a response. Templates are managed from the enterprise **Eval Templates** tab, located alongside **Functions** and **Enrichment Tables**.
+
+### Template fields
+
+Each template specifies:
+
+- **`response_type`**: The expected shape of the evaluation result, for example a numeric score in the range `0.0` to `1.0`. The `response_type` is also used to auto-resolve a template for a pipeline node when no template is explicitly selected.
+- **`name`**: A human-readable name used to select the template from a pipeline node.
+- **`description`**: An optional summary of what the template evaluates.
+- **`content`**: The prompt and instructions the judge uses to perform the evaluation.
+- **`dimensions`**: The criteria the trace is evaluated against. At least one dimension is required.
+
+### Versioning
+
+Templates are versioned. Editing a template creates a new version and preserves the original creation time, so you can iterate on a template without losing earlier definitions. New templates start at version `1`.
+
+### Per-template statistics
+
+Each template surfaces usage statistics so you can see how it is performing:
+
+- **Total Evaluations**: The number of evaluations the template has produced.
+- **Average Quality Score**: The mean quality score across those evaluations, shown as a percentage.
+
+A template that has been created but not yet used reports zero evaluations and a zero average quality score.
+
+### Managing templates through the API
+
+Eval Templates can also be managed through a CRUD REST API scoped to an organization:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/{org_id}/eval_templates` | List all templates for the organization. |
+| `POST` | `/api/{org_id}/eval_templates` | Create a new template. |
+| `GET` | `/api/{org_id}/eval_templates/{template_id}` | Retrieve a single template. |
+| `PUT` | `/api/{org_id}/eval_templates/{template_id}` | Update a template, creating a new version. |
+| `DELETE` | `/api/{org_id}/eval_templates/{template_id}` | Delete a template. |
+| `GET` | `/api/{org_id}/eval_templates/{template_id}/stats` | Get usage statistics for a template. |
+
+A template that is referenced by a pipeline cannot be deleted. The delete request returns a conflict response listing the pipelines that still use it; update or remove those pipelines first.
+
+## Viewing results
+
+Evaluation results are stored in the `<stream>_evaluations` output stream and surfaced per trace in the UI:
+
+1. Navigate to **Traces** in the left sidebar.
+2. Open an LLM trace that has been evaluated.
+3. Select the **Evaluations** tab in the trace detail view to see the scores and dimensions for that trace.
+
+The **Evaluations** tab appears only for LLM traces that have associated evaluation records. Traces without evaluations, or non-LLM traces, do not show the tab.
+
+You can also query the `<stream>_evaluations` stream directly from **Logs** or build dashboards on it to track quality trends over time.
+
+## Best practices
+
+- Confirm LLM traces are flowing and visible under **Traces** before adding an evaluation node, since the judge only evaluates LLM spans.
+- Begin with a low `sampling_rate` to validate your template and judge, then increase it once results look correct.
+- Define clear, focused `dimensions` in each template so scores are easy to interpret and act on.
+- Use template versioning to refine evaluation prompts over time instead of recreating templates.
+- Remove or update pipelines that reference a template before attempting to delete it.
+
+## Troubleshooting
+
+### The Evaluations tab does not appear on a trace
+
+**Problem**: You open a trace but there is no **Evaluations** tab.
+
+**Solution**:
+
+1. Confirm the trace is an LLM trace. Non-LLM traces never show the tab.
+2. Verify the evaluation pipeline is attached to the correct traces stream and is enabled.
+3. Check that `sampling_rate` is not `0.0`, since a zero sampling rate means no traces are evaluated.
+4. Confirm the `llm_span_identifier` matches a field present on your LLM spans, so the spans are recognized as LLM spans.
+5. Look for records in the `<stream>_evaluations` output stream. If none exist, the pipeline has not produced evaluations yet.
+
+### A template cannot be deleted
+
+**Problem**: Deleting a template returns a conflict error.
+
+**Solution**:
+
+1. Note the pipeline names listed in the error message.
+2. Update those pipelines to use a different template, or remove their LLM-evaluation nodes.
+3. Retry the delete once no pipeline references the template.
+
+> **Note**: Evaluation cost scales with the number of traces the judge processes. Use `sampling_rate` to balance coverage against the cost of running the judge model. To track the cost of the underlying LLM calls themselves, see [Model Pricing](model-pricing.md).
+
+## Read more
+
+- [LLM Observability with OpenObserve](llm-applications.md)
+- [Model Pricing](model-pricing.md)

--- a/docs/integration/ai/model-pricing.md
+++ b/docs/integration/ai/model-pricing.md
@@ -1,0 +1,145 @@
+# Model Pricing
+
+Model Pricing lets you define per-organization LLM pricing so OpenObserve can compute token costs directly on your traces. With it enabled, every LLM span is enriched with cost fields derived from the model name and token usage.
+
+## Overview
+
+When you ingest LLM traces, each span carries token usage and a model name. Model Pricing maps that model name to a pricing definition and calculates the cost of the call, writing the result into the cost fields stored on the span.
+
+This feature is for teams running LLM observability who want accurate, up-to-date cost attribution per model, per organization. You can rely on the built-in pricing catalog that OpenObserve maintains, or define your own pricing to match negotiated rates, custom models, or providers not covered by the catalog.
+
+OpenObserve populates the following cost fields on each LLM span when Model Pricing is enabled:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `llm_usage_cost_input` | Float64 | Cost of input (prompt) tokens |
+| `llm_usage_cost_output` | Float64 | Cost of output (completion) tokens |
+| `llm_usage_cost_total` | Float64 | Total cost of the LLM call |
+
+> **Note**: When Model Pricing is disabled, OpenObserve falls back to a built-in, hardcoded pricing set. The DB pricing lookup, the periodic sync job, and the **Model Pricing** UI tab are all gated behind the enable flag.
+
+## Key features
+
+### Built-in pricing catalog
+
+OpenObserve ships with a built-in catalog of model pricing that is synced periodically from an upstream source. Built-in definitions are read-only.
+
+- View the full built-in catalog without any setup
+- Clone a built-in definition to customize it for your organization
+- Refresh the catalog on demand from the upstream source
+
+### Custom pricing definitions
+
+Define your own pricing per organization. User-defined pricing takes priority over built-in pricing when both match a model.
+
+- Match incoming model names with a regex pattern (for example, `(?i)^gpt-4o`)
+- Define one or more pricing tiers with per-token rates keyed by usage type (`input`, `output`, and others)
+- Optionally set a validity start time so historical traces keep their original cost calculations
+
+### Test model match
+
+Before relying on a definition, test how a given model name resolves against your configured pricing, and preview the computed cost for a sample token count.
+
+## Getting started
+
+### Prerequisites
+
+- A self-hosted OpenObserve instance where you can set environment variables
+- LLM traces being ingested (see [LLM Observability](llm-applications.md))
+
+### Enabling Model Pricing
+
+Model Pricing is controlled by environment variables. The feature is disabled by default.
+
+Set the following variable to enable it:
+
+```shell
+ZO_MODEL_PRICING_ENABLED=true
+```
+
+Enabling this flag turns on three behaviors: it shows the **Model Pricing** tab in the UI, starts the background sync job that pulls built-in pricing, and enables the database pricing lookup during ingestion. When the flag is `false`, OpenObserve skips the database lookup and uses its hardcoded built-in pricing instead.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `ZO_MODEL_PRICING_ENABLED` | Enable user-defined model pricing. When `true`, uses database pricing definitions and syncs from the source URL. When `false`, falls back to hardcoded built-in pricing only. | `false` |
+| `ZO_MODEL_PRICING_SOURCE_URL` | URL of the built-in LLM model pricing JSON source. | `https://raw.githubusercontent.com/openobserve/sdr_patterns/refs/heads/main/llm_pricing.json` |
+| `ZO_MODEL_PRICING_SYNC_INTERVAL_SECS` | Interval in seconds for syncing built-in model pricing from the source URL. | `21600` (6 hours) |
+
+> **Tip**: Restart your OpenObserve instance after changing these variables so the configuration takes effect.
+
+## Managing pricing in the UI
+
+After enabling the feature, manage pricing from the **Settings > Model Pricing** tab. The tab is hidden unless `ZO_MODEL_PRICING_ENABLED` is `true`.
+
+From this tab you can:
+
+- **View built-in pricing**: Browse the read-only built-in catalog and search by model name.
+- **Refresh built-in pricing**: Trigger an on-demand sync from the configured source URL.
+- **Import**: Bring in pricing definitions to seed your organization's pricing.
+- **Edit**: Create and edit custom pricing definitions in the editor, including the match pattern and pricing tiers.
+- **List**: Review all pricing definitions for your organization.
+- **Test model match**: Enter a model name to see which definition it matches and preview the computed cost.
+
+### How matching works
+
+For each LLM span, OpenObserve evaluates pricing definitions by their regex `match_pattern` against the model name. User-defined definitions take priority over built-in ones. Within a matched definition, pricing tiers are evaluated in order: tiers with a condition are checked first, and the first tier whose condition is met wins. A tier without a condition acts as the default fallback.
+
+Per-token rates are keyed by usage type, for example `input` and `output`, and are expressed as the price for a single token (for example, `0.000003` equals $3 per 1M tokens).
+
+## API reference
+
+All endpoints are scoped to an organization (`{org_id}`) and use the `model_pricing` resource for authorization.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/{org_id}/llm/models` | List pricing definitions for the organization |
+| `POST` | `/api/{org_id}/llm/models` | Create a pricing definition |
+| `GET` | `/api/{org_id}/llm/models/{model_id}` | Get a pricing definition by ID |
+| `PUT` | `/api/{org_id}/llm/models/{model_id}` | Update a pricing definition |
+| `DELETE` | `/api/{org_id}/llm/models/{model_id}` | Delete a pricing definition |
+| `GET` | `/api/{org_id}/llm/models/built-in` | Get the read-only built-in pricing catalog |
+| `POST` | `/api/{org_id}/llm/models/refresh-built-in` | Refresh built-in pricing from the source URL |
+| `POST` | `/api/{org_id}/llm/models/test` | Test how a model name matches and preview its cost |
+
+A pricing definition includes a display `name`, a regex `match_pattern` used to match incoming model names, an `enabled` flag, and a list of pricing `tiers`. The test endpoint accepts a `model_name`, an optional `usage` map of token counts (for example, `{"input": 1000, "output": 500}`), and an optional `timestamp` so only definitions valid at that time are considered.
+
+> **Note**: Built-in definitions are read-only. They cannot be created, edited, or deleted directly. Use the refresh endpoint to sync them from the upstream source, and clone a built-in definition if you need to customize it.
+
+## Best practices
+
+- Keep Model Pricing disabled until you are ingesting LLM traces and want cost attribution; the built-in hardcoded pricing still applies as a fallback.
+- Use anchored, case-insensitive regex patterns (for example, `(?i)^gpt-4o`) to avoid unintended matches across model families.
+- Set a validity start time on definitions when rates change, so historical traces retain their original computed costs.
+- Use the test model match tool to confirm a new definition resolves as expected before depending on its cost output.
+
+## Troubleshooting
+
+### Cost fields are empty on LLM traces
+
+**Problem**: Traces show token usage but `llm_usage_cost_*` fields are zero or missing.
+
+**Solution**:
+1. Confirm `ZO_MODEL_PRICING_ENABLED=true` and that the instance was restarted.
+2. Verify the model name on the span matches a definition's `match_pattern` using the test model match tool.
+3. Check that the matched tier defines a per-token price for the usage keys present on the span (for example, `input` and `output`).
+
+### The Model Pricing tab is not visible
+
+**Problem**: The **Model Pricing** tab does not appear under **Settings**.
+
+**Solution**:
+1. Ensure `ZO_MODEL_PRICING_ENABLED=true`; the tab is hidden when the flag is `false`.
+2. Restart the instance so the updated configuration is applied.
+
+### Built-in catalog is out of date
+
+**Problem**: Built-in pricing does not reflect the latest upstream values.
+
+**Solution**:
+1. Trigger a refresh from the **Model Pricing** tab, or call `POST /api/{org_id}/llm/models/refresh-built-in`.
+2. Confirm `ZO_MODEL_PRICING_SOURCE_URL` points to a reachable source.
+3. Review `ZO_MODEL_PRICING_SYNC_INTERVAL_SECS` if you expect more frequent automatic syncs.
+
+## Related
+
+For instrumenting and shipping LLM traces to OpenObserve, see [LLM Observability](llm-applications.md). The cost fields documented there (`llm_usage_cost_input`, `llm_usage_cost_output`, `llm_usage_cost_total`) are populated by the Model Pricing feature described on this page.


### PR DESCRIPTION
- Add LLM Evaluations page (eval pipeline node, eval templates, results in trace detail)
- Add Model Pricing page (per-org LLM model pricing, config, REST API)