### PR TITLE
docs(alerts): update alerts pages for Mar-May changes

### DIFF
--- a/docs/user-guide/analytics/alerts/alert-conditions.md
+++ b/docs/user-guide/analytics/alerts/alert-conditions.md
@@ -74,6 +74,13 @@ In measure mode, click **+** next to **Group by** to add one or more fields. Whe
 
 For example, grouping by `hostname` with "Alert if avg of cpu_usage >= 80" evaluates CPU usage per host and alerts if any individual host exceeds the threshold.
 
+### Having groups
+
+**Having groups** sets the minimum number of groups that must satisfy the condition for the alert to trigger. For example, with a value of 3, the alert fires only when at least 3 group-by combinations meet the condition.
+
+!!! note
+    When aggregation or group-by is enabled, the right-hand **Preview** panel renders a multi-series chart. When there are three or more group-by fields, the preview is shown as a table instead.
+
 ---
 
 ## Filter conditions

--- a/docs/user-guide/analytics/alerts/alert-history.md
+++ b/docs/user-guide/analytics/alerts/alert-history.md
@@ -33,6 +33,7 @@ Each row represents one alert evaluation.
     - **Evaluation Time**: The time taken to complete the alert’s search query.
     - **Silenced**: Indicates whether the alert was silenced.
     - **Source Node**: The node that processed the alert. Useful for debugging distributed environments.
+    - **Error**: The error message captured when the evaluation or delivery failed. Shown for records with a `failed` status.
 
 - **Status codes**:
     
@@ -41,7 +42,10 @@ Each row represents one alert evaluation.
     - **condition_not_met**: The configured alert condition was not satisfied for that time range.
     - **skipped**: The scheduled evaluation window was missed due to a delay, and the system evaluated the next aligned window.
 
-- **Alert Details** drawer: Opens when the user clicks an alert in the Alerts list. The drawer displays the alert condition, description, and evaluation history.  
+- **Alert Details** drawer: Opens when the user clicks an alert in the Alerts list. The drawer displays the alert condition, description, and evaluation history. It includes a date-time picker (relative or absolute, defaulting to the last 15 minutes) to filter the evaluation history, replacing the previous fixed window and manual refresh.
+
+!!! note
+    The selected time range is limited by the `max_query_range` setting on the organization's `triggers` stream; ranges larger than this are automatically shortened to the most recent allowed window.
 
 ![Alert details drawer](../../../images/alert-details-drawer.png)
 ## How to debug a failed alert

--- a/docs/user-guide/analytics/alerts/anomaly-detection.md
+++ b/docs/user-guide/analytics/alerts/anomaly-detection.md
@@ -11,13 +11,13 @@ Traditional threshold-based alerts require you to define exact conditions for ev
 Configure a detection rule on any logs, metrics, or traces stream. OpenObserve trains a model on your historical data, then runs periodic detection to surface anomalies and optionally send notifications.
 
 !!! note
-    Anomaly Detection is available in OpenObserve Enterprise and Cloud editions.
+    Anomaly Detection is available in OpenObserve Enterprise (self-hosted) edition.
 
 ## Getting started
 
 **Prerequisites:**
 
-- OpenObserve Enterprise or Cloud edition
+- OpenObserve Enterprise edition (not available in Cloud)
 - At least one data stream with historical data for model training
 
 **To access anomaly detection:**
@@ -26,11 +26,13 @@ Configure a detection rule on any logs, metrics, or traces stream. OpenObserve t
 2. Click the **Anomalies** tab in the filter bar
 3. The list displays all anomaly detection rules for the current organization
 
+The alerts list can be filtered by type using the tabs: **All / Scheduled / Realtime / Anomalies**.
+
 ## Key features
 
 ### Model training and retraining
 
-OpenObserve trains an isolation forest model on historical data from your selected stream. You control the training window (minimum 1 day) and the system automatically detects seasonality patterns:
+OpenObserve trains a Random Cut Forest (RCF) model on historical data from your selected stream. You control the training window (minimum 1 day) and the system automatically detects seasonality patterns:
 
 - **Less than 7 days**: hour-of-day seasonality
 - **7 days or more**: hour-of-day + day-of-week seasonality
@@ -47,7 +49,7 @@ The **Detection Config** tab provides a full configuration wizard:
 - **Check every** — how often the detection job runs
 - **Look back window** — how far back each detection run queries
 
