### PR TITLE
docs: add unique meta descriptions to pages missing them

### DIFF
--- a/docs/administration/configuration/o2-k8s-operator/deploy-script.md
+++ b/docs/administration/configuration/o2-k8s-operator/deploy-script.md
@@ -1,3 +1,7 @@
+---
+description: "Deploy the OpenObserve Kubernetes operator using deploy.sh with options for install, uninstall, custom image and tag, dry-run, and certificate generation."
+---
+
 
 ## Main Deployment Script (deploy.sh)
 

--- a/docs/administration/configuration/o2-k8s-operator/manual-deployment.md
+++ b/docs/administration/configuration/o2-k8s-operator/manual-deployment.md
@@ -1,3 +1,7 @@
+---
+description: "Manually deploy the OpenObserve Kubernetes operator with kubectl by applying the namespace, CRDs, RBAC, ConfigMap, deployment, and webhook manifests in order."
+---
+
 
 ## Manual Deployment Process
 

--- a/docs/administration/configuration/o2-k8s-operator/o2-operator-features.md
+++ b/docs/administration/configuration/o2-k8s-operator/o2-operator-features.md
@@ -1,3 +1,7 @@
+---
+description: "Manage OpenObserve Enterprise alerts, pipelines, functions, destinations, templates, and configs as Kubernetes CRDs with GitOps, HA, and VRL function support."
+---
+
 # OpenObserve Kubernetes Operator Features
 
 ## Overview

--- a/docs/administration/configuration/o2-k8s-operator/o2-operator-troubleshoot.md
+++ b/docs/administration/configuration/o2-k8s-operator/o2-operator-troubleshoot.md
@@ -1,3 +1,7 @@
+---
+description: "Troubleshoot the OpenObserve operator with kubectl commands to list, patch, and delete stuck resources, remove finalizers, and fix reconciliation failures."
+---
+
 # OpenObserve Operator - Troubleshooting Guide
 
 This guide provides kubectl commands and procedures for manually managing OpenObserve resources when they become stuck or need manual intervention.

--- a/docs/administration/maintenance/operator-guide/index.md
+++ b/docs/administration/maintenance/operator-guide/index.md
@@ -1,3 +1,7 @@
+---
+description: "Operate and maintain OpenObserve with guides for systemd services, SIMD, mimalloc, the Grafana plugin, etcd maintenance and restore, and Nginx proxy setup."
+---
+
 Learn more:
 
 - [Systemd](systemd.md)

--- a/docs/administration/maintenance/storage-management/configure-multiple-storage-accounts.md
+++ b/docs/administration/maintenance/storage-management/configure-multiple-storage-accounts.md
@@ -1,3 +1,7 @@
+---
+description: "Configure multiple S3-compatible object storage accounts in OpenObserve using environment variables and stream strategies to route each stream to a bucket."
+---
+
 This guide explains how to configure OpenObserve to store data in multiple object storage accounts. It also covers how to set environment variables to specify which stream should be stored in each account.
 
 ## Why Use Multiple Object Storage Accounts

--- a/docs/administration/maintenance/storage-management/index.md
+++ b/docs/administration/maintenance/storage-management/index.md
@@ -1,3 +1,7 @@
+---
+description: "Configure how OpenObserve stores stream data and metadata, optimize object storage across accounts and providers, and bring your own bucket for ingested data."
+---
+
 The Storage Management section helps you configure how OpenObserve stores ingested stream data and metadata. It also includes guidance on optimizing storage across different object storage accounts or providers.
 
 **Learn more:**

--- a/docs/features/distributed-tracing.md
+++ b/docs/features/distributed-tracing.md
@@ -1,3 +1,7 @@
+---
+description: "Track requests across microservices with OpenObserve distributed tracing: OpenTelemetry-native ingestion, Gantt views, service maps, and fast trace search."
+---
+
 # Distributed Tracing
 
 OpenObserve provides powerful distributed tracing capabilities that enable you to track requests as they flow through your microservices architecture, identify performance bottlenecks, and troubleshoot complex distributed systems with ease.

--- a/docs/features/frontend.md
+++ b/docs/features/frontend.md
@@ -1,3 +1,7 @@
+---
+description: "Monitor real user experience with OpenObserve frontend observability: Core Web Vitals, JavaScript error tracking, and session replay via a lightweight SDK."
+---
+
 # Frontend Observability
 
 OpenObserve provides robust frontend observability tools that help monitor user experience, track performance metrics, and capture errors in web applications. With minimal overhead, you can gain deep visibility into how users interact with your frontend—ensuring smooth performance across devices and browsers.

--- a/docs/features/upcoming.md
+++ b/docs/features/upcoming.md
@@ -1,3 +1,7 @@
+---
+description: "The OpenObserve product roadmap: upcoming features across logs, metrics, traces, RUM, error tracking, and session replay, shaped by the community on GitHub."
+---
+
 # Product Roadmap
 
 Our vision is to build the most performant and cost-effective observability platform that scales from startup to enterprise. We're committed to delivering lightning-fast analytics across logs, metrics, traces, RUM, error tracking, and session replay while keeping your storage costs 140x lower than traditional solutions.

--- a/docs/ingestion/ingestion-format-support.md
+++ b/docs/ingestion/ingestion-format-support.md
@@ -1,3 +1,7 @@
+---
+description: "Ingest logs into OpenObserve in JSON or HEC format through simple cURL endpoints, making it easy to migrate from Splunk or ship HEC-formatted log files."
+---
+
 OpenObserve supports ingestion in both JSON and HEC formats. 
 
 === "Ingest JSON-formatted Logs"

--- a/docs/integration/ai/custom-toolsets.md
+++ b/docs/integration/ai/custom-toolsets.md
@@ -1,3 +1,7 @@
+---
+description: "Extend the OpenObserve AI agent with organization-scoped custom toolsets: MCP servers, CLI tools, Markdown skills, and generic configs for the SRE Agent."
+---
+
 # Custom AI Toolsets
 
 Custom AI Toolsets let you define organization-scoped tools and skills that the OpenObserve AI agent loads into its set of available capabilities, so the SRE Agent and AI Assistant can act on systems and knowledge specific to your environment.

