### PR TITLE
fix(seo): repair the 33 broken internal links in the export

### DIFF
--- a/SEO-AEO-GEO-AUDIT.md
+++ b/SEO-AEO-GEO-AUDIT.md
@@ -108,7 +108,9 @@ Every number in this document was measured against the actual repo or the actual
 
 ---
 
-## 🔴 Correction: the export has 33 broken links, not zero
+## ✅ Correction: the export had 33 broken links, not zero — now fixed
+
+> **Resolved.** All three classes below are fixed, and [scripts/check-links.mjs](scripts/check-links.mjs) runs as part of `postbuild` so they cannot come back silently. The basePath class was fixed at the source — the links were inside headings, which the table of contents copies out as a bare `<a>` — by replacing those hand-written lists with `::child-pages` on the two hub pages and unlinking the headings on `features/frontend.md`. See M5.
 
 The first version of this audit reported **0 broken internal links**. That scan only matched `href="/docs/…"`. Three other href forms appear in the export and none were checked. Re-scanned across all forms (12,635 root-relative + 79 absolute + 26 relative `<a href>`s):
 
@@ -556,9 +558,11 @@ Measure with PageSpeed Insights first — the CLS claim here is inferred from ma
 
 ---
 
-#### M5. Wire up `onBrokenLink` and add a link check over the built HTML → **promoted to High Impact**
+#### M5. Wire up `onBrokenLink` and add a link check over the built HTML → ✅ **post-export check done; `onBrokenLink` still unwired**
 
