### PR TITLE
docs: remaining edits — traces, incidents, reports, reference API, query & RUM

### DIFF
--- a/docs/reference/api/ingestion/logs/loki.md
+++ b/docs/reference/api/ingestion/logs/loki.md
@@ -9,7 +9,7 @@ Endpoint: `POST /api/{organization}/loki/api/v1/push`
 
 OpenObserve is compatible with the Grafana Loki push API. You can send logs using any Loki-compatible client (e.g. Promtail, Grafana Agent, Alloy) by pointing it at OpenObserve.
 
-> we use `o2_stream_name` label for custom stream name, default will push into `default` stream.
+> we use the `o2_stream_name` label (or the legacy `stream_name` label) for custom stream name, default will push into `default` stream.
 
 ## Request
 
@@ -47,7 +47,7 @@ Content-Type: `application/json`
 | Field | Type | Description |
 |-------|------|-------------|
 | `streams` | array | List of log streams to push. |
-| `streams[].stream` | object | Key-value label pairs that identify the stream. Labels are indexed and can be used for filtering. |
+| `streams[].stream` | object | Key-value label pairs that identify the stream. Labels are indexed and can be used for filtering. Use the `o2_stream_name` label (or the legacy `stream_name` label) to set a custom target stream; if neither is present, logs are pushed into the `default` stream. |
 | `streams[].values` | array | List of log entries. Each entry is a two-element array: `[timestamp, line]`. |
 | `streams[].values[][0]` | string | Unix timestamp in **nanoseconds** as a string. |
 | `streams[].values[][1]` | string | Log line content. |

--- a/docs/reference/api/stream/setting.md
+++ b/docs/reference/api/stream/setting.md
@@ -42,7 +42,8 @@ Use the `StreamSettings` schema. All fields are optional.
   "approx_partition": false,
   "extended_retention_days": [],
   "index_original_data": false,
-  "index_all_values": false
+  "index_all_values": false,
+  "storage_type": "compliance"
 }
 
 ```
@@ -100,7 +101,8 @@ Use the `UpdateStreamSettings` schema. Fields that support `add`, `remove`, or `
     "add": []
   },
   "index_original_data": false,
-  "index_all_values": false
+  "index_all_values": false,
+  "storage_type": "compliance"
 }
 
 ```
@@ -121,7 +123,7 @@ Use the `UpdateStreamSettings` schema. Fields that support `add`, `remove`, or `
 | `index_fields`            | Fields to create secondary indexes for exact-match filters. Improves query performance on `field = value`.                                                                        |
 | `full_text_search_keys`   | Fields tokenized for full-text search. Required for substring or `match_all` queries. Defaults to common log fields if not set.                                                   |
 | `bloom_filter_fields`     | Fields with high-cardinality values to optimize rare value searches. Improves performance by skipping non-matching data blocks.                                                   |
-| `data_retention`          | Number of days to retain data in the stream. Minimum is 3 days. Overrides the global retention setting.                                                                           |
+| `data_retention`          | Number of days to retain data in the stream. Minimum is 3 days. Overrides the global retention setting. Compliance streams require a 30-day minimum.                              |
 | `flatten_level`           | Maximum depth for flattening nested JSON objects into fields. Helps expose nested keys for querying.                                                                              |
 | `defined_schema_fields`   | Fields to retain in the user-defined schema. Others are excluded or stored as raw if `store_original_data` is true.                                                               |
 | `max_query_range`         | Maximum time range in hours for a single query. Prevents resource-heavy long-range queries.                                                                                       |