--- a/docs/integration/ai/llm-applications.md
+++ b/docs/integration/ai/llm-applications.md
@@ -1,3 +1,7 @@
+---
+description: "Monitor, trace, and debug LLM apps in production with OpenObserve and OpenTelemetry: track token usage, latency, cost, model metadata, and errors per call."
+---
+
 # **LLM Observability with OpenObserve**
 
 Monitor, trace, and debug your LLM-powered applications in production using OpenObserve and OpenTelemetry.

--- a/docs/integration/ai/llm-evaluations.md
+++ b/docs/integration/ai/llm-evaluations.md
@@ -1,3 +1,7 @@
+---
+description: "Continuously score LLM traces and spans in OpenObserve with online evaluations using LLM-as-a-judge or remote scorers, score configs, and managed eval jobs."
+---
+
 # LLM Evaluations
 
 Online Evaluations let you continuously score your LLM application's traces and spans using configurable evaluators - either LLM-as-a-judge powered by your own AI providers, or external remote scoring endpoints.

--- a/docs/integration/ai/model-pricing.md
+++ b/docs/integration/ai/model-pricing.md
@@ -1,3 +1,7 @@
+---
+description: "Define per-organization LLM model pricing in OpenObserve to compute token costs on traces, enriching every LLM span with input, output, and total cost fields."
+---
+
 # Model Pricing
 
 Model Pricing lets you define per-organization LLM pricing so OpenObserve can compute token costs directly on your traces. With it enabled, every LLM span is enriched with cost fields derived from the model name and token usage.

--- a/docs/integration/cloud/cloudflare.md
+++ b/docs/integration/cloud/cloudflare.md
@@ -1,3 +1,7 @@
+---
+description: "Stream Cloudflare HTTP request logs, response codes, and security events into OpenObserve using the GraphQL API or Logpush to monitor traffic and threats."
+---
+
 # Integration with Cloudflare
 This guide provides step-by-step instructions to integrate Cloudflare with OpenObserve.
 

--- a/docs/integration/security/index.md
+++ b/docs/integration/security/index.md
@@ -1,3 +1,7 @@
+---
+description: "Integrate security data sources with OpenObserve to centralize audit logs, identity activity, and security events for unified compliance and anomaly detection."
+---
+
 The following user guides provide step-by-step instructions to integrate **security data sources** with OpenObserve.  
 These integrations allow you to centralize audit logs, identity activity, and security events, giving you unified visibility into compliance, authentication, and anomaly detection.
 

--- a/docs/migration/migrate-file-list-partition.md
+++ b/docs/migration/migrate-file-list-partition.md
@@ -1,3 +1,7 @@
+---
+description: "Manually migrate PostgreSQL file_list tables to partitioned tables in OpenObserve when auto-migration is held, with step-by-step SQL and sequence alignment."
+---
+
 # Migration Guide: PostgreSQL `file_list` Partition Upgrade
 
 > For the version > v0.60.x, Please upgrade to v0.60.x first if you are using old version.

--- a/docs/overview/guiding-principles.md
+++ b/docs/overview/guiding-principles.md
@@ -1,3 +1,7 @@
+---
+description: "OpenObserve's core principles: instant value in minutes, self-healing operations, unified logs, metrics and traces, low costs, and real-world performance."
+---
+
 # Our Principles
 
 We are building the best observability software in the world. These principles guide every decision we make:

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -1,3 +1,7 @@
+---
+description: "Meet OpenObserve (O2): enterprise-grade observability at up to 140x lower storage cost than Elasticsearch, with petabyte scale, SIMD speed, and one unified UI."
+---
+
 # OpenObserve: Introduction
 
 ## What Is OpenObserve?

--- a/docs/reference/api/ingestion/index.md
+++ b/docs/reference/api/ingestion/index.md
@@ -1,3 +1,7 @@
+---
+description: "Ingest logs, metrics, and traces into OpenObserve using ingestion APIs: Bulk, JSON, and Multi for logs, Prometheus and JSON for metrics, and OTLP for traces."
+---
+
 # API Index - Ingestion
 
 ## Logs

--- a/docs/reference/api/ingestion/logs/index.md
+++ b/docs/reference/api/ingestion/logs/index.md
@@ -1,3 +1,7 @@
+---
+description: "Ingest logs into OpenObserve through multiple APIs, including Elasticsearch-compatible Bulk, JSON, Multi-line, Loki, and OTLP endpoints for log ingestion."
+---
+
 # API Index - Logs Ingestion
 
 1. [Bulk](bulk.md)

--- a/docs/reference/api/ingestion/metrics/index.md
+++ b/docs/reference/api/ingestion/metrics/index.md
@@ -1,3 +1,7 @@
+---
+description: "Ingest metrics into OpenObserve using the Prometheus remote write API or the JSON endpoint to send time-series metric data from your monitored applications."
+---
+
 # API Index - Metrics Ingestion
 
 1. [Prometheus](prometheus.md)

--- a/docs/reference/api/ingestion/traces/index.md
+++ b/docs/reference/api/ingestion/traces/index.md
@@ -1,3 +1,7 @@
+---
+description: "Ingest distributed traces into OpenObserve using the OpenTelemetry OTLP protocol to capture spans and monitor request flows across your distributed services."
+---
+
 # API Index - Traces Ingestion
 
 1. [OTLP](otlp.md)

--- a/docs/reference/api/metrics.md
+++ b/docs/reference/api/metrics.md
@@ -1,3 +1,7 @@
+---
+description: "Expose OpenObserve's internal metrics in Prometheus format through the GET /metrics endpoint, enabled by setting ZO_PROMETHEUS_ENABLE=true for scraping."
+---
+
 # Metrics
 
 Get metrics of OpenObserve in prometheus format

