### PR TITLE
fix(nav): move the marketing links to the bottom of the docs sidebar

### DIFF
--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -1,4 +1,5 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
+import { SidebarItem } from 'fumadocs-ui/components/sidebar/base';
 import { BASE_PATH } from '@/lib/constants';
 
 /**
@@ -23,10 +24,6 @@ export const baseOptions: BaseLayoutProps = {
     url: '/',
   },
   links: [
-    { text: 'Home', url: 'https://openobserve.ai/', external: true },
-    { text: 'Blog', url: 'https://openobserve.ai/blog/', external: true },
-    { text: 'Downloads', url: 'https://openobserve.ai/downloads/', external: true },
-    { text: 'Cloud', url: 'https://cloud.openobserve.ai/', external: true },
     {
       type: 'icon',
       icon: (
@@ -40,3 +37,42 @@ export const baseOptions: BaseLayoutProps = {
     },
   ],
 };
+
+/**
+ * Marketing-site links. Passed as the docs sidebar's `footer` rather than as
+ * `baseOptions.links` so they sit *below* the page tree instead of above it —
+ * fumadocs renders text link items at the top of the sidebar viewport. Absolute
+ * URLs for the same reason as `nav` above: they leave the docs `basePath`.
+ */
+const siteLinks = [
+  { text: 'Home', url: 'https://openobserve.ai/', external: true },
+  { text: 'Blog', url: 'https://openobserve.ai/blog/', external: true },
+  { text: 'Downloads', url: 'https://openobserve.ai/downloads/', external: true },
+  { text: 'Cloud', url: 'https://cloud.openobserve.ai/', external: true },
+];
+
+/**
+ * Copy of the classes fumadocs' own `SidebarItem` applies to a top-level link
+ * (`itemVariants({ variant: 'link' })` in `layouts/docs/slots/sidebar`), so
+ * these render identically to the page-tree entries above them.
+ */
+const sidebarItemClass =
+  'relative flex flex-row items-center gap-2 rounded-lg p-2 text-start ' +
+  'text-fd-muted-foreground wrap-anywhere [&_svg]:size-4 [&_svg]:shrink-0 ' +
+  'transition-colors hover:bg-fd-accent/50 hover:text-fd-accent-foreground/80 hover:transition-none';
+
+export function SidebarSiteLinks() {
+  return (
+    // `order-first` lifts this above the icon-links / theme-switch row that
+    // fumadocs renders in the same flex column of the sidebar footer.
+    <nav className="flex flex-col order-first mb-2">
+      {siteLinks.map((link) => (
+        // `SidebarItem` is what the page tree uses, so `external` still draws
+        // the same external-link icon these entries had as `baseOptions.links`.
+        <SidebarItem key={link.url} href={link.url} external={link.external} className={sidebarItemClass}>
+          {link.text}
+        </SidebarItem>
+      ))}
+    </nav>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import { Inter } from 'next/font/google';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { source } from '@/lib/source';
-import { baseOptions } from '@/app/layout.config';
+import { baseOptions, SidebarSiteLinks } from '@/app/layout.config';
 import { Analytics, GtmNoScript } from '@/components/analytics';
 import { SiteStructuredData } from '@/components/structured-data';
 import SearchDialog from '@/components/search-dialog';
@@ -51,7 +51,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <GtmNoScript />
         <SiteStructuredData />
         <RootProvider search={{ SearchDialog }}>
-          <DocsLayout tree={source.pageTree} {...baseOptions}>
+          <DocsLayout
+            tree={source.pageTree}
+            {...baseOptions}
+            sidebar={{ footer: <SidebarSiteLinks /> }}
+          >
             {children}
           </DocsLayout>
         </RootProvider>


### PR DESCRIPTION
Home / Blog / Downloads / Cloud were declared as `baseOptions.links`, which fumadocs always renders at the top of the sidebar viewport, above the page tree. There is no ordering option for that slot, so they move to the sidebar `footer` slot instead.

They keep their previous design: the footer renders fumadocs' own `SidebarItem`, so `external: true` still draws the external-link icon, and the items reuse the class string fumadocs applies to top-level sidebar links. `order-first` lifts them above the GitHub / theme-switch row that shares the same flex column.