### PR TITLE
docs: add dedicated Service Accounts page and credential comparison

### DIFF
--- a/docs/user-guide/account-administration/identity-and-access-management/.pages
+++ b/docs/user-guide/account-administration/identity-and-access-management/.pages
@@ -2,6 +2,7 @@ nav:
     - Identity and Access Management Overview: index.md
     - Role-Based Access Control (RBAC): role-based-access-control.md
     - Enable Role-Based Access Control (RBAC) in Enterprise Edition: enable-rbac-in-openobserve-enterprise.md
+    - Service Accounts: service-accounts.md
     - Single Sign-On (SSO): sso.md
     - Keycloak SSO: keycloak-sso.md
     - Organizations: organizations.md

--- a/docs/user-guide/account-administration/identity-and-access-management/index.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/index.md
@@ -2,6 +2,7 @@ The following guides provide details on managing user identities and controlling
 
 - [Role-Based Access Control (RBAC)](role-based-access-control.md)
 - [Enable Role-Based Access Control (RBAC) in Enterprise Edition](enable-rbac-in-openobserve-enterprise.md)
+- [Service Accounts](service-accounts.md)
 - [Single Sign-On (SSO)](sso.md)
 - [Keycloak SSO](keycloak-sso.md)
 - [Organizations](organizations.md)

--- a/docs/user-guide/account-administration/identity-and-access-management/role-based-access-control.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/role-based-access-control.md
@@ -86,30 +86,11 @@ Admins can create custom user roles in OpenObserve to define more granular acces
 
 ![Custom roles in OpenObserve](../../../images/rbac1-custom_roles.png)
 
-## Service Accounts  
+## Service Accounts
 
-A service account in OpenObserve is a non-human account used for API access, automation, and integrations. Each service account is assigned a **token** for authentication.
+A service account is a non-human identity used for API access, automation, and integrations. You assign it roles and permissions just like a user, and it is issued a **token** for authentication. On Enterprise, service accounts have no permissions until you assign them a role or add them to a group.
 
-- **Enterprise version**: Service accounts have no permission by default. Admins must assign roles to the service accounts explicitly.
-- **Open-source version**: Service accounts have full access by default.
-- **Cloud version**: Service accounts are not supported.
-
-**To add a service account**:
-
-1. From the **IAM** panel, select **Service Accounts**.
-2. Click **Add Service Account**.
-3. Enter the **Email, First Name,** and **Last Name**.
-4. Click **Save**.
-5. A **token** is generated and shown only once in the create response. Copy and store the token securely at creation. It cannot be viewed again later; only a redacted version is shown (the first 4 characters followed by `*`).
-6. After the service account is created, assign the necessary **roles** and **permissions**. This step is required for the service account to make API calls and access specific services in OpenObserve.
-
-![Service accounts in OpenObserve](../../../images/rbac2-service-account.png)
-
-**Note:**
-
-- You can rotate the token at any time by selecting the appropriate service account from the Service Accounts page and clicking the refresh icon next to it. A rotated token is also shown only once, so copy and store it securely.
-- Rotating a service account token requires the **Admin** or **Root** role (or, with RBAC/OpenFGA enabled, explicit permission). Users without sufficient privileges receive a `403` error.
-- Ensure that the assigned roles provide only the minimum required access based on the use case.
+For full details on creating service accounts, granting access, authenticating with the token, and rotation, see [Service Accounts](service-accounts.md).
 
 ## User Groups
 

