### PR TITLE
docs: rename Synthetic Monitoring section to Browser Checks

### DIFF
--- a/docs/user-guide/analytics/synthetics/.pages
+++ b/docs/user-guide/analytics/synthetics/.pages
@@ -1,7 +1,7 @@
-title: Synthetic Monitoring
+title: Browser Checks
 nav:
-    - Synthetic Monitoring Overview: index.md
-    - Synthetic Monitoring in OpenObserve: synthetic-monitoring-in-openobserve.md
+    - Browser Checks Overview: index.md
+    - Browser Checks in OpenObserve: synthetic-monitoring-in-openobserve.md
     - Create a Browser Check: create-a-browser-check.md
     - Locations and Probe Agents: locations-and-probe-agents.md
     - Analyze Check Results: analyze-check-results.md

--- a/docs/user-guide/analytics/synthetics/analyze-check-results.md
+++ b/docs/user-guide/analytics/synthetics/analyze-check-results.md
@@ -1,21 +1,21 @@
 ---
 description: >-
-  Use the monitor results and run detail views in OpenObserve to review synthetic
-  check pass rate, response time, failing steps, and screenshots.
+  Use the results and run detail views in OpenObserve to review browser check
+  pass rate, response time, failing steps, and screenshots.
 ---
 # Analyze Check Results
 
-Use this guide to review how a synthetic check has behaved over time, find the runs that failed, and inspect the step that broke.
+Use this guide to review how a browser check has behaved over time, find the runs that failed, and inspect the step that broke.
 