--- a/docs/reference/api/search/index.md
+++ b/docs/reference/api/search/index.md
@@ -1,3 +1,7 @@
+---
+description: "Query OpenObserve data with the Search API, including full-text and SQL search, the values endpoint for field values, and around search for surrounding logs."
+---
+
 # API Index - Search
 
 1. [Search](search.md)

--- a/docs/reference/api/stream/index.md
+++ b/docs/reference/api/stream/index.md
@@ -1,3 +1,7 @@
+---
+description: "Manage OpenObserve streams through the Stream API to list streams, view stream schema, update stream settings, and delete streams and their stored data."
+---
+
 # API Index - Stream
 
 1. [List](list.md)

--- a/docs/reference/api/traces/index.md
+++ b/docs/reference/api/traces/index.md
@@ -1,3 +1,7 @@
+---
+description: "Search and retrieve distributed traces and spans from OpenObserve using the trace API, exploring the full execution path of requests across your services."
+---
+
 
 This documentation provides comprehensive guidance on using the OpenObserve API to search and retrieve traces from your application. Traces in OpenObserve represent the complete operational flow of requests through your system, showing the full tree of operations and their sub-operations (spans).
 

--- a/docs/reference/api/traces/trace-search-api.md
+++ b/docs/reference/api/traces/trace-search-api.md
@@ -1,3 +1,7 @@
+---
+description: "Retrieve the latest traces from OpenObserve with the GET traces/latest endpoint, using time range, pagination, and filter parameters to fetch trace spans."
+---
+
 ## Get Latest Traces
 
 Retrieve traces within a specified time range.

--- a/docs/reference/api/user/index.md
+++ b/docs/reference/api/user/index.md
@@ -1,3 +1,7 @@
+---
+description: "Manage OpenObserve users through the User API: create and update accounts, add users to and remove them from organizations, and list all existing users."
+---
+
 # API Index - User
 
 1. [Create](create.md)

--- a/docs/reference/sql-functions/approximate-aggregate/index.md
+++ b/docs/reference/sql-functions/approximate-aggregate/index.md
@@ -1,3 +1,7 @@
+---
+description: "Analyze high-cardinality data at scale in OpenObserve with approximate aggregate SQL functions like approx_topk and approx_topk_distinct for top-k results."
+---
+
 OpenObserve provides the following approximate aggregate functions designed for high-cardinality data analysis at scale.
 
 Learn more: 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,3 +1,7 @@
+---
+description: "A visual tour of the OpenObserve UI through screenshots: the home dashboard, log search, real-time and standard alerts, dashboards, streams, and users."
+---
+
 # Screenshots
 
 ## Home

--- a/docs/user-guide/account-administration/cloud-ai-credits.md
+++ b/docs/user-guide/account-administration/cloud-ai-credits.md
@@ -1,3 +1,7 @@
+---
+description: "AI Credits give every OpenObserve Cloud organization a shared free-credit pool for AI chat and incident analysis, with usage tracking and pay-as-you-go billing."
+---
+
 # AI Credits (Cloud)
 
 AI Credits are a shared pool of free credits that every OpenObserve Cloud organization can spend on AI-powered features such as AI chat and incident analysis.

--- a/docs/user-guide/account-administration/identity-and-access-management/index.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/index.md
@@ -1,3 +1,7 @@
+---
+description: "Manage user identities and access in OpenObserve with RBAC, single sign-on, Keycloak SSO, organizations, ingestion tokens, quotas, and user password controls."
+---
+
 The following guides provide details on managing user identities and controlling access to resources in OpenObserve. They include instructions for setting up Role-Based Access Control, managing users and groups, configuring permissions:
 
 - [Role-Based Access Control (RBAC)](role-based-access-control.md)

--- a/docs/user-guide/account-administration/identity-and-access-management/quotas/index.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/quotas/index.md
@@ -1,3 +1,7 @@
+---
+description: "Quotas set per-second rate limits on OpenObserve API requests like List, Get, Create, Update, and Delete, applied at the organization level or per role."
+---
+
 Quotas in OpenObserve are rate limiting mechanisms that let you control how many API requests users can make per second. You can use Quotas to define request-per-second (Req/s) limits for API operations such as **List**, **Get**, **Create**, **Update**, and **Delete**. 
 These limits can be applied in two ways, at org-level and at role-level.
 

--- a/docs/user-guide/account-administration/management/correlation-settings.md
+++ b/docs/user-guide/account-administration/management/correlation-settings.md
@@ -1,3 +1,7 @@
+---
+description: "Correlation Settings tune how OpenObserve maps logs, metrics, and traces to services using semantic field groups, field aliases, and service identity rules."
+---
+
 # Correlation Settings
 
 This page explains how to use Correlation Settings in OpenObserve. These organization-level settings control how OpenObserve correlates your telemetry, mapping logs, metrics, and traces to the services they belong to.

--- a/docs/user-guide/account-administration/management/general-settings.md
+++ b/docs/user-guide/account-administration/management/general-settings.md
@@ -1,3 +1,7 @@
+---
+description: "General Settings configure OpenObserve scrape interval, light and dark theme colors, usage stream, and Enterprise branding like custom logo and logo text."
+---
+
 ## General settings
 This page explains how to use the settings available under General Settings in OpenObserve. These settings allow you to configure scrape interval, theme colors, and Enterprise branding. 
 

--- a/docs/user-guide/account-administration/management/index.md
+++ b/docs/user-guide/account-administration/management/index.md
@@ -1,3 +1,7 @@
+---
+description: "Management tools in OpenObserve cover streaming search, query management, alert destinations, templates, audit trails, cipher keys, nodes, and data redaction."
+---
+
 The Management section includes tools for maintaining and securing OpenObserve operations. It allows users to manage saved queries, configure alert destinations, create reusable templates, review audit trails, handle encryption keys, and monitor node-level performance and resource metrics.
 
 !!! note "Learn more"