-![Detection Config tab showing query builder, scheduling parameters, sensitivity chart with threshold slider, and configuration summary](../../../images/anomaly-detection-edit-config-chart.png)
+![Detection Config tab showing query builder, scheduling parameters, sensitivity chart with Anomaly Score Range slider, and configuration summary](../../../images/anomaly-detection-edit-config-chart.png)
 
 In **SQL** mode, the query editor replaces the visual builder. Your query must return exactly two columns: `time_bucket` and `value`.
 
@@ -55,9 +57,9 @@ In **SQL** mode, the query editor replaces the visual builder. Your query must r
 
 ### Sensitivity tuning
 
-The sensitivity section displays a time series preview of your historical data with adjustable threshold lines. Use the vertical range slider (0–100) to set the anomaly score range. Data points with scores outside this range trigger alerts.
+The sensitivity section displays a time series preview of your historical data. Use the **Anomaly Score Range** control, a chart with a dual-handle slider (0–100), to tune sensitivity. Points with anomaly scores outside the selected range do not trigger alerts. Narrow the range to flag only the most extreme outliers; widen it to flag more points.
 
-Click **Load data** to preview the time series and visually adjust your thresholds.
+Click **Load Data** to preview the time series and visually adjust the range. The **Load Data** button is only available after the rule is first saved (its tooltip reads "Available after saving").
 
 ### Alerting and notifications
 
@@ -98,7 +100,7 @@ Each anomaly detection rule progresses through a status lifecycle:
 
 5. Set the **Training Window** (days of historical data) and **Retrain Every** interval.
 
-6. Click **Load data** to preview the time series, then adjust the **Sensitivity** slider to set your anomaly score range.
+6. After saving the rule, click **Load Data** to preview the time series, then use the **Anomaly Score Range** slider (0–100) to tune which anomaly scores trigger alerts. (The **Load Data** button is only available after the rule is first saved.)
 
 7. Switch to the **Alerting** tab to enable notifications and select destinations.
 
@@ -118,4 +120,5 @@ From the **Anomalies** list, use the three-dot action menu on each row:
 - **Stop Training** — cancel an in-progress training job
 - **Retry** — retry training after a failure (the error message is shown in the dialog)
 - **Edit** — modify the detection configuration, schedule, or alerting settings
+- **Clone**: create a copy of the rule; the clone starts untrained with counters reset
 - **Delete** — permanently remove the rule and its trained model

--- a/docs/user-guide/analytics/alerts/import-export-alerts.md
+++ b/docs/user-guide/analytics/alerts/import-export-alerts.md
@@ -55,6 +55,9 @@ Alert export allows users to download an alert configuration as a JSON file. Thi
 The alert configuration is downloaded as a JSON file.  
 This JSON file can later be imported into another OpenObserve instance, making it easy to transfer or restore alerts.
 
+!!! note
+    The exported alert JSON intentionally omits the alert `id`. On import, any `id` present in the JSON is ignored, so the alert is always created as a new alert in the target instance and is never overwritten by ID. This is why re-importing an alert into the same organization prompts a name conflict (asking you to enter a new alert name) rather than updating the existing alert.
+
 ## Use Cases
 
 - If you manage separate instances, such as development, test, and production environments, you can configure alerts in one environment and import them into others to replicate the monitoring setup.   

--- a/docs/user-guide/analytics/alerts/index.md
+++ b/docs/user-guide/analytics/alerts/index.md
@@ -1,9 +1,10 @@
 ---
 title: Alerts in OpenObserve | OpenObserve
 description: >-
-  Learn how alerting works in OpenObserve. Supports scheduled, real-time, and
-  anomaly detection alerts with a natural language condition builder, SQL mode,
-  live preview, and flexible notification destinations.
+  Learn how alerting works in OpenObserve. Supports scheduled and real-time
+  alerts, plus anomaly detection alerts on Enterprise self-hosted, with a
+  natural language condition builder, SQL mode, live preview, and flexible
+  notification destinations.
 ---
 # Alerts
 
@@ -17,7 +18,7 @@ OpenObserve supports three types of alerts:
 
 - **Scheduled alerts**: Run at fixed intervals to evaluate aggregated or historical data. Use for routine monitoring and trend analysis. For example, every 10 minutes, the alert evaluates your data and checks if the average response time exceeds 500ms. If the condition is met, the alert sends a notification.
 - **Real-time alerts**: Monitor data continuously and trigger instantly when conditions are met. Use for critical events requiring instant action. For example, when a specific error pattern appears in your logs, the alert sends a notification within seconds.