@@ -130,3 +132,4 @@ Use the `UpdateStreamSettings` schema. Fields that support `add`, `remove`, or `
 | `extended_retention_days` | List of time ranges to retain data beyond `data_retention`. Must be applied before data expires.                                                                                  |
 | `index_original_data`     | Enables full-text indexing on the raw log body. Allows search across fields not part of the schema.                                                                               |
 | `index_all_values`        | Indexes all fields for exact-match lookups. Increases ingestion and index size. Best for fixed schemas.                                                                           |
+| `storage_type`            | Storage class for the stream: `normal` (default) or `compliance`. When `compliance`, compacted files are written to the infrequent-access storage class (requires `ZO_S3_FEATURE_FORCE_INFREQUENT_ACCESS=true`), and `data_retention` must be at least 30 days. |

--- a/docs/user-guide/account-administration/work-group.md
+++ b/docs/user-guide/account-administration/work-group.md
@@ -31,7 +31,7 @@ The background group uses its own queue and resource limits. This ensures that s
 
 
 ## Slot-based admission (v2)
-OpenObserve includes an optional slot-based distributed admission control model for search and PromQL queries. When enabled, it limits how many queries run concurrently by reserving execution slots on querier nodes before a query begins.
+OpenObserve includes an optional slot-based distributed admission control model for search (SQL) and PromQL queries. When enabled, it limits how many queries run concurrently by reserving execution slots on querier nodes before a query begins.
 
 With slot-based admission:
 

--- a/docs/user-guide/account-administration/work-group.md
+++ b/docs/user-guide/account-administration/work-group.md
@@ -30,6 +30,18 @@ The background work group handles system tasks that run independently of user ac
 The background group uses its own queue and resource limits. This ensures that system tasks do not interfere with user query performance.
 
 
+## Slot-based admission (v2)
+OpenObserve includes an optional slot-based distributed admission control model for search and PromQL queries. When enabled, it limits how many queries run concurrently by reserving execution slots on querier nodes before a query begins.
+
+With slot-based admission:
+
+- Each query may be confined to a subset of querier nodes rather than spreading across the entire cluster. The subset is selected consistently, so queries for the same organization or stream tend to route to the same nodes.
+- Before a query runs, the selected nodes reserve execution slots for it. A query is admitted only when the required slots are available; otherwise it waits until slots free up.
+- Short queries and long queries are handled separately, so that heavy long-running queries do not exhaust the capacity reserved for fast interactive queries.
+
+This capability is off by default, and the default behavior of work groups is unchanged unless it is explicitly enabled. Configuration is performed through enterprise settings.
+
+
 ## Environment variables
 Work groups rely on the following environment variables for resource management and concurrency limits.
 

--- a/docs/user-guide/advanced/query-tuning/result-cache.md
+++ b/docs/user-guide/advanced/query-tuning/result-cache.md
@@ -45,6 +45,8 @@ When a query is executed, the node performs the following steps:
 Cache invalidation ensures that query results remain accurate when underlying data changes. <br>
 In OpenObserve, cache retrieval is handled locally by each node, but cache invalidation must still be coordinated across all nodes to maintain consistency. This is done using a dedicated background mechanism that relies on the `delete_result_cache` RPC. The `delete_result_cache` RPC is a remote procedure call (RPC) endpoint that allows nodes in the OpenObserve cluster to coordinate cache invalidation.
 
+> **Note:** Clearing the result cache can be RBAC-controlled via the `logs_cache` resource (Delete permission) when cache RBAC is enabled (Enterprise/Cloud).
+
 ## Configuration
 | Variable            | Default | Description                                                                                                                                                    |
 | ------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/user-guide/analytics/incidents/index.md
+++ b/docs/user-guide/analytics/incidents/index.md
@@ -13,6 +13,9 @@ It brings together alert data, service topology, AI-powered root cause analysis,
 !!! note
     Incident Management is available in OpenObserve Enterprise and Cloud editions.
 
+!!! note
+    On OpenObserve Cloud, automatic incident creation and RCA reanalysis consume AI credits from your organization's free credit pool. Once the pool is exhausted, incidents are not created for unpaid organizations until you subscribe. Alerts continue to fire.
+
 ## Key features
 
 ### Automatic alert correlation
@@ -25,6 +28,16 @@ OpenObserve groups related alert firings into incidents using intelligent correl
 | **Primary Match** | High | Matches alerts sharing primary dimensions (cluster, region, namespace) |
 | **Secondary Match** | Medium | Matches alerts sharing secondary dimensions (service, deployment) |
 | **Alert ID** | Lowest | Isolates alerts by alert rule ID when no dimensional match exists |
+
+### Incident notifications
+
+When an alert has **Creates Incident** enabled, it no longer sends its regular notification. Instead, an incident notification is sent only when:
+
+- A new incident is created.
+- A new alert type joins an existing incident.
+- The incident severity changes.
+
+Repeated firings of the same alert are suppressed, which reduces notification noise. The incident notification is sent to the union of all correlated alerts' destinations and uses an incident JSON payload with the following fields: `id`, `title`, `event`, `service`, `severity`, `alert`, `time`, and `url`.
 
 ### Incident overview dashboard
 
@@ -58,6 +71,12 @@ The right side of the Overview tab contains the management panel:
 The built-in AI SRE Agent analyzes incident data and generates a root cause analysis report. The analysis streams in real-time and includes an incident summary, technical findings, and recommended actions. Use the **Table of Contents** on the left to navigate between sections.
 
 ![AI-powered Incident Analysis with table of contents and structured report](../../../images/incident-detail-incident-analysis.png)
+
+#### Reanalysis
+
+Root cause analysis reruns automatically on key incident lifecycle events: when a new alert type joins the incident, when dimensions upgrade, or when the incident is reopened. You can also re-trigger it after a severity change.
+
+Reanalysis appends delta findings to the existing report rather than restarting it, so prior findings are preserved. An in-flight banner appears while analysis runs.
 
 ### Activity timeline and collaboration
 
@@ -95,6 +114,8 @@ The Alert Graph tab visualizes the topology of alerts within an incident using a
 The **Logs**, **Metrics**, and **Traces** tabs provide direct access to telemetry data related to the incident. OpenObserve uses the incident's correlation dimensions (such as `service_name`, `host`, or `cluster`) to find matching streams automatically.
 
 Each tab filters telemetry by the incident's time window and dimensions, so you can investigate the underlying data without leaving the incident detail view.
+
+The **Metrics** tab uses selection **pills** (Essentials / Compute / Memory / Storage / Network / All) and **Pod / Node** scope chips to choose which metric streams to chart (Essentials is the default when curated streams are available).
 
 !!! note
     Correlated telemetry requires that your logs, metrics, and traces share common dimensions with your alert definitions. Configure dimension names consistently across your alerts and telemetry ingestion for best results.
@@ -137,7 +158,7 @@ Each tab filters telemetry by the incident's time window and dimensions, so you 
 3. View the streaming analysis as it generates. Use the **Table of Contents** on the left to navigate the report.
 
 !!! tip
-    Trigger reanalysis after new alerts are added to get updated findings.
+    Reanalysis reruns automatically when a new alert type joins the incident, when dimensions upgrade, or when the incident is reopened. You can also re-trigger it after a severity change. New findings are appended to the existing report.
 
 ## Edit incident details
 

--- a/docs/user-guide/analytics/reports/.pages
+++ b/docs/user-guide/analytics/reports/.pages
@@ -1,4 +1,3 @@
 nav:
 
     - Reports Overview: index.md
-    - Reports FAQ: reports-frequently-asked-questions.md

--- a/docs/user-guide/analytics/reports/index.md
+++ b/docs/user-guide/analytics/reports/index.md
@@ -1,5 +1,52 @@
 The Reports section allows users to create and manage recurring reports from dashboard visualizations. Reports can be configured as either Scheduled or Cached.
 
-Learn more: 
+## Organize reports into folders
 
-- [Reports FAQ](reports-frequently-asked-questions.md)
+Reports can be organized into folders. Every report belongs to a folder, and a report that is not assigned to a specific folder lives in the **default** folder.
+
+To create a folder:
+
+1. Open the **Reports** page.
+2. In the **Folders** panel, select the **+** (plus) icon.
+3. Enter a name for the folder and save it.
+
+To work with reports across folders:
+
+- Use the search field together with the **All Folders** toggle to search for reports across all folders instead of only the currently selected folder.
+- To move a report to a different folder, select the report and use the move option to assign it to the target folder.
+
+!!! note
+    A report's folder is set when the report is created. You cannot change a report's folder while editing the report; use the move option instead.
+
+## Configure the report format
+
+When you create or edit a report, you can control how the report is generated and delivered.
+
+**Report Type**
+
+- **PDF** (default): generates a multi-page PDF of the dashboard.
+- **PNG image**: captures an image of the dashboard. PNG captures only the first visible page. To include multiple pages, use PDF.
+- **CSV (Data)**: exports the underlying panel data as CSV rather than a rendered image of the dashboard.
+
+**Email Attachment Style**
+
+- **Inline**: the report image is embedded inline in the email body.
+- **File attachment**: the report is delivered as a file attached to the email.
+
+**Custom dimensions**
+
+You can optionally set custom **width** and **height** values (in pixels) for the generated output. If these fields are left blank, the system default dimensions are used.
+
+!!! note
+    **Email Attachment Style** and **Custom dimensions** apply only to **PDF** and **PNG** reports. They are hidden and not available for **CSV (Data)** reports.
+
+**Dashboard preview**
+
+You can optionally include an inline preview image of the dashboard in the email body.
+
+!!! note
+    The **Inline** attachment style is only valid for **PNG** reports. Selecting **Inline** for a **PDF** report returns a save error. For PDF reports, use the **File attachment** style.
+
+## Report frequency
+
+Reports can run on a recurring schedule, or run a single time. A report configured with the **Once** frequency runs a single time and is then automatically paused (disabled). Re-enable it, or use a recurring frequency, to run it again.

--- a/docs/user-guide/data-exploration/rum/source-map.md
+++ b/docs/user-guide/data-exploration/rum/source-map.md
@@ -62,6 +62,18 @@ curl -X POST "https://<host>/api/{org}/sourcemaps" \
 
 **RUM → Error Tracking → select an error** — stack frames now show original source locations (e.g. `src/components/Checkout.vue:42`).
 
+## Using the UI
+
+You can also upload source maps without the API:
+
+1. Navigate to **RUM → Source Maps**.
+2. Click **Upload Source Maps**.
+3. Fill in **Service**, **Env**, and **Version**.
+4. Attach the source-map ZIP.
+5. Submit.
+
+Resolved stack traces then appear in **Error Tracking**.
+
 ## API Reference
 
 ### List source maps
@@ -84,6 +96,7 @@ curl "https://<host>/api/{org}/sourcemaps/values" -H "Authorization: Basic <toke
   "service": "my-web-app",
   "env": "production",
   "version": "1.4.2",
+  "file_type": "javascript",
   "source_file_name": "main.abc123.js",
   "source_map_file_name": "main.abc123.js.map",
   "created_at": 1743000000
@@ -118,8 +131,18 @@ curl -X POST "https://<host>/api/{org}/sourcemaps/stacktrace" \
 ```json
 {
   "stacktrace": {
-    "frames": [
-      { "file": "src/components/Checkout.vue", "function": "handleSubmit", "line": 42, "col": 8 }
+    "error": "<error message>",
+    "stack": [
+      {
+        "line": "<original stack line>",
+        "source_info": {
+          "source": "<source file>",
+          "source_line_start": <n>,
+          "source_line_end": <n>,
+          "stack_line": <n>,
+          "stack_col": <n>
+        }
+      }
     ]
   }
 }

--- a/docs/user-guide/data-exploration/traces/service-graph.md
+++ b/docs/user-guide/data-exploration/traces/service-graph.md
@@ -17,8 +17,7 @@
     !!! note "Where to find this"
 
         1. Sign in to OpenObserve.
-        2. Select **Traces** in the left navigation panel.
-        3. The **Service graph** icon that appears at the top-left corner of the page.
+        2. Select **Traces** in the left navigation panel, then choose **Service Graph** from the **Spans | Traces | Service Graph | Service Catalog** toggle in the search bar (Enterprise only).
 
         The topology loads automatically when recent trace activity is available.
         If there is no trace activity, the section displays a message indicating that no service graph data is available.
@@ -42,6 +41,8 @@
     - Green shows healthy behaviour  
     - Yellow and orange show increased errors  
     - Red shows repeated failures  
+
+    An always-visible legend on the graph canvas maps these colours to error-rate thresholds: Healthy (<1%), Degraded (1–5%), Warning (5–10%), and Critical (>10%). The legend labels these as **Requests** and **Errors**. In Graph view, node size reflects request volume.
 
     ??? "Edges"
     ### Edges
@@ -88,7 +89,15 @@
     Graph view arranges services as a network. It uses a physics based simulation to maintain stable spacing between services. Force directed layouts group related services together. Circular layouts arrange services around a circle.
 
     ## Interaction
-    You can drag services to reposition them. You can zoom and pan to explore specific areas. Hovering over a service displays a summary of request and error behaviour. Filters and layouts can be combined to focus on specific sections of the topology.
+    You can drag services to reposition them. You can zoom and pan to explore specific areas. Hovering over a service displays a summary of request and error behaviour. Click a service node to open a node detail side panel. Filters and layouts can be combined to focus on specific sections of the topology.
+
+    ### Node detail panel
+    Clicking a service node opens a side panel with details for that service. When a single stream is selected, the panel shows the following tabs:
+
+    - **Operations**, **Nodes**, and **Pods** tabs, where Nodes and Pods reflect the Kubernetes node and pod. Each tab is a table showing request count, errors, and the p50, p75, p95, and p99 latency percentiles. These tables can be sorted by column, and the latency percentile columns sort by numeric value.
+    - **Metrics** tab, which uses selection **pills** (**Essentials**, **Compute**, **Memory**, **Storage**, **Network**, **All**) along with **Pod** / **Node** scope chips.
+
+    A **View Traces** action opens the Spans view pre-filtered by service, operation, node, pod, errors, and duration.
 
 === "How-to"
     ## Filter the graph by service

--- a/docs/user-guide/data-exploration/traces/traces.md
+++ b/docs/user-guide/data-exploration/traces/traces.md
@@ -61,14 +61,18 @@ This document explains how to use OpenObserve to collect, view, and analyze dist
     
     Each row shows:
 
-    - The service and operation name
+    - Separate **Service** and **Operation name** columns. The first span determines these values.
     - The number of spans
-    - The request timestamp
-    - The total duration
+    - The request **Timestamp**
+    - The total **Duration**
     - Badges for the services involved
-    - The first span determines the label.
-    
+
+    The **Timestamp** and **Duration** column headers are clickable to sort the list in ascending or descending order. The list header shows a badge with the total count of traces found and a separate **Error Traces** count badge. A pagination control lets you choose the number of rows per page (`10`, `25`, `50`, or `100`) and navigate between pages.
     ![trace-list](../../../images/trace-list.png)
+
+    **Customize columns**: Toggle a field's visibility icon in the field sidebar to add or remove it as a table column, drag column headers to reorder them, and click the X on a column header to remove it. Column choices are remembered separately for Traces and Spans modes. Hover any cell to copy its value or add it as an include/exclude filter.
+
+    In the field sidebar, fields are organized into groups: **Key Fields** first, then type groups (**String**, **Number**, **Boolean**), semantic/prefix groups (for example, Kubernetes and HTTP), and **Other** last. For a single stream, the groups are expanded by default.
 
     **Timeline:** Shows spans as color-coded horizontal bars. Parent spans contain child spans. Parent time includes the time of child spans, which may run in parallel.
     ![Timeline](../../../images/timeline.png)
@@ -254,6 +258,11 @@ This document explains how to use OpenObserve to collect, view, and analyze dist
     4. Click **Run query**. 
     5. From the query result, select the desired trace. 
 
+    Use the **Spans | Traces | Service Graph | Service Catalog** toggle in the search bar to switch the result list between individual spans and aggregated traces (the default view is **Spans**), with **Service Graph** and **Service Catalog** available on Enterprise. In **Spans** mode, the result list shows a **Spans Found** count, and selecting a span row opens its trace with that span focused. **Service Catalog** shows a per-service metrics table (requests, error rate, latency percentiles, and health status); clicking a service opens **Traces** filtered by `service_name`. See [Service Catalog](service-catalog.md) for details.
+
+    !!! note "Flame Graph"
+        A **Flame Graph** view is also available for inspecting a trace. Selecting a span in the flame graph opens that span's details in a resizable bottom panel.
+
 
     ## Use Trace Timeline and Service Map
     Use Trace Timeline and Service Map to inspect performance and find slow spans:
@@ -280,7 +289,22 @@ This document explains how to use OpenObserve to collect, view, and analyze dist
     8. The detailed span view opens, showing the complete context for that span.  
     ![span-view](../../../images/span-view.png)
     9. If log and trace correlation is configured, select **View Logs** in the span details panel to open the related logs for further investigation.   
-    
+
+    ## Filter by duration
+    Click the `duration` field in the field sidebar to view its duration statistics: `P25`, `P50`, `P75`, `P95`, `P99`, and `Max` (the maximum observed duration). Each statistic provides one-click buttons to add a `duration >= <value>` or `duration <= <value>` filter to the query.
+
+    Duration filters also accept human-readable unit suffixes, for example:
+
+    - `duration >= '1.50ms'`
+    - `duration >= '2 seconds'`
+    - `duration <= '100us'`
+    - `duration >= '1.50m'`
+
+    The accepted units are `us` (or `µs`), `ms`, `s`, and `m`. OpenObserve auto-converts these values to microseconds.
+
+    !!! note "Enterprise"
+        While a query runs, a **Cancel** button replaces **Run query**, allowing you to abort in-flight queries.
+
     ## Explore the detailed span view
     ![detailed-span-view](../../../images/detailed-span-view.png)
 
@@ -290,3 +314,9 @@ This document explains how to use OpenObserve to collect, view, and analyze dist
     | Process | Compact identity of the emitting process (service, instance, version). | Confirm the exact instance/version for rollbacks or targeted restarts. |
     | Events | Time-ordered records emitted inside the span (INFO/ERROR messages with context). | Read the span's timeline narrative and error messages without leaving the trace. |
     | Attributes | The full JSON document is stored for this span. | Copy/paste into tickets, verify raw values, or see fields not surfaced elsewhere. |
+    | Error | Consolidated error indicators for the span: HTTP status, gRPC status/name/message, exception events, error type, DB response status, and process exit code. | Quickly assess what failed and why without scanning across multiple tabs. |
+    | DB | Database call details: DB system, the query/statement (syntax-highlighted by `db_system`), collection/table, rows returned, batch size, response status code, and a query summary. Appears only when the span has `db_*` attributes. | Inspect the database operation a span performed. |
+    | Metrics | Correlated metric streams for the span's service. Use the selection **pills** (**Essentials**, **Compute**, **Memory**, **Storage**, **Network**, **All**) together with the **Pod** / **Node** scope chips to choose which metrics to display. **Essentials** is the default when curated streams exist. | Inspect the resource health of the service that emitted the span without leaving the trace. When no matching metrics exist, the view reads **No Data Found**. |
+
+    !!! note "Enterprise"
+        For LLM traces that have an associated LLM-evaluation pipeline producing evaluation records, the trace detail view shows an additional **Evaluations** tab. It displays the evaluation results for the trace. This tab appears only when such evaluation records exist for the trace.

--- a/docs/user-guide/data-exploration/traces/traces.md
+++ b/docs/user-guide/data-exploration/traces/traces.md
@@ -298,7 +298,6 @@ This document explains how to use OpenObserve to collect, view, and analyze dist
     - `duration >= '1.50ms'`
     - `duration >= '2 seconds'`
     - `duration <= '100us'`
-    - `duration >= '1.50m'`
 
     The accepted units are `us` (or `µs`), `ms`, `s`, and `m`. OpenObserve auto-converts these values to microseconds.
 


### PR DESCRIPTION
## Summary

Final batch of documentation updates for features merged March-May, covering the remaining areas:

**Traces** (traces.md, service-graph.md)
- Search-mode toggle incl. Service Catalog; Error and DB span tabs; Flame Graph view; field-list grouping; node detail panel + Metrics pill/chip model.

**Incidents** (incidents/index.md)
- Incident notifications, RCA reanalysis, Metrics tab pill/chip model, and the Cloud AI-credit note.

**Reports** (reports/index.md, .pages)
- Report folders, format (PDF/PNG/CSV), attachment style, dimensions, dashboard preview, and Report frequency (Once auto-pause).
- Consolidation: the empty standalone **Reports FAQ** stub is removed; its one unique answer (Once auto-pause) is folded into Report frequency, and the other duplicated existing content.

**Reference API** (loki.md, stream/setting.md)
- Loki legacy stream_name label; stream storage_type field (compliance / infrequent-access).

**Query, Caching & RUM** (work-group.md, result-cache.md, rum/source-map.md)
- Slot-based admission (v2); logs_cache RBAC note; RUM source maps stacktrace response shape, file_type, and in-app UI.

All changes verified against the OpenObserve source. Build is clean.