### PR TITLE
[needs screenshots] docs: service-graph-inferred-dependencies — o2-enterprise PR #1876

### DIFF
--- a/docs/user-guide/data-exploration/traces/service-graph.md
+++ b/docs/user-guide/data-exploration/traces/service-graph.md
@@ -17,7 +17,8 @@
     !!! note "Where to find this"
 
         1. Sign in to OpenObserve.
-        2. Select **Traces** in the left navigation panel, then choose **Service Graph** from the **Spans | Traces | Service Graph | Service Catalog** toggle in the search bar (Enterprise only).
+        2. Select **Traces** in the left navigation panel.
+        3. The **Service graph** icon that appears at the top-left corner of the page.
 
         The topology loads automatically when recent trace activity is available.
         If there is no trace activity, the section displays a message indicating that no service graph data is available.
@@ -42,11 +43,25 @@
     - Yellow and orange show increased errors  
     - Red shows repeated failures  
 
-    An always-visible legend on the graph canvas maps these colours to error-rate thresholds: Healthy (<1%), Degraded (1–5%), Warning (5–10%), and Critical (>10%). The legend labels these as **Requests** and **Errors**. In Graph view, node size reflects request volume.
-
     ??? "Edges"
     ### Edges
     Edges represent calls from one service to another. They indicate downstream communication and help you identify where issues may originate.
+
+    ??? "Inferred dependencies"
+    ### Inferred dependencies
+
+    When OpenObserve detects communication with services that are not directly instrumented — such as **databases**, **message queues**, **external APIs**, or **RPC backends** — the service graph represents them as **inferred dependency** nodes.
+
+    Inferred dependencies are visually distinct from instrumented services:
+
+    - Nodes show a **dotted border** and a **type icon** identifying the dependency category (`database`, `queue`, `rpc`, or `external`).
+    - Edges connecting to inferred dependencies are drawn as **dotted lines** to reflect that the relationship is inferred rather than measured from both sides.
+
+    Instrumented services and their edges remain unchanged and render with solid borders and lines.
+
+    Inferred dependencies let you see the full topology of your system even when some downstream services do not send their own traces.
+
+    ![TODO: screenshot of an inferred dependency node with dotted border and type icon in service graph](images/placeholder.png)
 
     ??? "Topology behaviour"
     ### Topology behaviour
@@ -89,15 +104,7 @@
     Graph view arranges services as a network. It uses a physics based simulation to maintain stable spacing between services. Force directed layouts group related services together. Circular layouts arrange services around a circle.
 
     ## Interaction
-    You can drag services to reposition them. You can zoom and pan to explore specific areas. Hovering over a service displays a summary of request and error behaviour. Click a service node to open a node detail side panel. Filters and layouts can be combined to focus on specific sections of the topology.
-
-    ### Node detail panel
-    Clicking a service node opens a side panel with details for that service. When a single stream is selected, the panel shows the following tabs:
-
-    - **Operations**, **Nodes**, and **Pods** tabs, where Nodes and Pods reflect the Kubernetes node and pod. Each tab is a table showing request count, errors, and the p50, p75, p95, and p99 latency percentiles. These tables can be sorted by column, and the latency percentile columns sort by numeric value.
-    - **Metrics** tab, which uses selection **pills** (**Essentials**, **Compute**, **Memory**, **Storage**, **Network**, **All**) along with **Pod** / **Node** scope chips.
-
-    A **View Traces** action opens the Spans view pre-filtered by service, operation, node, pod, errors, and duration.
+    You can drag services to reposition them. You can zoom and pan to explore specific areas. Hovering over a service displays a summary of request and error behaviour. Filters and layouts can be combined to focus on specific sections of the topology.
 
 === "How-to"
     ## Filter the graph by service


### PR DESCRIPTION
Auto-generated documentation from openobserve/o2-enterprise PR #1876 (mode: `augment`).

⚠️ Some screenshots could not be auto-captured (0/?). The remaining `TODO: screenshot …` placeholders are still in the doc — please add those images manually. (Labelled `Manual-Screenshots-Needed`.) Please review for accuracy, then merge — or close if not needed.

🤖 Generated by DocGen-on-CI