-- **Anomaly detection** *(Enterprise and Cloud only)*: Use machine learning to detect unusual patterns in your data without manually setting thresholds. See [Anomaly Detection](anomaly-detection.md) for details.
+- **Anomaly detection** *(Enterprise self-hosted only)*: Use machine learning to detect unusual patterns in your data without manually setting thresholds. See [Anomaly Detection](anomaly-detection.md) for details.
 
 ## Alert creation layout
 
@@ -69,7 +70,7 @@ OpenObserve supports three query modes for defining conditions:
 How often the alert evaluation runs. Set the interval in minutes, or switch to a cron expression for precise scheduling. Real-time alerts run continuously and do not have a frequency setting.
 
 !!! note
-    OpenObserve aligns the next run to the nearest upcoming time that is divisible by the frequency, starting from the top of the hour in the configured timezone. For example, if the current time is 23:03 and frequency is 5 minutes, the next run is at 23:05.
+    OpenObserve aligns the next run to the nearest upcoming time that is divisible by the frequency, starting from the top of the hour in the configured timezone. For example, if the current time is 23:03 and frequency is 5 minutes, the next run is at 23:05. When you use a cron expression instead, the next run is the next time that matches the cron schedule in the configured timezone; the alert does not trigger immediately on save or enable.
 
 ### Look back window (period)
 

--- a/docs/user-guide/analytics/alerts/real-time-alerts.md
+++ b/docs/user-guide/analytics/alerts/real-time-alerts.md
@@ -28,7 +28,7 @@ Real-time alerts trigger immediately when matching data is ingested. Unlike sche
 
 Fill in the required fields across the top bar:
 
-- **Alert name**: Enter a descriptive name
+- **Alert name**: Enter a descriptive name. Alert names cannot contain spaces or the characters `: # ? ' " % & /`. Use underscores (`_`) instead.
 - **Folder**: Select a folder to organize the alert, or click **+** to create a new one
 - **Stream Type**: Select **logs**, **metrics**, or **traces**
 - **Stream Name**: Select the data stream to monitor

--- a/docs/user-guide/analytics/alerts/scheduled-alerts.md
+++ b/docs/user-guide/analytics/alerts/scheduled-alerts.md
@@ -28,7 +28,7 @@ Scheduled alerts evaluate your data at regular intervals and trigger when condit
 
 Fill in the required fields across the top bar:
 
-- **Alert name**: Enter a descriptive name (e.g., "High Error Rate - Production")
+- **Alert name**: Enter a descriptive name (e.g., "High Error Rate - Production"). Alert names cannot contain spaces or the characters `: # ? ' " % & /`. Use underscores (`_`) instead.
 - **Folder**: Select a folder to organize the alert, or click **+** to create a new one
 - **Stream Type**: Select **logs**, **metrics**, or **traces**
 - **Stream Name**: Select the data stream to monitor
@@ -53,6 +53,9 @@ Configure the condition:
 ### Step 4: Set the evaluation schedule
 
 - **Check every**: Enter the frequency in minutes (default: 10). You can switch to a cron expression for precise scheduling using the dropdown next to the minutes input.
+
+!!! note
+    When a scheduled alert uses a cron expression, its first (and every subsequent) run is the next time that matches the cron schedule in the configured timezone. It no longer fires immediately when you create, update, or enable the alert. With a non-cron **Check every N minutes** schedule, the alert still starts at the next interval boundary.
 
 ### Step 5: Add filters (optional)
 


### PR DESCRIPTION
## Summary

Documentation updates to the Alerts pages reflecting features merged March-May:

- **anomaly-detection.md** - Random Cut Forest model naming, the Anomaly Score Range slider (and Load Data gating), Enterprise self-hosted availability, Clone action, and Retry Training.
- **alerts/index.md, scheduled-alerts.md, real-time-alerts.md** - anomaly detection availability (Enterprise), cron first-run timing (no immediate trigger on save/enable), and alert-name character restrictions.
- **alert-conditions.md** - Having groups threshold and the multi-series aggregation preview.
- **alert-history.md** - date-time picker, max_query_range clamping, and the error field in run details.
- **import-export-alerts.md** - alert ID is stripped on export and ignored on import (reports created fresh).

All changes verified against the OpenObserve source. Edits to existing pages (no footer changes).