### PR TITLE
docs(iam): update IAM, security & management pages (Mar-May changes)

### DIFF
--- a/docs/user-guide/account-administration/identity-and-access-management/role-based-access-control.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/role-based-access-control.md
@@ -43,6 +43,21 @@ RBAC permissions define what actions users can perform:
 - **Update**: Modify existing resources.
 - **Delete**: Remove resources.
 
+### Per-Stream Resources
+
+!!! info "Availability"
+    These resources are available in Enterprise Edition and Cloud. Not available in Open Source.
+
+In addition to the standard resources, OpenObserve exposes the following per-stream RBAC resources. Each resource is scoped to an individual stream, allowing you to grant or restrict access on a stream-by-stream basis:
+
+- **`logs_pattern`**: Controls access to the logs patterns extract action. Exposes the **Get** and **All** actions only.
+- **`logs_insights`**: Controls access to the logs Insights feature. Exposes the **Get** and **All** actions only.
+- **`logs_cache`**: Controls access to clearing or refreshing the result cache. Exposes the **Delete** and **All** actions only.
+
+**Note:** When the corresponding RBAC toggle is enabled, users need explicit permission on these resources to use Insights, pattern extraction, and cache clearing, respectively. Generic stream search or PUT access is not sufficient.
+
+**Note:** Report permissions are now granted per **report folder** (resource `rfolder`). When editing a custom role, these permissions appear under the report folder hierarchy, allowing you to grant or restrict report access on a folder-by-folder basis.
+
 ## Roles
 
 ### Predefined User Roles
@@ -85,14 +100,15 @@ A service account in OpenObserve is a non-human account used for API access, aut
 2. Click **Add Service Account**.
 3. Enter the **Email, First Name,** and **Last Name**.
 4. Click **Save**.
-5. A **token** is generated for the service account.
+5. A **token** is generated and shown only once in the create response. Copy and store the token securely at creation. It cannot be viewed again later; only a redacted version is shown (the first 4 characters followed by `*`).
 6. After the service account is created, assign the necessary **roles** and **permissions**. This step is required for the service account to make API calls and access specific services in OpenObserve.
 
 ![Service accounts in OpenObserve](../../../images/rbac2-service-account.png)
 
 **Note:**
 
-- You can generate a new token at any time by selecting the appropriate service account from the Service Accounts page and clicking the refresh icon next to it.
+- You can rotate the token at any time by selecting the appropriate service account from the Service Accounts page and clicking the refresh icon next to it. A rotated token is also shown only once, so copy and store it securely.
+- Rotating a service account token requires the **Admin** or **Root** role (or, with RBAC/OpenFGA enabled, explicit permission). Users without sufficient privileges receive a `403` error.
 - Ensure that the assigned roles provide only the minimum required access based on the use case.
 
 ## User Groups
@@ -132,7 +148,11 @@ If the entered email address already belongs to an existing user, the system wil
 ![Create User and Set Password](../../../images/create-user-IAM-password.png)
 
 After you save the changes, the new user gets listed in the **Users** page.<br>
-Use the Actions column to edit and delete the user. 
+Use the Actions column to edit and delete the user. You can also edit an existing user's role assignments from the Actions column.
+
+**Note:** The Users list includes an **Auth** column and a **Roles** column. The **Auth** column shows **Native** for local users and **SSO** for externally provisioned users. The **Roles** column lists the assigned predefined role along with any custom-role chips.
+
+**Note:** For SSO/external users, custom-role assignment is read-only in OpenObserve and must be changed in the source system.
 
 **Note:** In the **Cloud version**, any user can invite new users by entering their email addresses, separated by commas or semicolons, selecting a role, and clicking **Send Invite**. <br>
 ![Invite_users_o2cloud](../../../images/rbac-invite-users-o2cloud.png)

--- a/docs/user-guide/account-administration/identity-and-access-management/update-password.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/update-password.md
@@ -42,7 +42,7 @@ If you are locked out of the root account, you can reset the root password from 
 1. Set environment variables for the new root credentials:
     ```bash
     export ZO_ROOT_USER_EMAIL="root@example.com"
-    export ZO_ROOT_USER_PASSWORD="NewStrongPassword123"
+    export ZO_ROOT_USER_PASSWORD="Complexpass#123"
     ```
 
 2. Run the reset command from your OpenObserve installation directory:

--- a/docs/user-guide/account-administration/management/general-settings.md
+++ b/docs/user-guide/account-administration/management/general-settings.md
@@ -7,6 +7,7 @@ General settings provides the following configuration options:
 - Scrape interval
 - Theme configuration for light and dark modes
 - Enterprise branding features such as custom logo text and custom logo
+- Enable Usage Stream
 
 !!! note "Note"
     `_meta` organizations can access all settings. Regular organizations see only the options allowed for their specific license and permissions.
