### PR TITLE
docs: add sidebar nav entries for new documentation pages

### DIFF
--- a/docs/administration/maintenance/operator-guide/.pages
+++ b/docs/administration/maintenance/operator-guide/.pages
@@ -8,3 +8,4 @@ nav:
     - Etcd restore: etcd-restore.md
     - Nginx proxy: nginx-proxy.md
     - Configuration Management: config-management.md
+    - CLI Commands: cli-commands.md

--- a/docs/integration/ai/.pages
+++ b/docs/integration/ai/.pages
@@ -1,5 +1,6 @@
 nav:
     - LLM Applications: llm-applications.md
+    - LLM Evaluations: llm-evaluations.md
     - Claude Code Tracing: claude-code-tracing.md
     - Frameworks: frameworks
     - Model Providers: providers
@@ -7,3 +8,5 @@ nav:
     - No-Code Agent Builders: no-code
     - Tools: tools
     - MCP: mcp
+    - Model Pricing: model-pricing.md
+    - Custom AI Toolsets: custom-toolsets.md

--- a/docs/integration/cloud/aws/.pages
+++ b/docs/integration/cloud/aws/.pages
@@ -1,6 +1,7 @@
 nav:
 
     - AWS Integrations Overview: index.md
+    - Complete AWS Integration (Quick Setup): quick-setup.md
     - Amazon EC2 : ec2.md
     - Application Load Balancer(ALB) : alb.md
     - Amazon Virtual Private Cloud : vpc-flow.md

--- a/docs/integration/cloud/azure/.pages
+++ b/docs/integration/cloud/azure/.pages
@@ -1,0 +1,3 @@
+nav:
+    - Azure Integrations Overview: index.md
+    - Azure Activity Logs: activity-logs.md

--- a/docs/reference/api/.pages
+++ b/docs/reference/api/.pages
@@ -7,3 +7,5 @@ nav:
     - Users: user
     - Cluster: cluster
     - Traces: traces
+    - Dashboards: dashboard
+    - Reports: report

--- a/docs/user-guide/account-administration/management/.pages
+++ b/docs/user-guide/account-administration/management/.pages
@@ -11,4 +11,5 @@ nav:
     - Nodes in OpenObserve: nodes.md
     - SSO Domain Restrictions: sso-domain-restrictions.md 
     - Sensitive Data Redaction: sensitive-data-redaction.md
+    - Correlation Settings: correlation-settings.md
     - License Management: lincense.md

--- a/docs/user-guide/analytics/dashboards/config/.pages
+++ b/docs/user-guide/analytics/dashboards/config/.pages
@@ -3,4 +3,6 @@ nav:
 - Config Overview: index.md
 - Trellis Layout: trellis-layout.md
 - Show Symbol: show-symbol.md
+- Show Field as JSON: show-field-as-json.md
+- Pivot Table: pivot-table.md
 

--- a/docs/user-guide/data-exploration/logs/.pages
+++ b/docs/user-guide/data-exploration/logs/.pages
@@ -5,5 +5,6 @@ nav:
     - Search Around: search-around.md
     - Insights: insights.md
     - Quick Mode and Interesting Fields: quickmode.md
+    - Log Patterns: log-patterns.md
     - Explain and Analyze Query: explain-analyze-query.md
 

--- a/docs/user-guide/data-exploration/traces/.pages
+++ b/docs/user-guide/data-exploration/traces/.pages
@@ -3,3 +3,4 @@ nav:
 - Traces Overview: index.md  
 - Traces in OpenObserve: traces.md
 - Service Graph: service-graph.md
+- Service Catalog: service-catalog.md


### PR DESCRIPTION
## Summary

Adds the awesome-pages sidebar nav (`.pages`) entries for the new documentation pages, across:

- operator-guide (CLI Commands)
- integration/ai (LLM Evaluations, Model Pricing, Custom AI Toolsets)
- integration/cloud — aws (Complete AWS Integration) and azure (Azure Integrations Overview, Azure Activity Logs)
- reference/api (Dashboards API, Reports API)
- account-administration/management (Correlation Settings)
- dashboards/config (Pivot Table, Show Field as JSON)
- logs (Log Patterns)
- traces (Service Catalog)

## ⚠️ Merge order
**Merge this PR last**, after the individual new-page PRs have landed. The nav entries reference pages introduced in those PRs (#381, #382 already merged; the rest in their respective PRs/branches), so the docs build only fully resolves once those pages are on `main`. Until then CI may flag missing nav targets — expected.