-> Visit the [Synthetic Monitoring in OpenObserve](https://openobserve.ai/docs/user-guide/analytics/synthetics/synthetic-monitoring-in-openobserve/) page before starting. It explains the concepts used in this guide.
+> Visit the [Browser Checks in OpenObserve](https://openobserve.ai/docs/user-guide/analytics/synthetics/synthetic-monitoring-in-openobserve/) page before starting. It explains the concepts used in this guide.
 
 !!! info "Availability"
-    This feature is available only in Enterprise Edition and Cloud.
+    Browser checks are available on OpenObserve Cloud and are currently in preview.
 
 ## Prerequisites
 
-- A synthetic check exists and has completed at least one run.
-- You have permissions to work with synthetic checks. Access is controlled from IAM > Roles > Permissions.
+- A browser check exists and has completed at least one run.
+- You have permissions to work with browser checks. Access is controlled from IAM > Roles > Permissions.
 
 ## Open the results
 
@@ -104,7 +104,7 @@ OpenObserve keeps screenshots and traces in object storage and serves them throu
 
 ## Related Links
 
-- [Synthetic Monitoring in OpenObserve](synthetic-monitoring-in-openobserve.md)
+- [Browser Checks in OpenObserve](synthetic-monitoring-in-openobserve.md)
 - [Create a Browser Check](create-a-browser-check.md)
 
 **Need help:**

--- a/docs/user-guide/analytics/synthetics/create-a-browser-check.md
+++ b/docs/user-guide/analytics/synthetics/create-a-browser-check.md
@@ -8,16 +8,16 @@ description: >-
 
 Use this guide to create a **Browser Test**. A browser check replays a multi-step user journey in a real browser from your selected locations, and reports where the journey broke.
 
-> Visit the [Synthetic Monitoring in OpenObserve](https://openobserve.ai/docs/user-guide/analytics/synthetics/synthetic-monitoring-in-openobserve/) page before starting. It explains the concepts used in this guide.
+> Visit the [Browser Checks in OpenObserve](https://openobserve.ai/docs/user-guide/analytics/synthetics/synthetic-monitoring-in-openobserve/) page before starting. It explains the concepts used in this guide.
 
 !!! info "Availability"
-    This feature is available only in Enterprise Edition and Cloud.
+    Browser checks are available on OpenObserve Cloud and are currently in preview.
 
 ## Prerequisites
 
-- Your OpenObserve Cloud or self-hosted instance is running.
-- You have permissions to work with synthetic checks. Access is controlled from IAM > Roles > Permissions.
-- At least one location is registered on the deployment.
+- You have access to OpenObserve Cloud.
+- You have permissions to work with browser checks. Access is controlled from IAM > Roles > Permissions.
+- At least one location is available to select. OpenObserve Cloud provides public locations.
 - To record a journey rather than build it by hand, install the **OpenObserve Recorder** Chrome extension and allow it in incognito mode.
 
 ## Steps to create a browser check
@@ -178,7 +178,7 @@ Use this guide to create a **Browser Test**. A browser check replays a multi-ste
     2. In **Browsers & Devices**, tick the combinations to run. The grid lists a row per browser and a column per device, and defaults to Chromium on Desktop.
 
     !!! note "Which browsers you see"
-        The browsers and devices offered are reported by the probe agents serving your locations, so the grid differs between deployments. A deployment whose agents run only Chromium shows a single browser row.
+        The browsers and devices offered are reported by the probe agents serving your locations, so the grid depends on those locations. If the agents run only Chromium, the grid shows a single browser row.
 
     !!! note "Each combination is a separate execution"
         A check runs once per location per browser and device combination. Three locations and two combinations produce six executions per run, so add combinations deliberately.
@@ -206,7 +206,7 @@ Use this guide to create a **Browser Test**. A browser check replays a multi-ste
 
 ## Related Links
 
-- [Synthetic Monitoring in OpenObserve](synthetic-monitoring-in-openobserve.md)
+- [Browser Checks in OpenObserve](synthetic-monitoring-in-openobserve.md)
 - [Locations and Probe Agents](locations-and-probe-agents.md)
 
 **Need help:**

--- a/docs/user-guide/analytics/synthetics/index.md
+++ b/docs/user-guide/analytics/synthetics/index.md
@@ -1,20 +1,18 @@
 ---
 description: >-
-  Learn how Synthetic Monitoring in OpenObserve proactively checks uptime,
-  performance, and user journeys from probe locations on a schedule.
+  Learn how browser checks in OpenObserve replay scripted user journeys from
+  probe locations on a schedule to catch problems before your users do.
 ---
-# Synthetic Monitoring Overview
+# Browser Checks Overview
 
-**Synthetic Monitoring** in OpenObserve replays scripted browser journeys against your application on a schedule, from probe locations you choose, so you find problems before your users report them.
+**Browser checks** in OpenObserve replay scripted user journeys against your application on a schedule, from probe locations you choose, so you find problems before your users report them.
 
 !!! info "Availability"
-    This feature is available only in Enterprise Edition and Cloud.
-
-    In self-hosted deployments, synthetic monitoring must also be enabled with the `O2_SYNTHETICS_ENABLED` environment variable. When it is disabled, the **Synthetic** menu item is hidden and the synthetics API returns 404.
+    Browser checks are available on OpenObserve Cloud and are currently in preview.
 
 **Learn more:**
 
-- [Synthetic Monitoring in OpenObserve](synthetic-monitoring-in-openobserve.md)
+- [Browser Checks in OpenObserve](synthetic-monitoring-in-openobserve.md)
 - [Create a Browser Check](create-a-browser-check.md)
 - [Locations and Probe Agents](locations-and-probe-agents.md)
 - [Analyze Check Results](analyze-check-results.md)

--- a/docs/user-guide/analytics/synthetics/locations-and-probe-agents.md
+++ b/docs/user-guide/analytics/synthetics/locations-and-probe-agents.md
@@ -1,15 +1,15 @@
 ---
 description: >-
-  Understand public and private synthetic monitoring locations in OpenObserve,
+  Understand public and private browser check locations in OpenObserve,
   how probe agents connect to a private location, and how location health is
   determined.
 ---
 # Locations and Probe Agents
 
-This guide explains where synthetic checks run from, the difference between public and private locations, and how probe agents serve a private location.
+This guide explains where browser checks run from, the difference between public and private locations, and how probe agents serve a private location.
 
 !!! info "Availability"
-    This feature is available only in Enterprise Edition and Cloud.
+    Browser checks are available on OpenObserve Cloud and are currently in preview.
 
 ## Locations
 
@@ -26,10 +26,8 @@ Use a private location to check a target that a public location cannot reach, su
 
 A location record carries a name, a provider (AWS, GCP, Azure, or custom), a region, and an enabled flag. In the check form, locations appear as `{name} · {region}`.
 
-!!! note "No locations are registered by default"
-    A new deployment starts with an empty location registry, and check creation fails until at least one location exists. The error tells you that no locations are registered on this deployment and asks you to register one before creating synthetics.
-
-    Only the root user can create or edit public locations.
+!!! note "At least one location is required"
+    A check cannot be created until at least one location is available to select. OpenObserve Cloud provides public locations. To run checks from your own environment, add a private location and connect a probe agent to it.
 
 ## View private locations
 
@@ -84,7 +82,7 @@ Click **Set up an agent** on the **Private Locations** tab. OpenObserve walks yo
 
 ## Related Links
 
-- [Synthetic Monitoring in OpenObserve](synthetic-monitoring-in-openobserve.md)
+- [Browser Checks in OpenObserve](synthetic-monitoring-in-openobserve.md)
 - [Create a Browser Check](create-a-browser-check.md)
 
 **Need help:**

--- a/docs/user-guide/analytics/synthetics/synthetic-monitoring-in-openobserve.md
+++ b/docs/user-guide/analytics/synthetics/synthetic-monitoring-in-openobserve.md
@@ -1,22 +1,24 @@
 ---
 description: >-
-  Understand browser checks in OpenObserve Synthetic Monitoring, including
-  scheduling, locations, statuses, alerting behavior, and where results are stored.
+  Understand browser checks in OpenObserve, including scheduling, locations,
+  statuses, alerting behavior, and where results are stored.
 ---
-# Synthetic Monitoring in OpenObserve
+# Browser Checks in OpenObserve
 
-This guide explains what synthetic browser checks are and the concepts used when you create and analyze them.
+This guide explains what browser checks are and the concepts used when you create and analyze them.
 
 !!! info "Availability"
-    This feature is available only in Enterprise Edition and Cloud.
+    Browser checks are available on OpenObserve Cloud and are currently in preview.
 
-## What is Synthetic Monitoring
+## What is a browser check
 
-Synthetic monitoring runs scripted checks against a target on a schedule, from one or more probe locations. Unlike monitoring that waits for real user traffic, synthetic checks generate their own traffic, so you learn about an outage as soon as it happens.
+A browser check replays a multi-step user journey in a real browser on a schedule, from one or more probe locations. You record the journey with a Chrome extension or build it step by step, then OpenObserve replays it from each location you choose.
 
-Each execution of a check records a status, a response time, and per-step results for the journey it replayed.
+A browser check generates its own traffic instead of waiting for real user traffic, so you learn about an outage as soon as it happens. OpenObserve times every step and lets you assert on it, so a failure names the step that broke instead of reporting only that the site is down.
 
-## How to access Synthetic Monitoring
+Each run records a status, a response time, and per-step results for the journey it replayed.
+
+## How to access browser checks
 
 1. Sign in to OpenObserve.
 2. Select the desired organization from the top navigation bar.
@@ -36,12 +38,6 @@ Each row has actions to pause, edit, and duplicate the check. The **⋮** menu a
 
 !!! note "Private Locations"
     The **Private Locations** tab on this page is where you manage the locations your own probe agents serve. See [Locations and Probe Agents](locations-and-probe-agents.md).
-
-## Browser checks
-
-A **Browser Test** replays a multi-step user journey in a real browser, across the browser and device combinations you select. You record the journey with a Chrome extension or build it step by step, then OpenObserve replays it on a schedule from each location you choose.
-
-OpenObserve times every step and lets you assert on it, so a failure names the step that broke instead of reporting only that the site is down.
 
 ## Scheduling
 


### PR DESCRIPTION
Follow-up to #476. Renames the section to **Browser Checks** and corrects its availability.

Scope was narrowed to browser checks only, so the section should not present itself as broader Synthetic Monitoring.

## What changed

- Section title, page headings, descriptions, and concept prose now say **Browser Checks**.
- Availability corrected to **OpenObserve Cloud, in preview**. Dropped the Enterprise and self-hosted framing, including the `O2_SYNTHETICS_ENABLED` enable step and the "empty location registry" note that only applied to self-hosted.
- Merged the redundant "What is Synthetic Monitoring" and "Browser checks" sections on the concept page into one.

## What was deliberately kept

- **The URL path stays `/synthetics/`.** No redirects needed, existing links keep working.
- **On-screen labels are kept verbatim**, because the product still shows them: the **Synthetic** nav item, the **Synthetic Checks** page title, and the **OpenObserve Synthetics Recorder** browser banner. Screenshots show these, so a step that renamed them would send readers looking for something that is not there.
- The `synthetics_results` stream name.

## Flag

The screenshots were taken on an instance whose badge reads **Edition: Enterprise**, but availability is documented as Cloud preview per the current go-to-market status. The UI is identical, so the screenshots are still accurate; only the availability statement reflects where the feature is offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)