@@ -16,6 +17,9 @@ General settings provides the following configuration options:
 
 ![theme-config](../../../images/theme-config.png)
 The scrape interval defines how often the monitoring system collects metrics. Enter the number of seconds and select Save.
+
+### Enable Usage Stream
+**Enable Usage Stream**: when enabled, OpenObserve writes this organization's usage/billing data into its own `usage` stream so you can view per-organization ingestion and usage locally. Enable in **Organization Settings**.
 
 ### Theme configuration
 Theme configuration allows you to manage the default colors for light mode and dark mode for your organization. When you save these values, they are applied across the UI for all users in the organization.

--- a/docs/user-guide/account-administration/management/templates.md
+++ b/docs/user-guide/account-administration/management/templates.md
@@ -96,6 +96,58 @@ And we define the `row template` in alert page:
 
 After these, the notification message will be what we expect.
 
+### JSON row templates
+
+When the row template itself is valid JSON and `{rows}` (or `{rows:N}`) appears in a JSON value position, each row is injected as an element of a JSON array instead of being joined into a single newline-separated string.
+
+For example, with this row template:
+
+```
+{"pod": "{k8s_pod_name}", "count": {cnt}}
+```
+
+and an alert template like:
+
+```json
+{
+  "rows": "{rows}"
+}
+```
+
+the notification body becomes a JSON array, one element per row:
+
+```json
+{
+  "rows": [
+    {"pod": "pod1", "count": 1},
+    {"pod": "pod2", "count": 2},
+    {"pod": "pod3", "count": 1}
+  ]
+}
+```
+
+If the row template is itself a JSON array, each row becomes an array element, so the result is an array of arrays.
+
+### Spread syntax
+
+Use `{...rows}` (or `{...rows:N}`) to flatten array-typed row templates into a single one-dimensional array. Where `{rows}` would produce an array of arrays, `{...rows}` merges all the inner arrays into one flat array.
+
+For example, with a JSON array row template like:
+
+```
+["{k8s_pod_name}", {cnt}]
+```
+
+`{...rows}` produces:
+
+```json
+{
+  "rows": ["pod1", 1, "pod2", 2, "pod3", 1]
+}
+```
+
+As with `{rows:N}`, the `N` in `{...rows:N}` limits the number of rows that are included.
+
 Check this video to understand more
 
 <iframe width="760" height="315" src="https://www.youtube.com/embed/tW8VnNnfZBg?si=9bXSzGXgPER2Gbaw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/docs/user-guide/account-administration/profile/language.md
+++ b/docs/user-guide/account-administration/profile/language.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Switch UI language in OpenObserve via your profile. Choose from 11 languages.
+  Switch UI language in OpenObserve via your profile. Choose from 12 languages.
   Only UI elements are translated—your data stays unchanged.
 ---
 OpenObserve supports multiple UI languages. You can switch the interface language to your preference in just a few clicks. 
@@ -25,6 +25,7 @@ OpenObserve supports multiple UI languages. You can switch the interface languag
 - English (Default)  
 - Türkçe  
 - 简体中文  
+- 繁體中文  
 - Français  
 - Español  
 - Deutsch  

--- a/docs/user-guide/users.md
+++ b/docs/user-guide/users.md
@@ -37,6 +37,8 @@ To create user click on Add user button on users page to open :
 1. Email id of the user being added
 1. Password for the new user being added 
 1. First name of new user being added (optional)
+
+> **Note:** The password must meet the complexity policy: 8 to 128 characters with at least one lowercase letter, one uppercase letter, one digit, and one special character (non-ASCII characters count as special). See [Password requirements](account-administration/identity-and-access-management/update-password.md#password-requirements) for details. The same policy applies when changing a password through the **Change Password** flow.
 1. Last name of new user being added (optional)
 1. Role for the new organization member possible values are admin & member
 1. Save button


### PR DESCRIPTION
## Summary

Documentation updates to IAM, security, and management pages reflecting features merged March-May:

- **role-based-access-control.md** - new per-stream RBAC resources (logs_pattern/logs_insights/logs_cache) and report-folder (rfolder); service-account token shown only once at creation + rotation requires RBAC; IAM Users list Auth/Roles columns and SSO read-only roles.
- **update-password.md / users.md** - strong password policy (8-128 chars; lowercase, uppercase, digit, special), applied on create/change and to ZO_ROOT_USER_PASSWORD.
- **general-settings.md** - Enable Usage Stream toggle (per-org usage reporting).
- **profile/language.md** - added Traditional Chinese (zh-TW); now 12 languages.
- **templates.md** - JSON row templates and the {...rows} / {...rows:N} spread syntax for destination templates.

All changes verified against the OpenObserve source. Edits to existing pages (no footer changes).