--- a/docs/user-guide/account-administration/management/lincense.md
+++ b/docs/user-guide/account-administration/management/lincense.md
@@ -1,3 +1,7 @@
+---
+description: "OpenObserve Enterprise license page to view, request, add, and update license keys, set daily ingestion capacity, and manage license access by user role."
+---
+
 This page explains how OpenObserve Enterprise licenses work and how users can view, request, add, and update licenses. The guide is role based so that each user clearly understands what they can do and how to do it.
 
 ## Overview 

--- a/docs/user-guide/account-administration/profile/index.md
+++ b/docs/user-guide/account-administration/profile/index.md
@@ -1,3 +1,7 @@
+---
+description: "The Profile section in OpenObserve lets users view their identity details, choose the user interface language, and access sign-out controls from one place."
+---
+
 The **Profile** section enables users to view their identity information, select the user interface language, and access sign-out controls.
 
 **Learn more**:

--- a/docs/user-guide/advanced/best-practices/index.md
+++ b/docs/user-guide/advanced/best-practices/index.md
@@ -1,3 +1,7 @@
+---
+description: "Best practices for deploying and managing OpenObserve, including preventing UI crashes from large queries and ensuring your S3 storage configuration is correct."
+---
+
 Use these best practices to make informed decisions when deploying and managing OpenObserve: 
 
 - [Prevent UI Crashes From Large Queries](prevent-ui-crashes-from-large-queries.md)

--- a/docs/user-guide/advanced/query-tuning/broadcast-join.md
+++ b/docs/user-guide/advanced/query-tuning/broadcast-join.md
@@ -1,6 +1,6 @@
 ---
 title: Broadcast Join - OpenObserve Query Optimization Feature
-description: Broadcast join in OpenObserve: 43% faster queries, 99.9% less network transfer. Automatic optimization for enrichment tables and subqueries.
+description: "Broadcast join in OpenObserve: 43% faster queries, 99.9% less network transfer. Automatic optimization for enrichment tables and subqueries."
 ---
 
 This document explains how broadcast join works as an automatic query optimization feature in OpenObserve. 

--- a/docs/user-guide/advanced/query-tuning/index.md
+++ b/docs/user-guide/advanced/query-tuning/index.md
@@ -1,3 +1,7 @@
+---
+description: "Optimize OpenObserve query performance and resource usage with the download manager, disk cache metrics, cache eviction strategies, and the Tantivy index."
+---
+
 The Performance section provides tools and configurations to optimize query execution and resource usage in OpenObserve. It includes documentation for managing the download queue, monitoring disk cache utilization, and setting disk cache eviction strategies. 
 
 **Learn more:** 

--- a/docs/user-guide/advanced/query-tuning/result-cache.md
+++ b/docs/user-guide/advanced/query-tuning/result-cache.md
@@ -1,3 +1,7 @@
+---
+description: "Result cache stores query results locally on each OpenObserve node using consistent hashing, cutting network overhead and speeding up repeated query response."
+---
+
 ## Overview
 Previously, when a query was executed, the system used gRPC calls to check whether other nodes in the cluster already had cached results for that query. This required distributed coordination across all nodes.<br>
 OpenObserve now implements a local result caching system that improves query performance by storing query results on the same node where the query is executed. The caching system relies on **consistent hashing**, which ensures that identical queries are always routed to the same node. This deterministic routing enables each node to maintain and reuse its own cached results without requiring cross-node communication. <br>

--- a/docs/user-guide/analytics/alerts/alert-history.md
+++ b/docs/user-guide/analytics/alerts/alert-history.md
@@ -1,3 +1,7 @@
+---
+description: "Alert History records every alert evaluation in OpenObserve's triggers stream, letting you read status codes and retries and debug failed or skipped alerts."
+---
+
 
 This guide provides information about how the Alert History feature in OpenObserve works, where the data originates from, who can access it, how to interpret the Alert History table, and how to debug failed or skipped alerts.
 

--- a/docs/user-guide/analytics/alerts/anomaly-detection.md
+++ b/docs/user-guide/analytics/alerts/anomaly-detection.md
@@ -1,3 +1,7 @@
+---
+description: "Anomaly Detection uses Random Cut Forest machine learning to flag unusual patterns in logs, metrics, and traces automatically, with no manual threshold tuning."
+---
+
 # Anomaly Detection
 
 Anomaly Detection automatically identifies unusual patterns in your data streams using machine learning, alerting you to deviations before they become incidents.

--- a/docs/user-guide/analytics/dashboards/config/index.md
+++ b/docs/user-guide/analytics/dashboards/config/index.md
@@ -1,3 +1,7 @@
+---
+description: "The Config tab customizes OpenObserve dashboard panel behavior, layout, and appearance through collapsible sections for legend, data, axis, labels, and more."
+---
+
 The Config tab in OpenObserve dashboards allows users to customize the behavior, layout, and appearance of individual panels.
 
 The **Config** tab is organized into collapsible sections (General, Legend, Data, Axis, Labels, and more). Use the **Search config** bar at the top to filter settings by name, and the expand/collapse toggle to open or close all sections at once.

--- a/docs/user-guide/analytics/dashboards/config/legend-and-gridline.md
+++ b/docs/user-guide/analytics/dashboards/config/legend-and-gridline.md
@@ -1,3 +1,7 @@
+---
+description: "Legend and gridline settings control legend position, type, height, width, chart alignment, gridline visibility, and axis label rotation in OpenObserve panels."
+---
+
 This document describes the legend and gridline configuration options available in OpenObserve dashboard panels.
 
 ## Overview

