### PR TITLE
docs(data-processing): update pipelines, enrichment & streams pages (Mar-May changes)

### DIFF
--- a/docs/user-guide/data-processing/enrichment-tables/enrichment-table-upload-recovery.md
+++ b/docs/user-guide/data-processing/enrichment-tables/enrichment-table-upload-recovery.md
@@ -30,6 +30,16 @@ The upload flow adapts based on the file size, controlled by the environment var
 - Directly uploads to remote telemetry storage such as S3.
 - No merging or background sync is involved in this path.
 
+### URL source restrictions
+When an enrichment table is loaded from a URL, OpenObserve validates the URL to protect against server-side request forgery (SSRF). A URL-based enrichment table source must use the `http://` or `https://` scheme and may not target:
+
+- localhost or loopback addresses
+- private (RFC 1918) IP ranges
+- link-local or cloud-metadata addresses, such as `169.254.169.254`
+- unspecified addresses
+
+Requests to such hosts are rejected.
+
 
 
 ## Local Disk Cache

--- a/docs/user-guide/data-processing/enrichment-tables/enrichment.md
+++ b/docs/user-guide/data-processing/enrichment-tables/enrichment.md
@@ -83,6 +83,12 @@ stderr,Standard Error – error or diagnostic logs
 
 The enrichment table is now available for use in VRL.
 
+!!! note "Naming and uniqueness"
+    Enrichment table names must be unique within an organization, regardless of how the table is created (URL or file upload).
+
+    - Names are normalized before they are stored: they are lowercased and special characters are replaced. As a result, names such as `My_Table` and `my_table` are treated as the same name and will collide.
+    - Creating a table whose name matches an existing table of the other source type (for example, creating a file-upload table that matches an existing URL table, or vice versa) is rejected. Use the matching update flow for that table type instead.
+
 ### Step 4: Use the Enrichment Table in a VRL Function
 1. Go to the **Logs** page.
 2. Select the relevant log stream.
@@ -152,6 +158,9 @@ To add more data to an existing enrichment table, enable the **Append data to ex
 5. Select **Save** to upload and append the new data to the existing table.
 <br>
 ![Append Data to an Existing Table](../../../images/enrichment-table-append.png)
+
+!!! note
+    OpenObserve does not silently overwrite existing data. Re-adding a URL that is already present in a table, or re-creating a URL-based table that already exists without using the append/reload flow, returns an error instead of overwriting the existing data.
 
 ## Storage Limit
 The maximum size of an enrichment table is controlled by the environment variable `ZO_ENRICHMENT_TABLE_LIMIT`.

--- a/docs/user-guide/data-processing/pipelines/pipeline-history.md
+++ b/docs/user-guide/data-processing/pipelines/pipeline-history.md
@@ -12,6 +12,9 @@ Pipeline History provides visibility into every pipeline run, including its exec
 ![pipeline-history](../../../images/pipeline-history.png)
 The table lists each pipeline run with key execution details.
 
+!!! note "Query range limit"
+    When querying pipeline history over a time range, the range is capped by the `max_query_range` setting on the organization's `triggers` stream. Longer ranges are automatically truncated to the most recent allowed window.
+
 - **Pipeline Name**: Name of the executed pipeline.
 - **Type**: Execution type. The current verified value is Scheduled.
 - **Is Silenced**: Indicates whether the pipeline was silenced during execution. The green speaker icon means it was not silenced.
@@ -34,3 +37,4 @@ The table lists each pipeline run with key execution details.
 - **Source Node**: Node responsible for executing the run. This helps identify where the execution occurred for debugging and performance monitoring.<br>
 Example: <br>
 **Source Node**: `o2-openobserve-alertmanager-0`
+- **Error**: The error message describing why the run failed. Populated for runs with a `failed` status; empty otherwise.

--- a/docs/user-guide/data-processing/streams/schema-settings.md
+++ b/docs/user-guide/data-processing/streams/schema-settings.md
@@ -53,6 +53,9 @@ To enable UDS support, set the following environment variable `ZO_ALLOW_USER_DEF
 4. Click **Add to Defined Schema**.  
 5. Save your changes using the **Update Settings** button.
 
+!!! note
+    Fields already part of the User Defined Schema cannot be re-added. The **Add to Defined Schema** button is disabled and shows a tooltip ("One or more selected fields are already part of the defined schema") when any selected field is already in the schema.
+
 
 After you save the changes:
 


### PR DESCRIPTION
## Summary

Documentation updates to data-processing pages reflecting features merged March-May:

- **enrichment.md** - enrichment table names must be unique within an org regardless of source type; cross-type (URL vs file upload) name collisions are rejected; re-adding an existing URL/table is no longer a silent overwrite.
- **enrichment-table-upload-recovery.md** - URL-based enrichment sources are SSRF-validated (must be http/https; localhost, private, link-local, cloud-metadata, and unspecified addresses are blocked).
- **pipeline-history.md** - query range capped by the triggers stream max_query_range; error field surfaced in run details.
- **streams/schema-settings.md** - Add to Defined Schema is disabled for fields already in the User Defined Schema.

All changes verified against the OpenObserve source. Edits to existing pages (no footer changes).