### PR TITLE
docs(logs): update logs and search pages 

### DIFF
--- a/docs/user-guide/data-exploration/example-queries.md
+++ b/docs/user-guide/data-exploration/example-queries.md
@@ -25,7 +25,7 @@ match_all('error')
 
 ![Full text Search](../../images/example-queries/match-all-error.png)
 
-- `match_all` searches only the fields configured for full-text search. By default, these include: `log`, `message`, `msg`, `content`, `data`, and `json`.
+- `match_all` searches only the fields configured for full-text search. By default, these include: `log`, `message`, `msg`, `content`, `data`, `body`, `json`, `error`, `llm_input`, `llm_output`.
 - If you want more fields to be scanned, configure them under stream settings.
 
 **Search for "error" in just the `log` field (more efficient):**

--- a/docs/user-guide/data-exploration/logs/insights.md
+++ b/docs/user-guide/data-exploration/logs/insights.md
@@ -101,6 +101,8 @@ Click "Fields (X)" button to:
 - Ensure search results are loaded (> 0 results)
 - Click "Run query" first
 
+> **Note:** If `logs_insights` RBAC is enabled (Enterprise/Cloud), your role needs Get permission on the relevant logs stream's `logs_insights` resource to use Insights.
+
 **No dimensions shown**
 - Click "Fields (X)" and manually select dimensions
 

--- a/docs/user-guide/data-exploration/logs/logs.md
+++ b/docs/user-guide/data-exploration/logs/logs.md
@@ -21,6 +21,9 @@ To start using the **Logs** page:
 
 This is the minimum setup required to explore log data for the selected time range. 
 
+!!! note "Auto Run"
+    When Auto Run is enabled (an administrator sets `ZO_AUTO_QUERY_ENABLED`), the query re-runs automatically when you change a filter, time range, query, or function, so you do not need to click **Run query** manually.
+
 
 ## Use the Query Editor
 The **Query Editor** allows you to define filters, expressions, and transformations on your log data.
@@ -68,10 +71,24 @@ Click a row to expand the full log record.
 
 ![Logs view row](../../../images/logs-view-row.png)
 
+### Filter by field values
+In the left field list, fields are organized into collapsible groups. **Key Fields** (the high-value fields configured for the stream) appear first, followed by data-type groups (**String**, **Number**, **Boolean**) and semantic or prefix-based groups (for example, Kubernetes and HTTP), with **Other** listed last. When viewing a single stream, the groups are expanded by default.
+
+Expand a field in the left field list to see its values. Use the value search box to find a specific value, then click a value to add it as a filter condition:
+
+- Adding it as an **include** condition applies `field = 'value'`.
+- Adding it as an **exclude** condition applies `field != 'value'`.
+
+Your selections persist when you toggle between include and exclude. The `_timestamp` field also supports include and exclude conditions. Previously used filters are restored from your last session.
+
 ## Use the Histogram and Chart
 - The histogram displays log event distribution over time. Use the **Histogram** toggle to hide it when not needed.
 
     ![Logs histogram disabled](../../../images/logs-histogram-disable.png)
+
+    When the stream contains a recognized category field, such as `severity`, `log_level`, `level`, or `status`, the histogram is automatically rendered as a stacked bar chart, with each category colored separately and a scrollable legend. The set of recognized fields is configurable by an administrator using the `ZO_HISTOGRAM_BREAKDOWN_FIELDS` environment variable.
+
+    In SQL mode, the histogram is not shown for queries that use `LIMIT`, `DISTINCT`, `JOIN`, or CTEs (`WITH`). In these cases, the UI displays the message: **Histogram unavailable for CTEs, DISTINCT, JOIN and LIMIT queries.**
 
 - The **Visualize** toggle enables or disables the chart panel, which allows you to plot logs using the available chart options for visual analysis.
 
@@ -110,6 +127,8 @@ To save a query and its configuration:
 3. Click **Save**.
 
 ![Logs save view](../../../images/logs-save-view.png)
+
+View names must be unique within the organization (case-insensitive); saving with a name that already exists returns an error.
 
 Use the dropdown next to the **Save** icon to reopen saved views at any time.
 

--- a/docs/user-guide/data-exploration/logs/refresh-cache-run-query.md
+++ b/docs/user-guide/data-exploration/logs/refresh-cache-run-query.md
@@ -32,6 +32,9 @@ In such cases, users can use Refresh Cache and Run Query to invalidate the old c
 
     This clears the cache for the selected query range and reloads results using the latest ingested data.
 
+    !!! note
+        When `ZO_AUTO_QUERY_ENABLED` is enabled, the **Run query** dropdown also exposes an **Auto Run** toggle alongside **Refresh Cache and Run Query**.
+
     **Dashboard panels**:
     ![dashboard-refresh-query](../../../images/dashboard-refresh-query.png)
     


### PR DESCRIPTION
## Summary

Documentation updates to the Logs and Search pages reflecting features merged March-May:

- **logs/logs.md** - automatic stacked histogram breakdown (and ZO_HISTOGRAM_BREAKDOWN_FIELDS), histogram unavailable for LIMIT/DISTINCT/JOIN/CTE in SQL mode, field-value include/exclude filtering from the field list, and the Auto Run note.
- **logs/insights.md** - RBAC note for the logs_insights resource.
- **refresh-cache-run-query.md** - Auto Run toggle now in the Run query dropdown.
- **example-queries.md** - updated default full-text search field list (adds llm_input/llm_output).

All changes verified against the OpenObserve source. Edits to existing pages (no footer changes).