--- a/docs/user-guide/analytics/dashboards/custom-charts/custom-charts-for-metrics-using-multiple-promql-queries.md
+++ b/docs/user-guide/analytics/dashboards/custom-charts/custom-charts-for-metrics-using-multiple-promql-queries.md
@@ -1,3 +1,7 @@
+---
+description: "Add multiple PromQL queries to one custom chart panel to compare related metrics, looping each query's results to plot combined series or dual-axis charts."
+---
+
 This guide extends the previous page on [building custom charts using a single PromQL query](https://openobserve.ai/docs/user-guide/analytics/dashboards/custom-charts/custom-charts-for-metrics-using-promql/).
 You will now learn how to add multiple PromQL queries in the same panel, inspect their combined results, and build a chart that displays the output of several queries together.
 

--- a/docs/user-guide/analytics/dashboards/custom-charts/custom-charts-for-metrics-using-promql.md
+++ b/docs/user-guide/analytics/dashboards/custom-charts/custom-charts-for-metrics-using-promql.md
@@ -1,3 +1,7 @@
+---
+description: "Build custom metric charts with a single PromQL query, transforming the matrix JSON response into timestamp-value pairs to render line, bar, or scatter charts."
+---
+
 This guide explains how to build custom charts for metrics in OpenObserve using PromQL. The goal is to help new and advanced users understand how raw metrics data transforms into a fully rendered chart through predictable and repeatable steps.
 
 ## How metric data flows into a chart

--- a/docs/user-guide/analytics/dashboards/filters/filters.md
+++ b/docs/user-guide/analytics/dashboards/filters/filters.md
@@ -1,3 +1,7 @@
+---
+description: "Filters narrow dashboard panel data using static list values, dynamic variables, and operators, combining conditions with AND or OR logic in nested groups."
+---
+
 This guide provides instructions on how to apply filters to narrow the data shown in a dashboard panel by using fixed values, referencing dynamic variables, or combining multiple conditions with logical operators.
 
 ## When to Use Filters

--- a/docs/user-guide/analytics/dashboards/filters/index.md
+++ b/docs/user-guide/analytics/dashboards/filters/index.md
@@ -1,0 +1,4 @@
+---
+description: "Dashboard filters narrow panel data by fixed values, dynamic variables, or logical conditions, making OpenObserve dashboards interactive and focused on data."
+---
+

--- a/docs/user-guide/analytics/dashboards/panels/index.md
+++ b/docs/user-guide/analytics/dashboards/panels/index.md
@@ -1,3 +1,7 @@
+---
+description: "Panels are the building blocks of OpenObserve dashboards; manage the panel toolbar, run multi-query visualizations, and troubleshoot common panel issues."
+---
+
 This section provides complete guidance on using and managing panels in the dashboard. It is intended for users who want to understand the panel toolbar features and troubleshoot common panel-related issues.
 
 **Learn more:**

--- a/docs/user-guide/analytics/dashboards/panels/panel-management.md
+++ b/docs/user-guide/analytics/dashboards/panels/panel-management.md
@@ -1,3 +1,7 @@
+---
+description: "Manage dashboard panels with toolbar controls for full screen, refresh, edit layout, resize, duplicate, move, query inspector, CSV/JSON export, and annotations."
+---
+
 This guide explains how to use and manage panels in the dashboard. It includes features available in the panel toolbar, step-by-step instructions, and troubleshooting tips for common issues.
 
 The panel toolbar offers the following controls to adjust, organize, and customize your panels:

--- a/docs/user-guide/analytics/dashboards/panels/table-chart.md
+++ b/docs/user-guide/analytics/dashboards/panels/table-chart.md
@@ -1,3 +1,7 @@
+---
+description: "Table chart panels display query results as tables with per-column formatting, units, conditional styling, Excel-style column filtering, and pagination."
+---
+
 # Table Chart
 
 Table chart panels display query results as a tabular view, with support for per-column formatting, Excel-style column filtering, and pagination.

--- a/docs/user-guide/analytics/dashboards/panels/troubleshooting.md
+++ b/docs/user-guide/analytics/dashboards/panels/troubleshooting.md
@@ -1,3 +1,7 @@
+---
+description: "Troubleshoot dashboard panel warnings and errors, including restricted query range, cached data, series limits, and incomplete data from interrupted queries."
+---
+
 This page provides instructions on the warning or error icons displayed on the panel toolbar, explains how to identify and troubleshoot these warnings. 
 
 ??? "1. Error: When the query duration is modified due to the query range is restricted"

--- a/docs/user-guide/analytics/dashboards/variables/variable-types.md
+++ b/docs/user-guide/analytics/dashboards/variables/variable-types.md
@@ -1,3 +1,7 @@
+---
+description: "OpenObserve dashboard variable types include Query Values, Constant, Textbox, and Custom, each with configuration and use cases for dynamic panel filtering."
+---
+
 This page describes the types of [variables](./variables-in-openobserve.md), their use cases, and the configuration required for each type.
 
 OpenObserve supports the following variable types:

--- a/docs/user-guide/analytics/dashboards/variables/variables-in-openobserve.md
+++ b/docs/user-guide/analytics/dashboards/variables/variables-in-openobserve.md
@@ -1,3 +1,7 @@
+---
+description: "Dashboard variables filter OpenObserve panels dynamically; create them, apply to panels, and use substitution syntax, multi-select, type-ahead, and defaults."
+---
+
 This page provides a comprehensive overview of variables in OpenObserve dashboards, including instructions on how to create your first variable, apply it to panels, and configure different variable options. 
 
 ## What Are Variables?

--- a/docs/user-guide/analytics/incidents/index.md
+++ b/docs/user-guide/analytics/incidents/index.md
@@ -1,3 +1,7 @@
+---
+description: "Incident Management correlates related alert firings into unified incidents with AI root cause analysis, alert graphs, and correlated logs, metrics, and traces."
+---
+
 # Incident Management
 
 Incident Management automatically groups related alert firings into unified incidents, reducing alert noise and helping you focus on root causes instead of individual alerts.

--- a/docs/user-guide/analytics/reports/index.md
+++ b/docs/user-guide/analytics/reports/index.md
@@ -1,3 +1,7 @@
+---
+description: "Reports schedule recurring PDF, PNG, or CSV exports of OpenObserve dashboards, delivered by email with folders, inline or file attachments, and custom sizes."
+---
+
 The Reports section allows users to create and manage recurring reports from dashboard visualizations. Reports can be configured as either Scheduled or Cached.
 
 ## Organize reports into folders

--- a/docs/user-guide/data-exploration/auto-run-query.md
+++ b/docs/user-guide/data-exploration/auto-run-query.md
@@ -1,3 +1,7 @@
+---
+description: "Auto Run re-executes your Logs and Traces search automatically when you change the stream, time range, filters, or function, skipping the Run query click."
+---
+
 # Auto Run
 
 Auto Run automatically re-executes your search whenever you change a query input, so you see updated results without clicking **Run query**. It is available on the **Logs** and **Traces** search bars.

--- a/docs/user-guide/data-exploration/cross-linking.md
+++ b/docs/user-guide/data-exploration/cross-linking.md
@@ -1,3 +1,7 @@
+---
+description: "Cross-Linking creates drill-down links from log records, trace records, and dashboard panels to external URLs using templates that substitute field values."
+---
+
 # Cross-Linking
 
 Cross-Linking lets you define drill-down links that take you from a log or trace record, or a dashboard panel, directly to an external URL. Use it to connect OpenObserve data with related systems such as APM tools, ticketing systems, runbooks, or internal dashboards.

--- a/docs/user-guide/data-exploration/logs/insights.md
+++ b/docs/user-guide/data-exploration/logs/insights.md
@@ -1,3 +1,7 @@
+---
+description: "Insights automates root cause analysis by comparing anomaly periods against baseline across dimensions, ranking which factors drive changes in logs and traces."
+---
+
 # Insights: Interactive Dimension Analysis
 
 ## Overview

--- a/docs/user-guide/data-exploration/logs/refresh-cache-run-query.md
+++ b/docs/user-guide/data-exploration/logs/refresh-cache-run-query.md
@@ -1,3 +1,7 @@
+---
+description: "Refresh Cache and Run Query clears outdated cached results and re-runs your query against the latest data, fixing gaps from delayed ingestion or cache issues."
+---
+
 # Refresh Cache and Run Query
 
 ## Overview

--- a/docs/user-guide/data-exploration/metrics/index.md
+++ b/docs/user-guide/data-exploration/metrics/index.md
@@ -1,3 +1,7 @@
+---
+description: "Metrics in OpenObserve store and query time-series data efficiently, with guides covering file access time behavior and downsampling to reduce storage costs."
+---
+
 #Metrics Overview
 
 Learn more:

--- a/docs/user-guide/data-exploration/rum/advanced-features.md
+++ b/docs/user-guide/data-exploration/rum/advanced-features.md
@@ -1,3 +1,7 @@
+---
+description: "Advanced RUM features let you attach global and view context, add custom timings, manage tracking consent, tune sampling, and filter events with beforeSend."
+---
+
 # Advanced Features
 
 This guide covers advanced RUM features for power users who want to get the most out of OpenObserve RUM monitoring.

--- a/docs/user-guide/data-exploration/rum/best-practices.md
+++ b/docs/user-guide/data-exploration/rum/best-practices.md
@@ -1,3 +1,7 @@
+---
+description: "RUM best practices for production: initialize early, optimize sampling for cost, protect PII, manage consent, filter error noise, and a deployment checklist."
+---
+
 # Best Practices
 
 This guide covers production-ready best practices for deploying and managing OpenObserve RUM at scale.

--- a/docs/user-guide/data-exploration/rum/error-tracking.md
+++ b/docs/user-guide/data-exploration/rum/error-tracking.md
@@ -1,3 +1,7 @@
+---
+description: "RUM error tracking automatically captures frontend JavaScript, network, and resource errors with stack traces, then links each one to its session replay."
+---
+
 # Error Tracking
 
 Error tracking is crucial for maintaining application quality and user experience. Unlike server-side errors, frontend errors often go unnoticed unless you have proper monitoring in place. OpenObserve RUM automatically captures and tracks all frontend errors, giving you complete visibility into issues affecting your users.

--- a/docs/user-guide/data-exploration/rum/index.md
+++ b/docs/user-guide/data-exploration/rum/index.md
@@ -1,3 +1,7 @@
+---
+description: "Real User Monitoring (RUM) is OpenObserve's frontend solution bundling performance metrics, session tracking, error tracking, and session replay in one place."
+---
+
 Real User Monitoring (RUM) is a comprehensive frontend monitoring solution that helps you understand how real users experience your application in production. RUM captures actual user interactions, performance metrics, errors, and sessions as they happen in real-world conditions.
 
 **Learn more:**

--- a/docs/user-guide/data-exploration/rum/metrics-reference.md
+++ b/docs/user-guide/data-exploration/rum/metrics-reference.md
@@ -1,3 +1,7 @@
+---
+description: "Complete reference of every RUM metric OpenObserve collects: Web Vitals, navigation and resource timing, user actions, session, error, and custom metrics."
+---
+
 # Metrics Reference
 
 This document provides a comprehensive reference of all metrics collected by OpenObserve RUM. Understanding these metrics will help you analyze and optimize your application's performance and user experience.

--- a/docs/user-guide/data-exploration/rum/overview.md
+++ b/docs/user-guide/data-exploration/rum/overview.md
@@ -1,3 +1,7 @@
+---
+description: "OpenObserve RUM captures real user sessions in production, recording actual interactions, performance metrics, and errors across every device and browser."
+---
+
 # RUM (Real User Monitoring) - Overview
 
 ## What is RUM?

--- a/docs/user-guide/data-exploration/rum/performance-monitoring.md
+++ b/docs/user-guide/data-exploration/rum/performance-monitoring.md
@@ -1,3 +1,7 @@
+---
+description: "RUM performance monitoring tracks Core Web Vitals like LCP, FID, and CLS plus page load, API response times, and slow resources in a real-time dashboard."
+---
+
 # Performance Monitoring
 
 Performance monitoring helps you understand how fast your application loads and responds for real users. OpenObserve RUM tracks various performance metrics automatically and displays them in an easy-to-understand dashboard.

--- a/docs/user-guide/data-exploration/rum/session-replay.md
+++ b/docs/user-guide/data-exploration/rum/session-replay.md
@@ -1,3 +1,7 @@
+---
+description: "RUM session replay reconstructs user sessions as video-like playback, showing every click, scroll, and error so you can watch exactly what led to a bug."
+---
+
 # Session Replay
 
 Session replay is one of the most powerful features of OpenObserve RUM. It allows you to watch a video-like playback of user sessions, showing exactly what users saw and did in your application. This is invaluable for debugging issues, understanding user behavior, and improving user experience.

--- a/docs/user-guide/data-exploration/rum/sessions.md
+++ b/docs/user-guide/data-exploration/rum/sessions.md
@@ -1,3 +1,7 @@
+---
+description: "RUM session tracking captures complete user journeys, showing session duration, page views, errors, and device or location for every visit to your app."
+---
+
 # Session Tracking
 
 Session tracking helps you understand user behavior by capturing complete user journeys through your application. A session represents a single visit by a user, from the moment they land on your site until they leave or become inactive.

--- a/docs/user-guide/data-exploration/rum/setup.md
+++ b/docs/user-guide/data-exploration/rum/setup.md
@@ -1,3 +1,7 @@
+---
+description: "RUM setup installs the OpenObserve browser SDK, configures your client token, and initializes monitoring in React, Vue, Angular, or vanilla JavaScript apps."
+---
+
 # RUM Setup Guide
 
 This guide will walk you through setting up OpenObserve RUM in your web application.

--- a/docs/user-guide/data-exploration/rum/troubleshooting-guide.md
+++ b/docs/user-guide/data-exploration/rum/troubleshooting-guide.md
@@ -1,3 +1,7 @@
+---
+description: "Troubleshoot common RUM problems such as no data appearing, session replay not recording, missing errors, high data volume, and browser compatibility issues."
+---
+
 # Troubleshooting Guide
 
 This guide helps you diagnose and resolve common issues with OpenObserve RUM.

--- a/docs/user-guide/data-exploration/rum/use-cases.md
+++ b/docs/user-guide/data-exploration/rum/use-cases.md
@@ -1,3 +1,7 @@
+---
+description: "Real-world RUM use cases with code for e-commerce checkout flows, SaaS feature usage, conversion funnels, A/B testing, and performance budget monitoring."
+---
+
 # Use Cases and Real-World Examples
 
 This guide demonstrates practical applications of OpenObserve RUM in real-world scenarios. Each use case includes complete implementation examples and analysis strategies.

--- a/docs/user-guide/data-exploration/traces/index.md
+++ b/docs/user-guide/data-exploration/traces/index.md
@@ -1,3 +1,7 @@
+---
+description: "Traces in OpenObserve show how requests flow across services in distributed systems, helping you pinpoint performance bottlenecks and troubleshoot errors."
+---
+
 Traces help you understand how requests flow across services, identify performance bottlenecks, and troubleshoot errors in distributed systems.
 
 !!! note "Learn more"

--- a/docs/user-guide/data-exploration/traces/service-catalog.md
+++ b/docs/user-guide/data-exploration/traces/service-catalog.md
@@ -1,3 +1,7 @@
+---
+description: "Service Catalog is a sortable per-service table built from distributed traces, summarizing request volume, error rate, and latency percentiles to rank health."
+---
+
 === "Overview"
     Service Catalog provides a per-service metrics table built from your distributed traces. It summarizes request volume, error behaviour, and latency for every service in the selected trace stream so that you can compare services side by side and decide where to investigate next.
 

--- a/docs/user-guide/data-exploration/traces/service-graph.md
+++ b/docs/user-guide/data-exploration/traces/service-graph.md
@@ -1,3 +1,7 @@
+---
+description: "Service Graph visualizes how services communicate as a real-time topology from distributed traces, with health colors, call edges, and inferred dependencies."
+---
+
 === "Overview"
     Service graph provides a real time visual overview of how your services communicate with each other. It reads distributed traces and identifies which services call downstream services, how many requests flow between them, and how healthy those interactions are.
 

--- a/docs/user-guide/data-processing/actions/index.md
+++ b/docs/user-guide/data-processing/actions/index.md
@@ -1,3 +1,7 @@
+---
+description: "Actions in OpenObserve are user-defined Python scripts that automate custom workflows, run against log data from the Logs UI, or serve as alert destinations."
+---
+
 **Actions** in OpenObserve are user-defined Python scripts that support custom automation workflows. They can be applied to log data directly from the Logs UI or used as alert destinations. 
 
 **Learn more:**

--- a/docs/user-guide/data-processing/enrichment-tables/enrichment-example.md
+++ b/docs/user-guide/data-processing/enrichment-tables/enrichment-example.md
@@ -1,3 +1,7 @@
+---
+description: "Enrich log data in OpenObserve using VRL functions and CSV enrichment tables, with hands-on examples for protocol lookups and MaxMind GeoIP location data."
+---
+
 # Enrichment Examples
 
 ## Introduction 

--- a/docs/user-guide/data-processing/enrichment-tables/index.md
+++ b/docs/user-guide/data-processing/enrichment-tables/index.md
@@ -1,3 +1,7 @@
+---
+description: "Enrichment tables in OpenObserve add context to log data by joining it with external reference data uploaded as CSV, used during ingestion or at query time."
+---
+
 Enrichment tables in OpenObserve allow you to add meaningful context to your log data by joining it with external reference data. These tables are uploaded as CSV files and can be used during ingestion or at query time to add or modify fields.
 
 Learn more: 

--- a/docs/user-guide/data-processing/opentelemetry/openobserve-python-sdk.md
+++ b/docs/user-guide/data-processing/opentelemetry/openobserve-python-sdk.md
@@ -1,3 +1,7 @@
+---
+description: "OpenObserve's Python SDK exports OpenTelemetry logs, metrics, and traces with minimal setup, plus auto-instrumentation for OpenAI, Anthropic, and LangChain."
+---
+
 # OpenObserve Telemetry SDK
 
 A simple and lightweight Python SDK for exporting OpenTelemetry logs, metrics, and traces to [OpenObserve](https://openobserve.ai/).

--- a/docs/user-guide/data-processing/pipelines/create-and-use-real-time-pipeline.md
+++ b/docs/user-guide/data-processing/pipelines/create-and-use-real-time-pipeline.md
@@ -1,3 +1,7 @@
+---
+description: "Create real-time pipelines in OpenObserve to process data instantly on ingestion, applying conditions and functions to filter and route events to destinations."
+---
+
 Use this guide to create and run real-time pipelines. Real-time pipelines process data immediately after it is ingested into a source stream. They allow you to apply conditions and functions and then route the processed data to one or more destinations.
 
 > Visit the [Pipelines in OpenObserve](https://openobserve.ai/docs/user-guide/data-processing/pipelines/pipelines/) page before starting. It explains pipeline concepts, types, and components used in this guide.

--- a/docs/user-guide/data-processing/pipelines/create-and-use-scheduled-pipeline.md
+++ b/docs/user-guide/data-processing/pipelines/create-and-use-scheduled-pipeline.md
@@ -1,3 +1,7 @@
+---
+description: "Create scheduled pipelines in OpenObserve that run at set intervals, querying data with SQL or PromQL to transform and load results into a destination stream."
+---
+
 Use this guide to create and run scheduled pipelines. Scheduled pipelines run at a fixed interval. They query existing data from a stream using SQL or PromQL, apply optional transformations, and write the results to a destination stream or external system.
 
 > Visit the [Pipelines overview](https://openobserve.ai/docs/user-guide/data-processing/pipelines/pipelines/) page before starting. 

--- a/docs/user-guide/data-processing/pipelines/index.md
+++ b/docs/user-guide/data-processing/pipelines/index.md
@@ -1,3 +1,7 @@
+---
+description: "OpenObserve pipelines read data from a source, transform it, and write to a destination; compare real-time and scheduled types and when to use each one."
+---
+
 In OpenObserve, pipelines are data processing workflows used to transform logs, metrics, or traces during ingestion or before storage.
 
 **Learn more:**

--- a/docs/user-guide/data-processing/pipelines/pipeline-history.md
+++ b/docs/user-guide/data-processing/pipelines/pipeline-history.md
@@ -1,3 +1,7 @@
+---
+description: "Pipeline History in OpenObserve tracks every pipeline run with execution time, status, duration, retries, and error details to help monitor and debug failures."
+---
+
 This guide provides information about how the Pipeline History feature in OpenObserve works, where the data originates from, who can access it, and how to interpret the pipeline execution records.
 
 > For information on other pipeline management options, see the [Manage Pipelines](manage-pipelines.md) page. 

--- a/docs/user-guide/data-processing/pipelines/pipelines.md
+++ b/docs/user-guide/data-processing/pipelines/pipelines.md
@@ -1,3 +1,7 @@
+---
+description: "Pipelines in OpenObserve are data processing workflows that transform, filter, and route logs, metrics, and traces during ingestion or before storage."
+---
+
 This page provides an overview of pipelines, their types, and how they work.<br>
 
 ## Overview

--- a/docs/user-guide/data-processing/streams/data-type-and-index-type-in-streams.md
+++ b/docs/user-guide/data-processing/streams/data-type-and-index-type-in-streams.md
@@ -1,3 +1,7 @@
+---
+description: "Define stream fields in OpenObserve with data types (utf8, int64, boolean) and index types like full-text search, bloom filter, and partitions to speed queries."
+---
+
 This guide explains how to define and configure stream fields in OpenObserve, including supported field types and index options. 
 
 

--- a/docs/user-guide/data-processing/streams/index.md
+++ b/docs/user-guide/data-processing/streams/index.md
@@ -1,3 +1,7 @@
+---
+description: "Streams in OpenObserve define how observability data is ingested, stored, indexed, and queried, covering stream details, schema settings, and retention."
+---
+
 Streams define how observability data is ingested, stored, indexed, and queried in OpenObserve. This guide introduces key concepts related to streams and explains how to create and use them.
 
 !!! note "Learn more:" 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,3 +1,7 @@
+---
+description: "OpenObserve User Guide covering log search, metrics, RUM, organizations, users, streams, ingestion, pipelines, alerts, dashboards, functions, and management."
+---
+
 # User Guide
 
 1. [Log Search](data-exploration/logs/index.md)

--- a/docs/user-guide/users.md
+++ b/docs/user-guide/users.md
@@ -1,3 +1,7 @@
+---
+description: "Manage OpenObserve users by inviting members, creating accounts, assigning admin or member roles, and updating user details across one or many organizations."
+---
+
 # Users
 Users are individuals using OpenObserve by logging in with appropriate credentials. 
 


### PR DESCRIPTION
## What

Adds unique `description` frontmatter to **92 documentation pages** that had none, plus a fix to one page whose description was malformed.

## Why

Those 92 pages had no `description` and were all falling back to the site-wide `site_description`, so they shipped the **same duplicate meta description** — a real SEO weakness (no page-specific snippet, duplicate-description signal across the docs). Additionally, `broadcast-join.md` had an authored description but with an **unquoted colon** (`OpenObserve: 43%…`), which is invalid YAML — MkDocs silently discarded it and served the site default too.

## What changed

- **92 pages** → each gets a unique, **answer-first** meta description, **150–160 chars**, grounded in the page's actual content.
- **`broadcast-join.md`** → wrapped its existing description in quotes so the YAML parses and the page serves its own description.
- Scope: **meta descriptions only.** No content, nav, or template changes in this PR.

## Verification

- `mkdocs build` succeeds; every description renders into `<meta name="description">` (449/450 pages now carry a unique description, up from 358).
- All 92: verified 150–160 chars, **0 duplicates**, **0 generic openers**, valid YAML frontmatter.
- Descriptions fact-checked against each page body — no invented features or misrepresented scope.