### PR TITLE
ci: build and deploy docs preview on every pull request

### DIFF
--- a/.github/workflows/deploy-docs-preview.yaml
+++ b/.github/workflows/deploy-docs-preview.yaml
@@ -1,11 +1,13 @@
 name: Deploy Docs Site to S3 (preview)
 
-# Preview environment for the Fumadocs site. Deploys to a dedicated preview
-# bucket/distribution, hardcoded below like the staging and prod workflows.
+# Preview environment for the Fumadocs site. Every pull request is built and
+# published to the dedicated preview bucket, and the preview URL is posted back
+# as a PR comment. The bucket is hardcoded below like the staging and prod
+# workflows. No CloudFront sits in front of the preview bucket, so there is
+# nothing to invalidate.
 on:
-  push:
-    branches:
-      - migrate-to-fumadocs   # Change this to your preview branch
+  pull_request:
+    types: [opened, reopened, synchronize]
   workflow_dispatch:          # allow deploying any branch by hand
 
 jobs:
@@ -14,14 +16,17 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      issues: write
+      pull-requests: write
     env:
-      PREVIEW_BUCKET: openobserve-website-staging  # TODO: replace with the real preview bucket name
-      PREVIEW_DISTRIBUTION_ID: E2GZJM0TJIDFRM       # TODO: replace with the real CloudFront distribution ID
+      PREVIEW_BUCKET: openobserve-website-preview
+      PREVIEW_URL: https://openobserve-website-preview.openobserve.ai/docs
 
     steps:
     - name: Checkout source code
       uses: actions/checkout@v3
       with:
+        ref: ${{ github.head_ref || github.ref_name || github.sha }}
         fetch-depth: 0   # full history so the per-page "last updated" dates resolve
 
     - name: Set up pnpm
@@ -62,9 +67,8 @@ jobs:
       run: |
         aws s3 sync ./out "s3://$PREVIEW_BUCKET/docs" --exclude=".git/*" \
           --exclude "api/search.json*" --delete
-        # The search index is ~37 MB and CloudFront only auto-compresses objects
-        # under 10 MB, so the gzipped copy scripts/post-export.mjs writes is
-        # published instead (~4.7 MB). Browsers decode it transparently.
+        # The search index is ~37 MB, so the gzipped copy scripts/post-export.mjs
+        # writes is published instead (~4.7 MB). Browsers decode it transparently.
         aws s3 cp ./out/api/search.json.gz "s3://$PREVIEW_BUCKET/docs/api/search.json" \
           --content-type application/json --content-encoding gzip
         # Raw Markdown is served for LLM crawlers and the "Copy page" menu.
@@ -72,6 +76,24 @@ jobs:
           --recursive --exclude "*" --include "*.md" \
           --content-type "text/markdown; charset=utf-8"
 
-    - name: Invalidate CloudFront cache
-      run: |
-        aws cloudfront create-invalidation --distribution-id "$PREVIEW_DISTRIBUTION_ID" --paths "/docs/*"
+    - name: Find existing preview comment
+      if: github.event_name == 'pull_request'
+      uses: peter-evans/find-comment@v3
+      id: find-comment
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: "github-actions[bot]"
+        body-includes: "Preview Ready!"
+
+    - name: Post or update PR preview comment
+      if: github.event_name == 'pull_request'
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        body: |
+          ✅ Preview Ready!
+          🔗 ${{ env.PREVIEW_URL }}
+        edit-mode: replace


### PR DESCRIPTION
Switches the preview workflow from a hardcoded push branch to pull_request (opened/reopened/synchronize) and points it at the real preview bucket, openobserve-website-preview, instead of the staging placeholder. The preview URL is posted back to the PR as a comment that is updated in place on each push. No CloudFront fronts the preview bucket, so the invalidation step is dropped.