--- a/docs/user-guide/account-administration/identity-and-access-management/service-accounts.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/service-accounts.md
@@ -1,0 +1,67 @@
+---
+description: >-
+  Create and manage service accounts in OpenObserve — non-human identities that give applications, automation, and integrations scoped, role-based API access through a rotatable token.
+---
+This guide explains how to create, manage, and authenticate with **service accounts** in OpenObserve.
+
+## Overview
+
+A service account is a non-human account used for API access, automation, and integrations. It is an **identity**: you assign it roles and permissions, and it is issued a **token** for authentication. Because permissions attach to the account rather than to the token, you can rotate the token at any time without changing the account's access, and audit logs stay tied to a stable identity across rotations.
+
+!!! tip "Coming from API keys?"
+    If you have used **API keys** in other tools (such as Kubernetes, GCP, or SaaS APIs), a service account is OpenObserve's equivalent — with roles and rotation built in. The **service account** is the identity you grant permissions to, and its **token** is the API key you place in your application.
+
+Availability differs by edition:
+
+- **Enterprise**: Service accounts have no permissions by default. Admins must assign roles explicitly.
+- **Open-source**: Service accounts have full access by default.
+- **Cloud**: Service accounts are not supported.
+
+## Create a service account
+
+1. From the **IAM** panel, select **Service Accounts**.
+2. Click **Add Service Account**.
+3. Enter the **Email** (used as the account identifier), **First Name**, and **Last Name**.
+4. Click **Save**.
+5. A **token** is generated and shown only once. Copy and store it securely at creation — it cannot be viewed again later; only a redacted version is shown (the first 4 characters followed by `*`).
+6. After the account is created, assign the necessary **roles** and **permissions**. On Enterprise this step is required before the service account can make any API calls.
+
+![Service accounts in OpenObserve](../../../images/rbac2-service-account.png)
+
+## Grant access
+
+Service accounts are principals just like users, so you grant them access the same way:
+
+- **Assign a role** — go to **IAM > Roles**, open a role, and add the service account from its **Service Accounts** tab.
+- **Add to a user group** — go to **IAM > User Groups**, open a group, and add the service account from its **Service Accounts** tab. The account inherits every role attached to that group.
+
+Grant only the minimum access the integration needs.
+
+## Authenticate with the token
+
+OpenObserve authenticates API requests using **HTTP Basic auth**, where the service account's email is the username and its token is the password.
+
+```bash
+curl -u "service-account@example.com:YOUR_TOKEN" \
+  "https://your-instance/api/<org_identifier>/streams"
+```
+
+To send the credential as a header instead, base64-encode `email:token` and pass it as `Authorization: Basic <encoded>`.
+
+## Rotate the token
+
+You can rotate a service account's token at any time from the **Service Accounts** page by clicking the rotate icon next to the account. A rotated token is also shown only once, so copy and store it securely. Rotating does not change the account's roles or identity — only the secret.
+
+Rotating a token requires the **Admin** or **Root** role (or, with RBAC/OpenFGA enabled, explicit permission). Users without sufficient privileges receive a `403` error.
+
+## Which credential do I need?
+
+OpenObserve issues a few different credentials. Use this table to pick the right one:
+
+| Credential | Where to manage | What it authorizes | Typical use |
+|---|---|---|---|
+| **Service account token** | IAM > Service Accounts | Whatever roles you grant the account — general, scoped API access | Applications, automation, and integrations calling the OpenObserve API |
+| **Ingestion token** (`o2oi_`) | IAM > Ingestion Tokens | Ingestion endpoints only; rejected on any other API path | Sending logs, metrics, and traces into an organization |
+| **RUM token** | Ingestion page (RUM) | Real User Monitoring data from the browser | Instrumenting front-end apps with OpenObserve RUM |
+
+If you need role-based access to the general API, use a **service account**. If you only need to ship data in, use an **[ingestion token](ingestion-tokens.md)**.

--- a/docs/user-guide/account-administration/identity-and-access-management/update-password.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/update-password.md
@@ -58,7 +58,7 @@ If you are locked out of the root account, you can reset the root password from 
 ## Best Practices
 
 * Update usernames, passwords, or roles via the UI whenever possible.
-* Update root and user passwords periodically; rotate API keys or service accounts.
+* Update root and user passwords periodically; rotate service account tokens and ingestion tokens on a regular schedule.
 * Use long, complex, and unique passwords. Avoid reusing passwords across environments.
 * Back up your metadata database, especially before manual or DB-level changes.
 * Use dedicated users with least privilege; reserve root for emergencies.


### PR DESCRIPTION
## What

Service accounts were only documented as a subsection of the RBAC page — no nav entry, absent from the IAM index, and with no guidance distinguishing their token from ingestion tokens and RUM tokens.

### Changes
- **New `service-accounts.md`** — dedicated page covering create / grant access / authenticate (HTTP Basic, `email:token`) / rotate. Includes:
  - A **"Coming from API keys?"** callout clarifying that a service account is OpenObserve's equivalent (identity + token), which also makes the page discoverable for readers searching "API key".
  - A **"Which credential do I need?"** comparison table: service account token vs ingestion token (`o2oi_`) vs RUM token.
- **Nav + index** — added the page to `.pages` and the IAM `index.md` so it's no longer hidden.
- **RBAC page** — trimmed the duplicated Service Accounts section to a short summary + link.
- **update-password.md** — fixed loose "rotate API keys or service accounts" wording to reference service account tokens and ingestion tokens.

## Related
- Web UI counterpart (terminology standardization): openobserve/openobserve#13255