### PR TITLE
fix(seo): keep meta titles and descriptions within search-result limits

### DIFF
--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -9,6 +9,7 @@ import { LlmPageActions } from '@/components/llm-page-actions';
 import { PageStructuredData } from '@/components/structured-data';
 import { Landing } from '@/components/landing';
 import { absoluteUrl, markdownUrl, SOCIAL_IMAGE } from '@/lib/constants';
+import { composeTitle } from '@/lib/seo';
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const params = await props.params;
@@ -101,8 +102,9 @@ export async function generateMetadata(props: {
   if (!page) notFound();
 
   // `metaTitle` preserves the long MkDocs <title>; `title` is the short sidebar
-  // label. See scripts/migration/convert-frontmatter.mjs.
-  const title = page.data.metaTitle ?? page.data.title;
+  // label. See scripts/migration/convert-frontmatter.mjs. Pages that have only
+  // the short label get the brand appended — see lib/seo.ts.
+  const title = composeTitle(page.data.metaTitle ?? page.data.title);
 
   return {
     title,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,8 +19,11 @@ export const metadata: Metadata = {
     default: 'OpenObserve Documentation',
     template: '%s',
   },
+  // Fallback for routes with no metadata of their own (the 404). Kept within the
+  // ~160-character search-result limit that scripts/check-seo.mjs enforces on
+  // doc pages; the previous wording ran to 197 and was truncated.
   description:
-    'OpenObserve (O2) is a cloud-native observability platform that unifies logs, metrics, and traces into a single solution, built for petabyte scale with up to 140x lower storage cost than Elasticsearch.',
+    'OpenObserve (O2) is a cloud-native observability platform that unifies logs, metrics, and traces, built for petabyte scale at 140x lower storage cost.',
   icons: { icon: `${BASE_PATH}/images/logo_circle.png` },
   // Default share card, so routes without their own metadata (the 404) still
   // get one. Doc pages restate it alongside their per-page OG data.

--- a/docs/administration/deployment/ha-deployment.md
+++ b/docs/administration/deployment/ha-deployment.md
@@ -1,7 +1,7 @@
 ---
 title: High Availability (HA) Deployment - Kubernetes Production Setup
 metaTitle: High Availability Deployment Guide - HA Setup on Kubernetes
-description: Complete high availability (HA) deployment guide for OpenObserve on Kubernetes using Helm charts with object storage and PostgreSQL for production observability.
+description: "High availability deployment guide for OpenObserve on Kubernetes using Helm charts with object storage and PostgreSQL for production use."
 ---
 
 # High Availability (HA) Deployment - Kubernetes Production Setup

--- a/docs/administration/maintenance/operator-guide/config-management.md
+++ b/docs/administration/maintenance/operator-guide/config-management.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Management
-metaTitle: Custom Configuration File and Dynamic Reloading in OpenObserve
+metaTitle: "Configuration File and Dynamic Reloading in OpenObserve"
 description: Learn how to use custom config paths and dynamic config reloading in OpenObserve to apply changes without restarts.
 ---
 

--- a/docs/enterprise-setup/amazon-eks.md
+++ b/docs/enterprise-setup/amazon-eks.md
@@ -1,6 +1,6 @@
 ---
 title: Amazon EKS
-description: Install OpenObserve Enterprise on Amazon EKS using Helm. Step-by-step guide with CLI and AWS Console paths, per-step troubleshooting, verification, and teardown.
+description: "Install OpenObserve Enterprise on Amazon EKS using Helm. CLI and AWS Console paths, per-step troubleshooting, verification, and teardown."
 ---
 
 # Install OpenObserve Enterprise on Amazon EKS

--- a/docs/enterprise-setup/capacity-planning.md
+++ b/docs/enterprise-setup/capacity-planning.md
@@ -1,6 +1,6 @@
 ---
 title: Capacity Planning
-metaTitle: Capacity Planning Guide - Resource Sizing for Production Deployment
+metaTitle: "Capacity Planning - Resource Sizing for Production"
 description: "Capacity planning for OpenObserve: compute, memory, and storage sizing for production observability workloads and high availability clusters."
 ---
 

--- a/docs/enterprise-setup/enterprise-features.md
+++ b/docs/enterprise-setup/enterprise-features.md
@@ -1,5 +1,6 @@
 ---
 title: Enterprise Features
+metaTitle: "Enterprise Edition Feature Overview | OpenObserve"
 description: Overview of OpenObserve Enterprise Edition features — Security & Access Control, Performance & Scalability, AI & Intelligence, Data Processing & Integration.
 ---
 

--- a/docs/enterprise-setup/google-gke.md
+++ b/docs/enterprise-setup/google-gke.md
@@ -1,6 +1,6 @@
 ---
 title: Google GKE
-description: "Install OpenObserve Enterprise on Google GKE with GCS object storage and CloudNativePG. Step-by-step CLI and Console paths, with verification and troubleshooting."
+description: "Install OpenObserve Enterprise on Google GKE with GCS object storage and CloudNativePG. CLI and Console paths, verification, and troubleshooting."
 ---
 
 # Install OpenObserve Enterprise on Google Kubernetes Engine (GKE)

--- a/docs/enterprise-setup/performance.md
+++ b/docs/enterprise-setup/performance.md
@@ -1,7 +1,7 @@
 ---
 title: Performance
 metaTitle: Performance Tuning for Ingestion and Query in OpenObserve
-description: Complete performance optimization guide for OpenObserve ingestion performance, query optimization, and search performance tuning for high-throughput observability.
+description: "Performance tuning guide for OpenObserve: ingestion throughput, query optimization, and search tuning for high-volume observability workloads."
 ---
 
 # Performance Optimization - Ingestion & Query Performance

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Quickstart
-metaTitle: Getting Started with OpenObserve - Cloud and Self-Hosted Setup Guide
-description: Complete getting started guide for OpenObserve observability platform setup - cloud deployment and self-hosted installation for logs, metrics, and traces monitoring.
+metaTitle: "Getting Started with OpenObserve - Cloud & Self-Hosted Setup"
+description: "Get started with OpenObserve: cloud signup or self-hosted installation, then ingest and explore your first logs, metrics, and traces."
 ---
 
 # Getting Started with OpenObserve - Observability Platform Setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 title: "OpenObserve: Cloud Native Observability Platform"
 metaTitle: OpenObserve - Observability for Logs, Metrics, and Traces
-description: OpenObserve is a cloud native observability platform for unified logs, metrics, and traces monitoring with 140x lower storage costs and petabyte-scale performance.
+description: "OpenObserve is a cloud native observability platform for logs, metrics, and traces, with 140x lower storage costs and petabyte-scale performance."
 ---
 
 # OpenObserve: Cloud Native Observability Platform

--- a/docs/ingestion/index.md
+++ b/docs/ingestion/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ingestion Overview
 metaTitle: Data Ingestion Guide - Logs, Metrics, and Traces Collection
-description: Comprehensive data ingestion guide for collecting logs, metrics, and traces using OpenTelemetry, Prometheus, log forwarders, and APIs for complete observability.
+description: "Ingest logs, metrics, and traces into OpenObserve using OpenTelemetry, Prometheus, log forwarders, and APIs for complete observability."
 ---
 
 # Data Ingestion - Logs, Metrics & Traces Collection

--- a/docs/ingestion/logs/filebeat.md
+++ b/docs/ingestion/logs/filebeat.md
@@ -1,6 +1,6 @@
 ---
 title: Filebeat
-metaTitle: Filebeat Log Shipper Integration for Log Collection | OpenObserve
+metaTitle: "Filebeat Log Shipper Integration | OpenObserve"
 description: Set up Filebeat log shipper to collect and forward logs from files, servers, and applications to OpenObserve for centralized log management and analysis.
 ---
 

--- a/docs/ingestion/logs/fluent-bit.md
+++ b/docs/ingestion/logs/fluent-bit.md
@@ -1,6 +1,6 @@
 ---
 title: Fluent-bit
-metaTitle: Fluent Bit Log Ingestion for Kubernetes and Cloud-Native Logs
+metaTitle: "Fluent Bit Log Ingestion for Cloud-Native Kubernetes"
 description: Configure Fluent Bit log forwarding to OpenObserve using HTTP or Elasticsearch output for Kubernetes logging, container logs, and cloud-native log collection.
 ---
 

--- a/docs/ingestion/logs/fluentd.md
+++ b/docs/ingestion/logs/fluentd.md
@@ -1,7 +1,7 @@
 ---
 title: Fluentd
-metaTitle: Fluentd Log Aggregation for Unified Logging Layer | OpenObserve
-description: Configure Fluentd unified logging layer for log aggregation, log collection, and centralized log management with OpenObserve using HTTP output and JSON formatting.
+metaTitle: "Fluentd Log Aggregation & Unified Logging | OpenObserve"
+description: "Configure Fluentd for log aggregation and centralized log management with OpenObserve, using the HTTP output plugin and JSON formatting."
 ---
 
 # Fluentd - Unified Logging Layer & Log Aggregation

--- a/docs/ingestion/logs/go.md
+++ b/docs/ingestion/logs/go.md
@@ -1,6 +1,6 @@
 ---
 title: Go
-metaTitle: Go (Golang) Log Ingestion SDK - Structured Logging for Go Applications
+metaTitle: "Go Log Ingestion SDK - Structured Logging for Go Apps"
 description: Go/Golang SDK guide for structured log ingestion, application logging, and log forwarding to OpenObserve using HTTP API for Go application monitoring.
 ---
 

--- a/docs/ingestion/logs/index.md
+++ b/docs/ingestion/logs/index.md
@@ -1,7 +1,7 @@
 ---
 title: Logs
 metaTitle: Log Ingestion Methods for Centralized Logging | OpenObserve
-description: Comprehensive guide to log ingestion using OpenTelemetry, Vector, Filebeat, Fluent-bit, Fluentd, Kinesis Firehose, Syslog, and more for centralized log management.
+description: "Ingest logs into OpenObserve using OpenTelemetry, Vector, Filebeat, Fluent Bit, Fluentd, Kinesis Firehose, Syslog, and more for central log management."
 ---
 
 # Log Ingestion - Centralized Logging & Log Management

--- a/docs/ingestion/logs/kinesis-firehose.md
+++ b/docs/ingestion/logs/kinesis-firehose.md
@@ -1,6 +1,6 @@
 ---
 title: Kinesis Firehose
-metaTitle: AWS Kinesis Firehose Log Ingestion - CloudWatch and AWS Service Logs
+metaTitle: "AWS Kinesis Firehose Log Ingestion - CloudWatch Logs"
 description: Complete AWS Kinesis Firehose guide for ingesting CloudWatch logs, VPC Flow Logs, WAF logs, and AWS service logs to OpenObserve for AWS log management.
 ---
 

--- a/docs/ingestion/logs/otlp.md
+++ b/docs/ingestion/logs/otlp.md
@@ -1,6 +1,6 @@
 ---
 title: otel-collector
-metaTitle: OpenTelemetry Collector (OTEL) - OTLP Log, Metric, and Trace Ingestion
+metaTitle: "OpenTelemetry Collector - OTLP Log, Metric, Trace Ingestion"
 description: Complete OpenTelemetry Collector guide for OTLP log ingestion, metrics collection, and trace ingestion via HTTP and gRPC protocols for unified observability.
 ---
 

--- a/docs/ingestion/logs/python.md
+++ b/docs/ingestion/logs/python.md
@@ -1,6 +1,6 @@
 ---
 title: Python
-metaTitle: Python Log Ingestion SDK - Application Logging and Log Forwarding
+metaTitle: "Python Log Ingestion SDK - Application Logging"
 description: Python SDK guide for application log ingestion, structured logging, and log forwarding to OpenObserve using HTTP API for Python application monitoring.
 ---
 

--- a/docs/ingestion/logs/syslog.md
+++ b/docs/ingestion/logs/syslog.md
@@ -1,6 +1,6 @@
 ---
 title: Syslog
-metaTitle: Syslog Server Integration for System Log Collection | OpenObserve
+metaTitle: "Syslog Server Integration for Log Collection | OpenObserve"
 description: "Configure syslog server integration to collect system, server, and network device logs over TCP or UDP with OpenObserve for centralized logging."
 ---
 

--- a/docs/ingestion/logs/vector.md
+++ b/docs/ingestion/logs/vector.md
@@ -1,6 +1,6 @@
 ---
 title: Vector
-metaTitle: Vector Log Aggregation and Routing for High-Performance Logging
+metaTitle: "Vector Log Aggregation and High-Performance Routing"
 description: Configure Vector for high-performance log aggregation, transformation, and routing to OpenObserve with HTTP and Elasticsearch sinks for scalable log management.
 ---
 

--- a/docs/ingestion/metrics/index.md
+++ b/docs/ingestion/metrics/index.md
@@ -1,6 +1,6 @@
 ---
 title: Index
-metaTitle: Metrics Ingestion for Monitoring and Observability | OpenObserve
+metaTitle: "Metrics Ingestion for Observability | OpenObserve"
 description: "Ingest metrics into OpenObserve with Prometheus, the OpenTelemetry Collector, or Telegraf for infrastructure and application performance monitoring."
 ---
 

--- a/docs/ingestion/metrics/telegraf.md
+++ b/docs/ingestion/metrics/telegraf.md
@@ -1,6 +1,6 @@
 ---
 title: Telegraf
-metaTitle: Telegraf Metrics Collection for System and Infrastructure Monitoring
+metaTitle: "Telegraf Metrics Collection for Infrastructure Monitoring"
 description: Configure Telegraf agent for system metrics collection, server monitoring, and infrastructure metrics ingestion to OpenObserve using Prometheus remote write.
 ---
 

--- a/docs/ingestion/traces/go.md
+++ b/docs/ingestion/traces/go.md
@@ -1,6 +1,6 @@
 ---
 title: Go
-metaTitle: Go Distributed Tracing - OpenTelemetry for Golang APM | OpenObserve
+metaTitle: "Go Distributed Tracing - OpenTelemetry Golang APM"
 description: Complete Go/Golang distributed tracing guide using OpenTelemetry SDK for Go application performance monitoring and trace instrumentation.
 ---
 

--- a/docs/ingestion/traces/opentelemetry.md
+++ b/docs/ingestion/traces/opentelemetry.md
@@ -1,6 +1,6 @@
 ---
 title: OpenTelemetry
-metaTitle: OpenTelemetry Tracing SDKs - Distributed Tracing for Applications
+metaTitle: "OpenTelemetry Tracing SDKs - Distributed Tracing Setup"
 description: OpenTelemetry tracing guide for instrumenting applications with OpenTelemetry SDKs in Node.js, TypeScript, Python, and Go for distributed tracing and APM.
 ---
 

--- a/docs/ingestion/traces/rust.md
+++ b/docs/ingestion/traces/rust.md
@@ -1,6 +1,6 @@
 ---
 title: Rust
-metaTitle: Rust Distributed Tracing - OpenTelemetry for Rust APM | OpenObserve
+metaTitle: "Rust Distributed Tracing - OpenTelemetry Rust APM"
 description: Complete Rust distributed tracing guide using OpenTelemetry SDK for Rust application performance monitoring and trace instrumentation.
 ---
 

--- a/docs/ingestion/traces/typescript.md
+++ b/docs/ingestion/traces/typescript.md
@@ -1,6 +1,6 @@
 ---
 title: Typescript
-metaTitle: TypeScript Distributed Tracing - OpenTelemetry for TypeScript APM
+metaTitle: "TypeScript Distributed Tracing - OpenTelemetry APM"
 description: Complete TypeScript distributed tracing guide using OpenTelemetry SDK for TypeScript application performance monitoring and trace instrumentation.
 ---
 

--- a/docs/integration/ai/frameworks/index.md
+++ b/docs/integration/ai/frameworks/index.md
@@ -1,6 +1,6 @@
 ---
 title: Frameworks
-metaTitle: AI Framework Observability - LangChain, CrewAI, LlamaIndex, AutoGen
+metaTitle: "AI Framework Observability - LangChain, CrewAI, AutoGen"
 description: "Instrument AI orchestration and agent frameworks with OpenObserve. Trace LangChain, CrewAI, LlamaIndex, AutoGen, and 30+ more via OpenTelemetry."
 ---
 

--- a/docs/integration/ai/gateways/index.md
+++ b/docs/integration/ai/gateways/index.md
@@ -1,6 +1,6 @@
 ---
 title: Gateways
-metaTitle: AI Gateway Observability - Portkey, LiteLLM Proxy, OpenRouter, Kong
+metaTitle: "AI Gateway Observability - Portkey, LiteLLM, OpenRouter"
 description: "Monitor AI gateway traffic with OpenObserve. Trace Portkey, LiteLLM Proxy, OpenRouter, Kong, and Vercel AI Gateway for token usage, latency, and routing."
 ---
 

--- a/docs/integration/ai/index.md
+++ b/docs/integration/ai/index.md
@@ -1,6 +1,6 @@
 ---
 title: AI
-metaTitle: AI & LLM Observability Integrations - Frameworks, Providers, Gateways
+metaTitle: "AI & LLM Observability - Frameworks, Providers, Gateways"
 description: "AI and LLM observability with OpenObserve: trace AI frameworks, LLM providers, AI gateways, no-code tools, and AI developer tools via OpenTelemetry."
 ---
 

--- a/docs/integration/ai/mcp/claude.md
+++ b/docs/integration/ai/mcp/claude.md
@@ -1,6 +1,6 @@
 ---
 title: Claude code CLI
-description: Connect OpenObserve as an MCP (Model Context Protocol) server to Claude Code CLI for querying logs, traces, managing alerts, and streams through natural language.
+description: "Connect OpenObserve as an MCP server to Claude Code CLI to query logs and traces, and manage alerts and streams through natural language."
 ---
 
 # OpenObserve MCP Server Setup Guide for Claude Code

--- a/docs/integration/ai/no-code/index.md
+++ b/docs/integration/ai/no-code/index.md
@@ -1,6 +1,6 @@
 ---
 title: No-Code Agent Builders
-metaTitle: No-Code AI Platform Observability - n8n, Flowise, LangFlow, OpenWebUI
+metaTitle: "No-Code AI Observability - n8n, Flowise, LangFlow, OpenWebUI"
 description: "Monitor no-code AI platforms with OpenObserve. Trace n8n, Flowise, LangFlow, OpenWebUI, LobeChat, and Vapi voice AI via OpenTelemetry."
 ---
 

--- a/docs/integration/ai/no-code/n8n.md
+++ b/docs/integration/ai/no-code/n8n.md
@@ -1,6 +1,6 @@
 ---
 title: n8n
-description: Send n8n webhook trigger traces to OpenObserve via OpenTelemetry.
+description: "Send n8n webhook trigger traces to OpenObserve via OpenTelemetry to capture workflow latency, status codes, and payload metadata on every run."
 ---
 
 # **n8n → OpenObserve**

--- a/docs/integration/ai/no-code/openwebui.md
+++ b/docs/integration/ai/no-code/openwebui.md
@@ -1,6 +1,6 @@
 ---
 title: Open WebUI
-description: Send Open WebUI chat traces to OpenObserve via OpenTelemetry.
+description: "Send Open WebUI chat traces to OpenObserve via OpenTelemetry to capture chat completion spans with model, question, and response metadata."
 ---
 
 # **Open WebUI → OpenObserve**

--- a/docs/integration/ai/providers/index.md
+++ b/docs/integration/ai/providers/index.md
@@ -1,6 +1,6 @@
 ---
 title: Model Providers
-metaTitle: LLM Provider Observability - OpenAI, Anthropic, Gemini, Mistral
+metaTitle: "LLM Provider Observability - OpenAI, Anthropic, Gemini"
 description: "Trace LLM provider API calls with OpenObserve. Monitor token usage, latency, and model metadata for OpenAI, Anthropic, Gemini, Mistral, Ollama, and more."
 ---
 

--- a/docs/integration/ai/tools/index.md
+++ b/docs/integration/ai/tools/index.md
@@ -1,6 +1,6 @@
 ---
 title: Tools
-metaTitle: AI Developer Tool Observability - Promptfoo, Milvus, Firecrawl
+metaTitle: "AI Developer Tool Observability - Promptfoo, Milvus"
 description: "Trace AI developer tools with OpenObserve: Promptfoo evaluations, Milvus vector search, Firecrawl scraping, Gradio, LibreChat, and MCP-Use agent calls."
 ---
 

--- a/docs/integration/cloud/aws/cloudwatch-logs.md
+++ b/docs/integration/cloud/aws/cloudwatch-logs.md
@@ -1,6 +1,6 @@
 ---
 title: AWS Cloudwatch logs
-metaTitle: AWS CloudWatch Logs Monitoring - Stream CloudWatch Logs to OpenObserve
+metaTitle: "AWS CloudWatch Logs Monitoring with OpenObserve"
 description: "Stream AWS CloudWatch application and infrastructure logs to OpenObserve using Kinesis Firehose for centralized AWS log management."
 ---
 

--- a/docs/integration/cloud/aws/ec2.md
+++ b/docs/integration/cloud/aws/ec2.md
@@ -1,6 +1,6 @@
 ---
 title: Amazon EC2
-metaTitle: AWS EC2 Monitoring - Server Metrics and Logs Collection | OpenObserve
+metaTitle: "AWS EC2 Monitoring - Server Metrics and Logs | OpenObserve"
 description: "Collect server metrics, system logs, and performance data from EC2 Linux instances using OpenTelemetry for AWS infrastructure monitoring."
 ---
 

--- a/docs/integration/cloud/aws/ecs.md
+++ b/docs/integration/cloud/aws/ecs.md
@@ -1,6 +1,6 @@
 ---
 title: Amazon Elastic Container Service (ECS)
-metaTitle: AWS ECS Container Monitoring with FireLens - Fargate and EC2 Logs
+metaTitle: "AWS ECS Container Monitoring with FireLens - Fargate Logs"
 description: "Collect container logs from AWS ECS on Fargate and EC2 using AWS FireLens with Fluent Bit for containerized application monitoring."
 ---
 

--- a/docs/integration/cloud/aws/rds.md
+++ b/docs/integration/cloud/aws/rds.md
@@ -1,6 +1,6 @@
 ---
 title: Amazon Relational Database Service (RDS)
-metaTitle: AWS RDS Database Monitoring - MySQL, PostgreSQL Database Logs
+metaTitle: "AWS RDS Monitoring - MySQL and PostgreSQL Database Logs"
 description: "Collect MySQL and PostgreSQL logs, slow query logs, and error logs from AWS RDS via CloudWatch and Kinesis Firehose for database performance monitoring."
 ---
 

--- a/docs/integration/cloud/aws/vpc-flow.md
+++ b/docs/integration/cloud/aws/vpc-flow.md
@@ -1,6 +1,6 @@
 ---
 title: Amazon Virtual Private Cloud
-metaTitle: AWS VPC Flow Logs Monitoring - Network Traffic and Security Analysis
+metaTitle: "AWS VPC Flow Logs - Network Traffic & Security Analysis"
 description: "Send AWS VPC Flow Logs to OpenObserve with Kinesis Firehose for network traffic analysis, security monitoring, and cloud network visibility."
 ---
 

--- a/docs/integration/cloud/gcp/index.md
+++ b/docs/integration/cloud/gcp/index.md
@@ -1,6 +1,6 @@
 ---
 title: GCP Integrations Overview
-metaTitle: GCP Monitoring Integration - Google Cloud Platform Logs and Metrics
+metaTitle: "GCP Monitoring - Google Cloud Platform Logs and Metrics"
 description: "GCP monitoring integrations for Google Cloud logs, Cloud Run, and metrics collection, bringing Google Cloud observability into OpenObserve."
 ---
 

--- a/docs/integration/database/index.md
+++ b/docs/integration/database/index.md
@@ -1,6 +1,6 @@
 ---
 title: Database Integrations Overview
-metaTitle: Database Monitoring Integration - MySQL, PostgreSQL, MongoDB, Redis
+metaTitle: "Database Monitoring - MySQL, PostgreSQL, MongoDB, Redis"
 description: "Database monitoring integrations for MySQL, PostgreSQL, MongoDB, Redis, and other SQL and NoSQL databases with OpenObserve."
 ---
 

--- a/docs/integration/database/mysql.md
+++ b/docs/integration/database/mysql.md
@@ -1,6 +1,6 @@
 ---
 title: MySQL
-metaTitle: MySQL Database Monitoring - Performance Metrics and Query Optimization
+metaTitle: "MySQL Database Monitoring - Metrics and Query Optimization"
 description: "Collect MySQL performance metrics, query performance, and database health with OpenTelemetry for MySQL monitoring in OpenObserve."
 ---
 

--- a/docs/integration/database/oracle.md
+++ b/docs/integration/database/oracle.md
@@ -1,6 +1,6 @@
 ---
 title: Oracle Database
-metaTitle: Monitor Your Oracle Database with OpenTelemetry and OpenObserve
+metaTitle: "Oracle Database Monitoring with OpenTelemetry"
 description: Learn how to collect Oracle Database metrics and logs using the OpenTelemetry Collector and visualize them in OpenObserve.
 ---
 

--- a/docs/integration/database/postgresql.md
+++ b/docs/integration/database/postgresql.md
@@ -1,6 +1,6 @@
 ---
 title: PostgreSQL
-metaTitle: PostgreSQL Monitoring - Performance Metrics and Query Analysis
+metaTitle: "PostgreSQL Monitoring - Metrics and Query Analysis"
 description: "Collect PostgreSQL performance metrics, query analysis, and database health with OpenTelemetry for PostgreSQL monitoring in OpenObserve."
 ---
 

--- a/docs/integration/database/redis.md
+++ b/docs/integration/database/redis.md
@@ -1,6 +1,6 @@
 ---
 title: Redis
-metaTitle: Redis Monitoring - Cache Performance and In-Memory Database Metrics
+metaTitle: "Redis Monitoring - Cache Performance and Memory Metrics"
 description: "Collect Redis cache performance metrics with OpenTelemetry for in-memory database monitoring and performance optimization in OpenObserve."
 ---
 

--- a/docs/integration/devops/index.md
+++ b/docs/integration/devops/index.md
@@ -1,6 +1,6 @@
 ---
 title: DevOps Integrations Overview
-metaTitle: DevOps Monitoring - CI/CD, Jenkins, Terraform, GitHub Actions
+metaTitle: "DevOps Monitoring - CI/CD, Jenkins, GitHub Actions"
 description: "DevOps monitoring integrations for CI/CD pipelines, Jenkins, Terraform, GitHub Actions, and Ansible automation with OpenObserve."
 ---
 

--- a/docs/integration/message-brokers/kafka.md
+++ b/docs/integration/message-brokers/kafka.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka
-metaTitle: Apache Kafka Monitoring - Stream Processing and Message Broker Metrics
+metaTitle: "Apache Kafka Monitoring - Message Broker and Stream Metrics"
 description: "Collect Apache Kafka metrics with OpenTelemetry for message broker, stream processing, and cluster monitoring in OpenObserve."
 ---
 

--- a/docs/integration/system/linux.md
+++ b/docs/integration/system/linux.md
@@ -1,6 +1,6 @@
 ---
 title: Linux Server Monitoring - System Logs & Performance Metrics
-metaTitle: Linux Server Monitoring - System Logs and Performance Metrics
+metaTitle: "Linux Server Monitoring - System Logs and Metrics"
 description: "Collect Linux system logs, server metrics, and performance data with the OpenObserve Collector for Linux server monitoring."
 ---
 

--- a/docs/integration/system/windows.md
+++ b/docs/integration/system/windows.md
@@ -1,6 +1,6 @@
 ---
 title: Windows Server Monitoring - Event Logs & Performance Metrics
-metaTitle: Windows Server Monitoring - Event Logs and Performance Metrics
+metaTitle: "Windows Server Monitoring - Event Logs and Metrics"
 description: "Collect Windows event logs, server metrics, and performance data with the OpenObserve Collector for Windows server monitoring."
 ---
 

--- a/docs/migration/migrate-from-datadog-to-openobserve/architecture.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture & Terminology
-metaTitle: Datadog vs OpenObserve Architecture - Migration Path & Terminology
+metaTitle: "Datadog vs OpenObserve - Architecture & Terminology"
 description: "How Datadog Agent, DogStatsD, and APM components map to OpenObserve: architecture comparison, terminology, and protocol compatibility."
 ---
 

--- a/docs/migration/migrate-from-datadog-to-openobserve/index.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/index.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-metaTitle: Migrate from Datadog to OpenObserve | Complete Migration Guide
+metaTitle: "Migrate from Datadog to OpenObserve - Migration Guide"
 description: "Migrate metrics, traces, logs, dashboards, and monitors from Datadog to OpenObserve using the OpenTelemetry Collector, without rewriting applications."
 ---
 

--- a/docs/migration/migrate-from-datadog-to-openobserve/logs.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/logs.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating Logs
-metaTitle: Migrate Logs from Datadog to OpenObserve (Agent, Fluent Bit, Vector)
+metaTitle: "Migrate Logs from Datadog to OpenObserve - Agent & Vector"
 description: "Migrate logs from Datadog to OpenObserve: paths for the Datadog Agent, Fluent Bit, Vector, OTel Collector, Kubernetes, CloudWatch, and Azure Monitor."
 ---
 

--- a/docs/migration/migrate-from-datadog-to-openobserve/metrics.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/metrics.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating Metrics
-metaTitle: Migrate Metrics from Datadog to OpenObserve (Agent, DogStatsD, OTel)
+metaTitle: "Migrate Metrics from Datadog to OpenObserve - Agent & OTel"
 description: "Migrate Datadog metrics to OpenObserve with the OpenTelemetry Collector. Covers DogStatsD, Agent forwarding, Kubernetes, CloudWatch, and Azure Monitor."
 ---
 

--- a/docs/migration/migrate-from-grafana-to-openobserve/architecture.md
+++ b/docs/migration/migrate-from-grafana-to-openobserve/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture & Terminology
-metaTitle: LGTM Stack Architecture vs OpenObserve - Migration Path & Terminology
+metaTitle: "LGTM Stack vs OpenObserve - Architecture & Terminology"
 description: "How Loki, Grafana, Tempo, and Mimir map to OpenObserve: architecture comparison, terminology reference, and protocol compatibility for LGTM migrations."
 ---
 

--- a/docs/migration/migrate-from-grafana-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-grafana-to-openobserve/dashboards-and-alerts.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating Dashboards & Alerts
-metaTitle: Migrate Dashboards & Alerts from Grafana LGTM Stack to OpenObserve
+metaTitle: "Migrate Dashboards & Alerts from Grafana to OpenObserve"
 description: "Migrate Grafana dashboards and Alertmanager rules to OpenObserve. Covers LogQL to SQL translation, PromQL compatibility, and notification channels."
 ---
 

--- a/docs/migration/migrate-from-grafana-to-openobserve/metrics.md
+++ b/docs/migration/migrate-from-grafana-to-openobserve/metrics.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating Metrics
-metaTitle: Migrate Metrics from LGTM Stack (Mimir/Prometheus) to OpenObserve
+metaTitle: "Migrate Metrics from Mimir & Prometheus to OpenObserve"
 description: "Migrate Prometheus and Mimir metrics to OpenObserve: remote write, OTel Collector, kube-prometheus-stack, Grafana Alloy, Telegraf, and CloudWatch."
 ---
 

--- a/docs/reference/api/report/index.md
+++ b/docs/reference/api/report/index.md
@@ -1,7 +1,7 @@
 ---
 title: Reports
 metaTitle: Reports API | OpenObserve
-description: Manage folder-aware dashboard reports in OpenObserve via the v2 REST API. List, create, get, update, move, delete, enable, and trigger reports scoped to folders.
+description: "Manage folder-aware dashboard reports via the OpenObserve v2 REST API: list, create, get, update, move, delete, enable, and trigger reports."
 ---
 
 # Reports API

--- a/docs/user-guide/account-administration/identity-and-access-management/enable-rbac-in-openobserve-enterprise.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/enable-rbac-in-openobserve-enterprise.md
@@ -1,5 +1,6 @@
 ---
 title: Enable Role-Based Access Control (RBAC) in Enterprise Edition
+metaTitle: "Enable RBAC - Role-Based Access Control in Enterprise"
 description: Enable Role-Based Access Control (RBAC) in OpenObserve Enterprise Edition using OpenFGA to manage access and enforce permissions across resources.
 ---
 

--- a/docs/user-guide/account-administration/management/aggregation-cache.md
+++ b/docs/user-guide/account-administration/management/aggregation-cache.md
@@ -1,7 +1,7 @@
 ---
 title: Streaming Aggregation
 metaTitle: Streaming Aggregation in OpenObserve
-description: Learn how streaming aggregation works in OpenObserve Enterprise.
+description: "How streaming aggregation and the aggregation cache work in OpenObserve Enterprise, and how they speed up repeated queries over large time ranges."
 ---
 
 This page explains what streaming aggregation is and how it improves query performance in OpenObserve.

--- a/docs/user-guide/advanced/query-tuning/tantivy-index.md
+++ b/docs/user-guide/advanced/query-tuning/tantivy-index.md
@@ -1,7 +1,7 @@
 ---
 title: Tantivy Index
 metaTitle: Tantivy Indexing in OpenObserve
-description: Learn how Tantivy indexing works in OpenObserve, including full-text and secondary indexes, query behaviors with AND and OR operators, and how to verify index usage.
+description: "How Tantivy indexing works in OpenObserve: full-text and secondary indexes, query behavior with AND and OR, and how to verify index usage."
 ---
 
 This document explains Tantivy indexing in OpenObserve, the types of indexes it builds, how to use the correct query patterns for both single-stream and multi-stream queries, and how to verify and configure indexing.

--- a/docs/user-guide/advanced/siem.md
+++ b/docs/user-guide/advanced/siem.md
@@ -1,6 +1,6 @@
 ---
 title: "**Building a SIEM Platform with OpenObserve**"
-metaTitle: SIEM Platform - Security Information and Event Management Solution
+metaTitle: "SIEM - Security Information and Event Management"
 description: "Build a SIEM platform on OpenObserve with threat detection, security monitoring, incident response, and SOC operations."
 ---
 

--- a/docs/user-guide/data-processing/pipelines/remote-destination.md
+++ b/docs/user-guide/data-processing/pipelines/remote-destination.md
@@ -1,7 +1,7 @@
 ---
 title: Remote Destination
 metaTitle: Pipeline Remote Destinations
-description: Configure and manage remote destinations to send transformed pipeline data to external systems with persistent queuing, retry logic, and high-throughput performance.
+description: "Configure remote destinations to send transformed pipeline data to external systems, with persistent queuing, retry logic, and high throughput."
 ---
 
 This document explains how to configure remote destinations in OpenObserve pipelines to send transformed data to external systems. It covers the setup process, technical architecture of the persistent queue mechanism, Write-Ahead Log (WAL) file operations, failure handling, retry logic, and performance optimization through environment variables.

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,36 @@
+/**
+ * Search-result limits for the `<title>` and `<meta name="description">` tags.
+ *
+ * Google renders both as pixel widths, not character counts, and the exact
+ * cutoff moves. These are the conventional character proxies: titles are
+ * truncated around 580px (~60 characters) and descriptions around 920px
+ * (~160 characters). `scripts/check-seo.mjs` enforces them at build time.
+ */
+export const TITLE_MAX = 60;
+export const DESCRIPTION_MIN = 70;
+export const DESCRIPTION_MAX = 160;
+
+/** Appended to unbranded titles, and the cost in characters of doing so. */
+const BRAND_SUFFIX = ' | OpenObserve';
+
+/**
+ * Builds the `<title>` for a docs page.
+ *
+ * Roughly half the pages carry only the short sidebar `title` ("Alerts",
+ * "Azure AKS") and no SEO-tuned `metaTitle`. On its own that makes a title tag
+ * with no brand and no topic context, which competes badly in search results
+ * and reads as ambiguous when shared. Those get the brand appended.
+ *
+ * Two guards keep the suffix from doing harm:
+ *
+ *  - Titles that already say "OpenObserve" anywhere are left alone, so nothing
+ *    ends up as "... | OpenObserve | OpenObserve".
+ *  - The suffix is only added when the result still fits in `TITLE_MAX`. A
+ *    hand-written `metaTitle` near the limit keeps its own wording rather than
+ *    being pushed past the truncation point.
+ */
+export function composeTitle(title: string): string {
+  if (/openobserve/i.test(title)) return title;
+  if (title.length + BRAND_SUFFIX.length > TITLE_MAX) return title;
+  return title + BRAND_SUFFIX;
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "node": ">=20.9"
   },
   "scripts": {
-    "prebuild": "node scripts/copy-assets.mjs",
-    "dev": "node scripts/copy-assets.mjs && next dev -p 3000",
+    "prebuild": "node scripts/copy-assets.mjs && node scripts/check-seo.mjs",
+    "check:seo": "node scripts/check-seo.mjs",
+    "dev": "node scripts/copy-assets.mjs && next dev -p 3030",
     "build": "next build",
     "postbuild": "node scripts/post-export.mjs",
     "start": "next start",

--- a/scripts/check-seo.mjs
+++ b/scripts/check-seo.mjs
@@ -1,0 +1,116 @@
+/**
+ * Fails the build when a page's `<title>` or `<meta name="description">` would
+ * be truncated or padded out in search results.
+ *
+ * The migration from MkDocs carried over 48 titles above the truncation point
+ * (up to 70 characters) and 13 descriptions above it, so this guards the fix
+ * rather than describing an aspiration. It checks the *rendered* title, meaning
+ * `metaTitle ?? title` with the brand suffix `lib/seo.ts` appends — checking the
+ * raw frontmatter would miss pages pushed over the limit by the suffix.
+ *
+ * Runs as `prebuild`, alongside scripts/copy-assets.mjs.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from 'yaml';
+
+const DOCS = path.resolve('docs');
+
+// Google renders both as pixel widths, so these are the conventional character
+// proxies: ~580px of title and ~920px of description. Kept in step with the
+// exported limits in lib/seo.ts, which is what the app itself uses.
+const TITLE_MAX = 60;
+const DESCRIPTION_MIN = 70;
+const DESCRIPTION_MAX = 160;
+const BRAND_SUFFIX = ' | OpenObserve';
+
+/** Mirrors composeTitle() in lib/seo.ts. */
+function composeTitle(title) {
+  if (/openobserve/i.test(title)) return title;
+  if (title.length + BRAND_SUFFIX.length > TITLE_MAX) return title;
+  return title + BRAND_SUFFIX;
+}
+
+/**
+ * Frontmatter only. Line endings are normalised first: the repo has CRLF files,
+ * and a trailing `\r` left on the closing quote of a value makes the YAML parser
+ * reject an otherwise valid block.
+ */
+function frontmatter(raw) {
+  const text = raw.replace(/\r\n/g, '\n');
+  if (!text.startsWith('---\n')) return null;
+  const end = text.indexOf('\n---', 3);
+  if (end === -1) return null;
+  return parse(text.slice(4, end)) ?? {};
+}
+
+function walk(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.name.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+const problems = [];
+const pages = walk(DOCS).sort();
+const titleOwners = new Map();
+
+for (const file of pages) {
+  const rel = path.relative(process.cwd(), file).replace(/\\/g, '/');
+  let data;
+  try {
+    data = frontmatter(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    problems.push(`${rel}: frontmatter does not parse - ${error.message}`);
+    continue;
+  }
+  if (!data) {
+    problems.push(`${rel}: no frontmatter block`);
+    continue;
+  }
+
+  const source = data.metaTitle ?? data.title;
+  if (!source) {
+    problems.push(`${rel}: no title`);
+  } else {
+    const rendered = composeTitle(source);
+    if (rendered.length > TITLE_MAX) {
+      problems.push(`${rel}: title is ${rendered.length} chars, max ${TITLE_MAX} - "${rendered}"`);
+    }
+    // Two pages competing on one title split their own ranking signals. This is
+    // easy to reintroduce by accident because composeTitle() brands a bare
+    // "Enterprise Features" into the same string a hand-written `metaTitle`
+    // already spells out in full.
+    titleOwners.set(rendered, [...(titleOwners.get(rendered) ?? []), rel]);
+  }
+
+  const description = data.description;
+  if (!description) {
+    problems.push(`${rel}: no description`);
+  } else if (description.length > DESCRIPTION_MAX) {
+    problems.push(`${rel}: description is ${description.length} chars, max ${DESCRIPTION_MAX}`);
+  } else if (description.length < DESCRIPTION_MIN) {
+    problems.push(`${rel}: description is ${description.length} chars, min ${DESCRIPTION_MIN}`);
+  }
+}
+
+for (const [title, owners] of titleOwners) {
+  if (owners.length > 1) {
+    problems.push(`duplicate title "${title}" on ${owners.length} pages: ${owners.join(', ')}`);
+  }
+}
+
+if (problems.length > 0) {
+  console.error(`SEO check failed - ${problems.length} problem(s):\n`);
+  for (const problem of problems) console.error(`  ${problem}`);
+  console.error(
+    `\nTitles are capped at ${TITLE_MAX} chars and descriptions kept to ` +
+      `${DESCRIPTION_MIN}-${DESCRIPTION_MAX}. Set a shorter \`metaTitle\` in the page's ` +
+      `frontmatter to keep the sidebar label as it is.`
+  );
+  process.exit(1);
+}
+
+console.log(`SEO check passed for ${pages.length} pages.`);


### PR DESCRIPTION
The MkDocs migration carried over metadata that search engines truncate: 48 pages had a <title> above the ~60-character cutoff (up to 70), 13 had a meta description above ~160, and 3 had descriptions too thin to be useful. A further 231 pages rendered only their short sidebar label as the title ("Alerts", "Azure AKS"), with no brand or topic context.

- Rewrite the 48 over-long metaTitles and 16 descriptions, preserving the keywords each page was already targeting.
- Add lib/seo.ts, which appends " | OpenObserve" to unbranded titles, but only when the title does not already say OpenObserve and the result still fits in 60 characters. 313 pages gain the suffix; hand-tuned metaTitles near the limit keep their own wording.
- Give enterprise-setup/enterprise-features.md its own metaTitle, since branding its bare title collided with features/enterprise.md.
- Shorten the root layout description, the 404 fallback, from 197 to 150.
- Add scripts/check-seo.mjs, run as prebuild, failing on titles over 60, descriptions outside 70-160, and duplicate rendered titles.

Verified against the built output: all 465 emitted HTML pages are now within both limits.