-**Why:** see the correction section above — there are 33 broken links shipping today, and nothing catches them. The hook in [lib/remark/mkdocs-links.ts:25](lib/remark/mkdocs-links.ts#L25) is never passed a handler.
+[scripts/check-links.mjs](scripts/check-links.mjs) now runs as part of `postbuild` and fails the build on all three classes below. All 33 links are fixed; the checker reports zero against the current export. The remark-stage hook in [lib/remark/mkdocs-links.ts:25](lib/remark/mkdocs-links.ts#L25) is still passed no handler — redundant for catching breakage, but it would move the 4th class earlier and give a file/line rather than a page URL.
+
+**Why:** see the correction section above — there were 33 broken links shipping, and nothing caught them.
 
 Two checks are needed, because they catch different classes:
 

--- a/docs/features/frontend.md
+++ b/docs/features/frontend.md
@@ -27,14 +27,16 @@ Frontend Observability in OpenObserve enables real user monitoring, performance 
 - **Network Insights**: Track HTTP requests and network timing
 
 
-### [Error Tracking](../user-guide/data-exploration/rum/error-tracking.md)
+### Error Tracking
 
 - **JavaScript Errors**: Automatically capture exceptions and errors with full stack traces
 - **Error Context**: Includes user session metadata and browser details
 
 ![Error Tracking](../images/frontend/error-tracking.webp)
 
-### [Session Replay](../user-guide/data-exploration/rum/session-replay.md)
+See [Error Tracking](../user-guide/data-exploration/rum/error-tracking.md) for the full guide.
+
+### Session Replay
 
 - **User Interaction Recording**: Replay user sessions to understand behavior and debug issues
 
@@ -45,6 +47,8 @@ Frontend Observability in OpenObserve enables real user monitoring, performance 
 ![Event Timeline](../images/features/event-timeline.png)
 
 - **Privacy Features**: Configurable masking for sensitive fields
+
+See [Session Replay](../user-guide/data-exploration/rum/session-replay.md) for the full guide.
 
 
 ## Integration

--- a/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
@@ -127,7 +127,7 @@ Set up notification destinations in OpenObserve **before** recreating rules, so 
 
 OpenObserve supports: **Slack, Email, PagerDuty, and Webhook**.
 
-See the [OpenObserve Alerts Documentation](https://openobserve.ai/docs/user-guide/alerts/) for setup instructions.
+See the [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/index.md) for setup instructions.
 
 ### Step 3: Recreate Alert Rules
 
@@ -177,7 +177,7 @@ The same AI Assistant that converts dashboard queries works here. Paste a Datado
 
 ## Next Steps
 
-- [OpenObserve Alerts Documentation](https://openobserve.ai/docs/user-guide/alerts/): full reference for alert rule types, conditions, and notification channels
+- [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/index.md): full reference for alert rule types, conditions, and notification channels
 - [OpenObserve Dashboards Documentation](https://openobserve.ai/docs/user-guide/analytics/dashboards/): dashboard builder, panel types, and variables
 - [OpenObserve Full-Text Search Functions](https://openobserve.ai/docs/reference/sql-functions/full-text-search/): SQL function reference for log queries (`match_all()`, `str_match()`, `re_match()`)
 - [OpenObserve Scheduled Pipelines](https://openobserve.ai/docs/user-guide/data-processing/pipelines/create-and-use-scheduled-pipeline/): pre-aggregate expensive queries for SLOs and dashboards

--- a/docs/migration/migrate-from-datadog-to-openobserve/logs.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/logs.md
@@ -219,7 +219,7 @@ You can normalize these with an OpenObserve **Pipeline** (VRL) at ingest time so
 
 ## Next Steps
 
-- [OpenObserve Logs User Guide](https://openobserve.ai/docs/user-guide/logs/): exploring streams, running queries, and configuring stream settings in the UI
+- [OpenObserve Logs User Guide](../../user-guide/data-exploration/logs/index.md): exploring streams, running queries, and configuring stream settings in the UI
 - [OpenObserve Full-Text Search Functions](https://openobserve.ai/docs/reference/sql-functions/full-text-search/): reference for `match_all()`, `str_match()`, `re_match()`, and more
 - [OpenObserve Pipelines](https://openobserve.ai/docs/user-guide/data-processing/pipelines/): parse, enrich, route, and transform logs at ingest
 

--- a/docs/migration/migrate-from-grafana-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-grafana-to-openobserve/dashboards-and-alerts.md
@@ -95,7 +95,7 @@ OpenObserve supports: **Slack, Email, PagerDuty, and Webhook**.
 
 ![Alert Destinations in OpenObserve](../../images/migration/lgtm/alert-destinations.png)
 
-See the [OpenObserve Alerts Documentation](https://openobserve.ai/docs/user-guide/alerts/) for setup instructions.
+See the [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/index.md) for setup instructions.
 
 ### Step 3: Recreate Alert Rules
 
@@ -136,7 +136,7 @@ The same AI Assistant that converts LogQL for dashboards works here too. Paste y
 
 ## Next Steps
 
-- [OpenObserve Alerts Documentation](https://openobserve.ai/docs/user-guide/alerts/) — full reference for alert rule types, conditions, and notification channels
+- [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/index.md) — full reference for alert rule types, conditions, and notification channels
 - [OpenObserve Dashboards Documentation](https://openobserve.ai/docs/user-guide/analytics/dashboards/) — dashboard builder, panel types, and variables
 - [OpenObserve Full-Text Search Functions](https://openobserve.ai/docs/reference/sql-functions/full-text-search/) — complete SQL function reference for log queries (`match_all()`, `str_match()`, `re_match()`)
 - [OpenObserve Scheduled Pipelines](https://openobserve.ai/docs/user-guide/data-processing/pipelines/create-and-use-scheduled-pipeline/) — pre-aggregate expensive queries, equivalent to Mimir recording rules

--- a/docs/migration/migrate-from-grafana-to-openobserve/logs.md
+++ b/docs/migration/migrate-from-grafana-to-openobserve/logs.md
@@ -207,7 +207,7 @@ If your logs are JSON, OpenObserve auto-parses them into columns. Check that exp
 
 ## Next Steps
 
-- [OpenObserve Logs User Guide](https://openobserve.ai/docs/user-guide/logs/) — exploring streams, running queries, and configuring stream settings in the UI
+- [OpenObserve Logs User Guide](../../user-guide/data-exploration/logs/index.md) — exploring streams, running queries, and configuring stream settings in the UI
 - [OpenObserve Full-Text Search Functions](https://openobserve.ai/docs/reference/sql-functions/full-text-search/) — complete reference for `match_all()`, `str_match()`, `re_match()`, and more
 
 ---

--- a/docs/reference/api/traces/trace-search-api.md
+++ b/docs/reference/api/traces/trace-search-api.md
@@ -84,7 +84,7 @@ Retrieve detailed span information for a specific trace using the traces `/lates
 
 ### Using Search API 
 
-For complex queries, you can use the [search API](https://openobserve.ai/docs/api/search/search/) with SQL queries:
+For complex queries, you can use the [search API](../search/search.md) with SQL queries:
 ```sql
 SELECT * FROM default WHERE trace_id = {trace_id} ORDER BY start_time
 ```

--- a/docs/user-guide/account-administration/identity-and-access-management/enable-rbac-in-openobserve-enterprise.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/enable-rbac-in-openobserve-enterprise.md
@@ -17,7 +17,7 @@ Before enabling RBAC, ensure the following:
 
 - You must have **OpenObserve Enterprise Edition** installed and running. Refer to the [Enterprise Setup guide](../../../enterprise-setup/index.md).
 - You must have **administrator access** to the system where OpenObserve is deployed.
-- OpenObserve must be running in [High Availability (HA) mode](https://openobserve.ai/docs/ha_deployment/), as RBAC is supported only in HA deployments.
+- OpenObserve must be running in [High Availability (HA) mode](../../../administration/deployment/ha-deployment.md), as RBAC is supported only in HA deployments.
 
 ## Step 1: Install OpenFGA
 

--- a/docs/user-guide/account-administration/identity-and-access-management/keycloak-sso.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/keycloak-sso.md
@@ -43,8 +43,8 @@ This guide uses `cluster1.example.com` as the example domain. Replace hostnames,
 - **OpenObserve Enterprise** deployed (SSO/Dex is an Enterprise feature), `https://dev.cluster1.example.com`
 - A **Dex** deployment reachable by both the user's browser and OpenObserve
 - A **Keycloak** instance (v26.x in this setup) with admin access
-  - Local dev: [docker-compose.yml](docker-compose.yml) (Keycloak 26.1 + Postgres 16)
-  - Cluster: [k8s-deployment.yml](k8s-deployment.yml) + [httproute.yml](httproute.yml) (Envoy Gateway route on `keycloak.cluster1.example.com`)
+  - Local dev: `docker-compose.yml` (Keycloak 26.1 + Postgres 16)
+  - Cluster: `k8s-deployment.yml` + `httproute.yml` (Envoy Gateway route on `keycloak.cluster1.example.com`)
 - All three endpoints served over **HTTPS** with mutually trusted certificates
 - Network connectivity: browser to all three; Dex to Keycloak; OpenObserve to Dex
 
@@ -145,7 +145,7 @@ Confirm the JSON loads and note the `issuer` value. The Dex connector must use i
 
 ### Step 3.1: Add the Keycloak connector
 
-The dev configuration lives in [dev-dex-config.yaml](dev-dex-config.yaml). The relevant pieces:
+The dev configuration lives in `dev-dex-config.yaml`. The relevant pieces:
 
 ```yaml
 issuer: https://dev-dex.cluster1.example.com/dex
@@ -274,7 +274,7 @@ kubectl -n openobserve rollout restart statefulset/o2-openobserve-router   # or 
 | `x509: certificate signed by unknown authority` in Dex logs | Dex does not trust Keycloak's TLS cert | Mount the CA into Dex and set `rootCAs: [/etc/dex/ca.pem]` in the connector config. |
 | User lands in the wrong org/role | Group mapping not applied | Re-check Step 2.4, `insecureEnableGroups: true`, and the `O2_DEX_GROUP_*` variables. Decode the token to confirm the `groups` claim shape. |
 | Login loops or immediately fails | Wrong Keycloak client secret in Dex | Re-copy the secret from Keycloak's Credentials tab into the connector config and restart Dex. |
-| Keycloak issues tokens with the in-cluster URL | Frontend hostname not set | Set `KC_HOSTNAME=keycloak.cluster1.example.com` (already in [k8s-deployment.yml](k8s-deployment.yml)). |
+| Keycloak issues tokens with the in-cluster URL | Frontend hostname not set | Set `KC_HOSTNAME=keycloak.cluster1.example.com` (already in `k8s-deployment.yml`). |
 
 ## Security Checklist
 

--- a/docs/user-guide/account-administration/management/index.md
+++ b/docs/user-guide/account-administration/management/index.md
@@ -5,18 +5,8 @@ description: Management tools in OpenObserve cover streaming search, query manag
 
 The Management section includes tools for maintaining and securing OpenObserve operations. It allows users to manage saved queries, configure alert destinations, create reusable templates, review audit trails, handle encryption keys, and monitor node-level performance and resource metrics.
 
-:::note[Learn more]
+## In this section
 
-- ### [Streaming Search](streaming-search.md)
-- ### [Streaming Aggregation](aggregation-cache.md)
-- ### [Query Management](query-management.md)
-- ### [Alert Destinations](alert-destinations.md)
-- ### [Templates](templates.md)
-- ### [Audit trail](audit-trail.md)
-- ### [Cipher Keys](cipher-keys.md)
-- ### [Nodes in OpenObserve](nodes.md)
-- ### [SSO Domain Restrictions](sso-domain-restrictions.md)
-- ### [Sensitive Data Redaction](sensitive-data-redaction.md)
-:::
+::child-pages
 
 

--- a/docs/user-guide/account-administration/management/sensitive-data-redaction.md
+++ b/docs/user-guide/account-administration/management/sensitive-data-redaction.md
@@ -40,7 +40,7 @@ This opens the Sensitive Data Redaction interface, where you can view, create, a
 :::
 
 :::note[Who can access]
-`Root` users have full access to both pattern creation and pattern association by default. For other users, permissions are controlled via the **Regexp Patterns** and **Streams** module in the **IAM** settings, using [role-based access control (RBAC)](https://openobserve.ai/docs/user-guide/identity-and-access-management/role-based-access-control/).
+`Root` users have full access to both pattern creation and pattern association by default. For other users, permissions are controlled via the **Regexp Patterns** and **Streams** module in the **IAM** settings, using [role-based access control (RBAC)](../identity-and-access-management/role-based-access-control.md).
 
 **Pattern Creation:**
 

--- a/docs/user-guide/advanced/siem.md
+++ b/docs/user-guide/advanced/siem.md
@@ -116,7 +116,7 @@ if .Operation == "UserLoginFailed" {
 
 Raw logs often lack context. Is IP 1.2.3.4 a customer or a known botnet? OpenObserve allows you to use **Enrichment Tables** to correlate live logs with external Threat Intelligence.
 
-Threat Intel feeds (such as lists of malicious IPs or domains) can be uploaded periodically as CSV files to OpenObserve. For detailed instructions on managing these tables, refer to the [Enrichment Tables Documentation](https://openobserve.ai/docs/user-guide/enrichment-tables/enrichment/).
+Threat Intel feeds (such as lists of malicious IPs or domains) can be uploaded periodically as CSV files to OpenObserve. For detailed instructions on managing these tables, refer to the [Enrichment Tables Documentation](../data-processing/enrichment-tables/enrichment.md).
 
 There are two primary methods to utilize this data:
 

--- a/docs/user-guide/data-exploration/logs/insights.md
+++ b/docs/user-guide/data-exploration/logs/insights.md
@@ -122,9 +122,9 @@ Click "Fields (X)" button to:
 ## Additional Resources
 
 - **Detailed guide with examples**: [From Symptoms to Quick Insights blog post](https://openobserve.ai/blog/observability-insights-troubleshooting-guide)
-- **Logs guide**: [Logs documentation](https://openobserve.ai/docs/user-guide/logs/)
+- **Logs guide**: [Logs documentation](index.md)
 - **Traces guide**: [Traces documentation](https://openobserve.ai/docs/user-guide/data-exploration/traces/)
-- **Alerts setup**: [Alerts documentation](https://openobserve.ai/docs/user-guide/alerts/)
+- **Alerts setup**: [Alerts documentation](../../analytics/alerts/index.md)
 
 
 ---

--- a/docs/user-guide/data-exploration/traces/index.md
+++ b/docs/user-guide/data-exploration/traces/index.md
@@ -5,10 +5,6 @@ description: Traces in OpenObserve show how requests flow across services in dis
 
 Traces help you understand how requests flow across services, identify performance bottlenecks, and troubleshoot errors in distributed systems.
 
-:::note[Learn more]
-- ### [Traces in OpenObserve](traces.md)
-:::
-
 ## In this section
 
 ::child-pages

--- a/docs/user-guide/data-processing/actions/create-and-use-real-time-actions.md
+++ b/docs/user-guide/data-processing/actions/create-and-use-real-time-actions.md
@@ -14,7 +14,7 @@ This feature is available in Enterprise Edition and Cloud. Not available in Open
 ## Create a Real-time Action
 :::accordion[Prerequisite]
 Create a Service Account and Assign a Role 
-A [Service Account](https://openobserve.ai/docs/user-guide/identity-and-access-management/role-based-access-control/#service-accounts) in OpenObserve is a way to give specific identity access to system features and data. When you create a service account:
+A [Service Account](../../account-administration/identity-and-access-management/role-based-access-control.md#service-accounts) in OpenObserve is a way to give specific identity access to system features and data. When you create a service account:
 
 - OpenObserve generates a secure token (like a password).  
 - You assign explicit permissions to that account. For example, access to:  

--- a/docs/user-guide/data-processing/pipelines/pipelines.md
+++ b/docs/user-guide/data-processing/pipelines/pipelines.md
@@ -127,4 +127,4 @@ OpenObserve maintains a cache for scheduled pipelines to prevent the alert manag
 - [Create and Use Real-time Pipelines](./create-and-use-real-time-pipeline.md)
 - [Create and Use Scheduled Pipeline](./create-and-use-scheduled-pipeline.md)
 - [Manage Pipelines](./manage-pipelines.md)
-- [Environment Variables to Configure Pipelines](https://openobserve.ai/docs/environment-variables/#pipeline)
+- [Environment Variables to Configure Pipelines](../../../administration/configuration/environment-variables.md#pipeline)

--- a/docs/user-guide/data-processing/pipelines/use-pipelines.md
+++ b/docs/user-guide/data-processing/pipelines/use-pipelines.md
@@ -77,7 +77,7 @@ This opens up the pipeline editor.
 
     **Note**: In the **Associate Function** fom, the **After Flattening** toggle is enabled by default. Disable it only if necessary.
     <br>The **After Flattening** toggle determines whether the function processes data after it has been transformed into a simpler, flat structure. When enabled (default), the function operates on pre-processed, structured data, making it easier to analyze. Disabling it allows the function to work with the original data.
-    <br>For more details, see the [Functions Guide](https://openobserve.ai/docs/user-guide/functions/).
+    <br>For more details, see the [Functions Guide](../functions/functions-in-openobserve.md).
 
 3. Click **Save** to confirm the transform node.
 
@@ -126,7 +126,7 @@ Ensure that the pipeline is active.
 
 ### Step 1: Ingest Data 
 
-Use `curl` or other [data ingestion options in OpenObserve](https://openobserve.ai/docs/user-guide/ingestion/).
+Use `curl` or other [data ingestion options in OpenObserve](../../../ingestion/index.md).
 
 **Example**: Ingesting new data from the `k8slog_json.json` file into the `k8s_logs` stream, which is under the `default` organization:
 > `curl http://localhost:5080/api/default/k8s_logs/_json -i -u 'root@example.com:Complexpass#123' --data-binary "@k8slog_json.json"`

--- a/docs/user-guide/data-processing/streams/index.md
+++ b/docs/user-guide/data-processing/streams/index.md
@@ -5,13 +5,6 @@ description: Streams in OpenObserve define how observability data is ingested, s
 
 Streams define how observability data is ingested, stored, indexed, and queried in OpenObserve. This guide introduces key concepts related to streams and explains how to create and use them.
 
-:::note[Learn more:]
-- ### [Streams in OpenObserve](streams-in-openobserve.md)
-- ### [Stream Details](stream-details.md)
-- ### [Schema Settings](schema-settings.md)
-- ### [Extended Retention](extended-retention.md)
-- ### [Summary Streams](summary-streams.md)
-- ### [Data Type and Index Types in Streams](data-type-and-index-type-in-streams.md)
-- ### [Field and Index Types in Streams](data-type-and-index-type-in-streams.md)
-- ### [Query Recommendations Stream](query-recommendations.md)
-:::
+## In this section
+
+::child-pages

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "scripts": {
     "prebuild": "node scripts/copy-assets.mjs && node scripts/check-seo.mjs",
     "check:seo": "node scripts/check-seo.mjs",
+    "check:links": "node scripts/check-links.mjs",
     "dev": "node scripts/copy-assets.mjs && next dev -p 3030",
     "build": "next build",
-    "postbuild": "node scripts/post-export.mjs",
+    "postbuild": "node scripts/post-export.mjs && node scripts/check-links.mjs",
     "start": "next start",
     "postinstall": "fumadocs-mdx"
   },

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,134 @@
+/**
+ * Fails the build on internal links that 404 in the exported site.
+ *
+ * This runs against `out/`, not the Markdown sources, because two of the three
+ * failure modes are invisible earlier:
+ *
+ *   - A link written inside a heading is copied into the table of contents as a
+ *     bare <a>, bypassing next/link and so never getting the /docs basePath.
+ *     The remark stage sees a correct link; the render is what breaks it.
+ *   - Fully-qualified https://openobserve.ai/docs/... links are left alone by
+ *     remarkMkdocsLinks, so a page move never updates them.
+ *
+ * The third — a relative link to a file that does not exist — is caught by
+ * `onBrokenLink` too, but is cheap to re-check here and keeps one report.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const OUT = path.resolve('out');
+const BASE_PATH = '/docs';
+const SITE_HOST = 'openobserve.ai';
+
+if (!fs.existsSync(OUT)) {
+  console.error(`check-links: ${OUT} does not exist — run the export first.`);
+  process.exit(1);
+}
+
+function walk(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(p, acc);
+    else acc.push(p);
+  }
+  return acc;
+}
+
+const files = walk(OUT);
+
+/** Every path the export can serve, normalised without a trailing slash. */
+const served = new Set();
+for (const file of files) {
+  const rel = path.relative(OUT, file).replace(/\\/g, '/');
+  served.add(`${BASE_PATH}/${rel}`);
+  if (rel === 'index.html') served.add(BASE_PATH);
+  else if (rel.endsWith('/index.html')) {
+    served.add(`${BASE_PATH}/${rel.slice(0, -'/index.html'.length)}`);
+  }
+}
+
+const norm = (p) => (p.length > 1 ? p.replace(/\/+$/, '') : p) || '/';
+const resolves = (p) => served.has(norm(p)) || served.has(`${norm(p)}.html`);
+
+// Bounded and lazy so a 250 KB single-line document cannot make this quadratic.
+const ANCHOR = /<a\b[^>]{0,600}?href="([^"]{0,600})"/gi;
+
+const broken = new Map(); // "class\ttarget" -> Set of pages
+function report(kind, target, page) {
+  const key = `${kind}\t${target}`;
+  if (!broken.has(key)) broken.set(key, new Set());
+  broken.get(key).add(page);
+}
+
+let checked = 0;
+for (const file of files) {
+  if (!file.endsWith('.html')) continue;
+  const html = fs.readFileSync(file, 'utf8');
+  const rel = path.relative(OUT, file).replace(/\\/g, '/');
+  const pageUrl = norm(`${BASE_PATH}/${rel.replace(/(^|\/)index\.html$/, '')}`);
+
+  for (const match of html.matchAll(ANCHOR)) {
+    const href = match[1];
+    if (!href || href.startsWith('#')) continue;
+    if (/^(mailto:|tel:|data:|javascript:)/i.test(href)) continue;
+    checked++;
+
+    const bare = href.split('#')[0].split('?')[0];
+    if (!bare) continue;
+
+    if (/^https?:\/\//i.test(href)) {
+      let url;
+      try {
+        url = new URL(href);
+      } catch {
+        report('malformed URL', href, pageUrl);
+        continue;
+      }
+      // Only our own docs paths are checkable; the marketing site and third
+      // parties are out of scope for a static check.
+      if (url.hostname !== SITE_HOST && !url.hostname.endsWith(`.${SITE_HOST}`)) continue;
+      if (url.pathname !== BASE_PATH && !url.pathname.startsWith(`${BASE_PATH}/`)) continue;
+      if (!resolves(url.pathname)) report('stale absolute URL', url.pathname, pageUrl);
+      continue;
+    }
+
+    if (bare.startsWith('//')) continue; // protocol-relative, external
+
+    if (bare.startsWith('/')) {
+      // A root-relative link that is not under basePath lands on the marketing
+      // site. This is what a link inside a heading produces.
+      if (bare !== BASE_PATH && !bare.startsWith(`${BASE_PATH}/`)) {
+        report(`missing ${BASE_PATH} basePath`, bare, pageUrl);
+      } else if (!resolves(bare)) {
+        report('broken root-relative link', bare, pageUrl);
+      }
+      continue;
+    }
+
+    const resolved = norm(path.posix.resolve(pageUrl, bare));
+    if (!resolves(resolved)) report('unresolved relative link', `${bare} -> ${resolved}`, pageUrl);
+  }
+}
+
+if (broken.size === 0) {
+  console.log(`check-links: ${checked} links checked, no broken internal links.`);
+  process.exit(0);
+}
+
+console.error(`\ncheck-links: ${broken.size} broken internal link target(s):\n`);
+const byKind = new Map();
+for (const [key, pages] of broken) {
+  const [kind, target] = key.split('\t');
+  if (!byKind.has(kind)) byKind.set(kind, []);
+  byKind.get(kind).push([target, pages]);
+}
+for (const [kind, entries] of [...byKind.entries()].sort()) {
+  console.error(`  ${kind} (${entries.length}):`);
+  for (const [target, pages] of entries.sort()) {
+    console.error(`    ${target}`);
+    for (const page of [...pages].sort().slice(0, 5)) console.error(`        on ${page}`);
+    if (pages.size > 5) console.error(`        ...and ${pages.size - 5} more page(s)`);
+  }
+}
+console.error('');
+process.exit(1);


### PR DESCRIPTION
The audit recorded 33 links that 404 in the built site, in three classes.

Twenty were never authored: a link written inside a heading is copied into the table of contents as a bare <a>, which bypasses next/link and so never gets the /docs basePath, landing on the marketing root. It also emitted nested anchors. Fixed at the source by taking links out of headings -- management/ and streams/ now use ::child-pages, which also closes the drift the audit noted (the hand-written lists were missing four child pages and listed one page twice), traces/ drops a note block that duplicated the ::child-pages list directly below it, and the two headings on features/frontend.md are unlinked with the links moved into the body.

Nine were fully-qualified https://openobserve.ai/docs/... URLs pointing at pages that moved; remarkMkdocsLinks leaves those alone. They are now relative .md links, so the rewriter resolves them and the next move fails the build instead of the page. The two anchors carried over (#pipeline, #service-accounts) both still exist on their new targets.

Four were relative links on keycloak-sso to YAML files that were never shipped in docs/. They are inline code now, matching how the same filenames already appear in the kubectl blocks on that page.

Adds scripts/check-links.mjs, run from postbuild, which resolves every internal href in out/ against the paths the export actually writes. It has to run over the rendered HTML: the basePath class does not exist at the remark stage, and the absolute class was never a relative link. Against the pre-fix export it reported exactly the 33 in the same 20/9/4 split; against this build, 0 of 8812 links.