### PR TITLE
docs(dashboards): update dashboards pages (Mar-May changes)

### DIFF
--- a/docs/user-guide/analytics/dashboards/config/index.md
+++ b/docs/user-guide/analytics/dashboards/config/index.md
@@ -1,5 +1,7 @@
 The Config tab in OpenObserve dashboards allows users to customize the behavior, layout, and appearance of individual panels.
 
+The **Config** tab is organized into collapsible sections (General, Legend, Data, Axis, Labels, and more). Use the **Search config** bar at the top to filter settings by name, and the expand/collapse toggle to open or close all sections at once.
+
 Learn more: 
 
 - [Trellis Layout](../config/trellis-layout/)

--- a/docs/user-guide/analytics/dashboards/config/legend-and-gridline.md
+++ b/docs/user-guide/analytics/dashboards/config/legend-and-gridline.md
@@ -123,6 +123,21 @@ A toggle switch that controls gridline visibility on the chart.
 When gridlines are disabled, the chart displays without reference lines, providing a cleaner appearance.
 
 
+## Axis configuration
+
+The following options control how x-axis labels are displayed.
+
+### Label Rotate
+
+Rotate x-axis label text by a chosen angle (in degrees) to improve readability when labels are long or crowded.
+
+### Label Truncate
+
+Truncate x-axis labels to a specified width in pixels.
+
+**Note:** Label Truncate is not supported for time-series x-axis fields.
+
+
 ## Chart type support
 
 ### Legend options

--- a/docs/user-guide/analytics/dashboards/dashboards-in-openobserve.md
+++ b/docs/user-guide/analytics/dashboards/dashboards-in-openobserve.md
@@ -91,6 +91,9 @@ The following charts are supported in Dashboards:
 17. Markdown
 18. Sankey
 19. Custom Charts
+20. Table: Display data in rows and columns, with optional pivot mode.
+
+The **Table** chart supports a pivot mode: add a **Breakdown** field (the **+P** button) to cross-tabulate data into columns (up to 3 pivot fields), with optional **Show Row Totals** / **Show Column Totals** (and sticky variants). **Transpose** and **Dynamic Columns** are disabled while pivot mode is active.
 
 ### Tabs
 Tabs help organize your Panels into different sections within a **Dashboard**. For example, you might have one Tab for Performance, another for Errors, and another for Traffic Analysis.

--- a/docs/user-guide/analytics/dashboards/variables/variables-in-openobserve.md
+++ b/docs/user-guide/analytics/dashboards/variables/variables-in-openobserve.md
@@ -30,6 +30,10 @@ To create a variable:
 
     - **Type of Variable**: Query Values
     - **Name**: pod
+
+        !!! Note
+            Variable names must be unique within a dashboard. If you enter a name that already exists, OpenObserve shows `Variable with same name already exists.` and does not save the variable.
+
     - **Label**: Pod
     - **Stream Type**: logs
     - **Stream**: `default`
@@ -69,6 +73,23 @@ To apply the variable to a panel:
 
 The panel is now dynamically filtered using the **Pod** variable. When users select a value from the **Pod** dropdown on the dashboard, the panel updates to display data for that pod only.
 ![Variable in Dashboard](../../../../images/query-variable-results.png)
+
+### Variable Substitution Syntax
+
+You can reference a variable in panel queries (and in HTML panels) using any of the following syntaxes, where `var` is the variable name:
+
+- `$var`
+- `${var}`
+- `{{var}}` (mustache)
+
+Surrounding spaces are tolerated, so `{{ var }}` and `${ var }` are also valid.
+
+For multi-value variables, you can apply format modifiers to control how the selected values are joined:
+
+- `{{var:csv}}` or `${var:csv}`: joins the values with commas.
+- `{{var:pipe}}` or `${var:pipe}`: joins the values with pipes.
+- `{{var:doublequote}}` or `${var:doublequote}`: wraps each value in double quotes.
+- `{{var:singlequote}}` or `${var:singlequote}`: wraps each value in single quotes.
 
 ## Advanced Configuration
 After creating and applying a variable, you can further refine its behavior using advanced settings.


### PR DESCRIPTION
## Summary

Documentation updates to the Dashboards pages reflecting features merged March-May:

- **config/index.md** - the redesigned Config tab (collapsible sections, Search config bar, expand/collapse toggle).
- **config/legend-and-gridline.md** - new Label Rotate and Label Truncate x-axis options.
- **dashboards-in-openobserve.md** - Table added to supported chart types, plus a pivot-mode note (Breakdown / +P, totals toggles).
- **variables-in-openobserve.md** - mustache {{var}} substitution syntax and :csv/:pipe/:doublequote/:singlequote format specifiers; variable names must be unique within a dashboard.

All changes verified against the OpenObserve source. Edits to existing pages (no footer changes).