### PR TITLE
docs: rename AlertManager node role to Scheduler

### DIFF
--- a/docs/administration/configuration/environment-variables.md
+++ b/docs/administration/configuration/environment-variables.md
@@ -23,7 +23,7 @@ Pick the form that matches how you run OpenObserve:
 | ZO_ROOT_USER_PASSWORD | - | Password for the root user. |
 | ZO_LOCAL_MODE | true | If local mode is set to true, OpenObserve becomes single node deployment.If it is set to false, it indicates cluster mode deployment which supports multiple nodes with different roles. For local mode one needs to configure SQLite DB, for cluster mode one needs to configure PostgreSQL (recommended) or MySQL. |
 | ZO_LOCAL_MODE_STORAGE | disk | Applicable only for local mode. By default, local disk is used as storage. OpenObserve supports both disk and S3 in local mode. |
-| ZO_NODE_ROLE | all | Node role assignment. Possible values are ingester, querier, router, compactor, alertmanager, and all. A single node can have multiple roles by specifying them as a comma-separated list. For example, compactor, alertmanager. |
+| ZO_NODE_ROLE | all | Node role assignment. Possible values are ingester, querier, router, compactor, scheduler, and all. A single node can have multiple roles by specifying them as a comma-separated list. For example, compactor, scheduler. |
 | ZO_NODE_ROLE_GROUP | "" | Each query-processing node can be assigned to a specific group using ZO_NODE_ROLE_GROUP. <br>- **interactive**: Handles queries triggered directly by users through the UI. <br>- **background**: Handles automated or scheduled queries, such as alerts and reports. <br>- **empty string** (default): Handles all query types. <br>
 In high-load environments, alerts or reports might run large, resource-intensive queries. By assigning dedicated groups, administrators can prevent such queries from blocking or slowing down real-time user searches. |
 | ZO_NODE_HEARTBEAT_TTL | 30 | Time-to-live (TTL) for node heartbeats in seconds. |
@@ -199,10 +199,10 @@ In high-load environments, alerts or reports might run large, resource-intensive
 ## Alerts and Reports
 | Environment Variable | Default Value | Description |
 |---------------------|---------------|-------------|
-| ZO_ALERT_SCHEDULE_INTERVAL | 10s | Defines how often the alert manager checks for scheduled jobs such as alerts, reports, or scheduled pipelines. The default value is 10 seconds. This means the alert manager fetches and processes alerts, reports, and pipelines every 10 seconds. |
-| ZO_ALERT_SCHEDULE_TIMEOUT           | 90     | The maximum expected time duration in seconds within which the processing of alert by the alert manager should be complete. If the processing of the alert is not complete within the timeframe, the alert will become available again for other alert managers to pick. |
-| ZO_SCHEDULER_WATCH_INTERVAL         | 30    | The scheduler frequently watches if there are any scheduled jobs which are in processing state for more than the `ZO_ALERT_SCHEDULE_TIMEOUT`/`ZO_REPORT_SCHEDULE_TIMEOUT`, if so it increases their `retries` field by 1 and marks them as available for processing again by alert managers. |
-| ZO_ALERT_SCHEDULE_CONCURRENCY       | 5   | The number of scheduled jobs the the alert manager will pull at a time from the scheduler for processing |
+| ZO_ALERT_SCHEDULE_INTERVAL | 10s | Defines how often the scheduler checks for scheduled jobs such as alerts, reports, or scheduled pipelines. The default value is 10 seconds. This means the scheduler fetches and processes alerts, reports, and pipelines every 10 seconds. |
+| ZO_ALERT_SCHEDULE_TIMEOUT           | 90     | The maximum expected time duration in seconds within which the processing of alert by the scheduler should be complete. If the processing of the alert is not complete within the timeframe, the alert will become available again for other schedulers to pick. |
+| ZO_SCHEDULER_WATCH_INTERVAL         | 30    | The scheduler frequently watches if there are any scheduled jobs which are in processing state for more than the `ZO_ALERT_SCHEDULE_TIMEOUT`/`ZO_REPORT_SCHEDULE_TIMEOUT`, if so it increases their `retries` field by 1 and marks them as available for processing again by schedulers. |
+| ZO_ALERT_SCHEDULE_CONCURRENCY       | 5   | The number of scheduled jobs the the scheduler will pull at a time from the scheduler for processing |
 | ZO_CHROME_ENABLED                   | false  | When true, it looks for chromium executable. Required for dashboard reports. |
 | ZO_CHROME_PATH                      | -  | If chrome is enabled, custom chrome executable path can be specified. If not specified, it looks for chrome executable in default locations. If still not found, it automatically downloads a good known version of chromium. |
 | ZO_CHROME_CHECK_DEFAULT_PATH        | true | If false, it skips default locations (e.g. CHROME env, usual chrome file path etc.) when looking for chrome executable. |
@@ -216,11 +216,11 @@ In high-load environments, alerts or reports might run large, resource-intensive
 | ZO_SCHEDULER_CLEAN_INTERVAL         | 30   | The interval in seconds after which the scheduler will clean up the completed scheduled jobs. |
 | ZO_REPORT_USER_NAME                 |  | The username that will be used by the headless chromium to login into openobserve and generate report. |
 | ZO_REPORT_USER_PASSWORD             |  | The password that will be used by the headless chromium to login into openobserve and generate report. |
-| ZO_ENABLE_EMBEDDED_REPORT_SERVER    | false  | If true, the alert manager (for which this ENV is enabled) spawns a new report-server running on PORT `5082` (default, can be changed through `ZO_REPORT_SERVER_HTTP_PORT`). |
+| ZO_ENABLE_EMBEDDED_REPORT_SERVER    | false  | If true, the scheduler (for which this ENV is enabled) spawns a new report-server running on PORT `5082` (default, can be changed through `ZO_REPORT_SERVER_HTTP_PORT`). |
 | ZO_REPORT_SERVER_HTTP_PORT          | `5082` | The port used by the newly spawned report-server. |
 | ZO_REPORT_SERVER_HTTP_ADDR          | `127.0.0.1`  | The ip address used by the newly spawned report-server. |
 | ZO_REPORT_SERVER_URL                | `localhost:5082` | The report server server URL. E.g. - `https://report-server.example.com/api`. |
-| ZO_REPORT_SERVER_SKIP_TLS_VERIFY    | false| If true, it will skip tls verification while making request to report-server from alert manager. |
+| ZO_REPORT_SERVER_SKIP_TLS_VERIFY    | false| If true, it will skip tls verification while making request to report-server from scheduler. |
 
 ## Enrichment Tables
 | Environment Variable | Default Value | Description |

--- a/docs/administration/deployment/ha-deployment.md
+++ b/docs/administration/deployment/ha-deployment.md
@@ -262,7 +262,7 @@ STATUS: deployed
 REVISION: 1
 ```
 
-- ~12 pods, every one `READY 1/1` (or `2/2` for NATS) and `STATUS Running`. Components: NATS x3, postgres x2, openfga, alertmanager, router, ingester, querier, compactor, openfga-init.
+- ~12 pods, every one `READY 1/1` (or `2/2` for NATS) and `STATUS Running`. Components: NATS x3, postgres x2, openfga, scheduler, router, ingester, querier, compactor, openfga-init.
 - Image: `o2cr.ai/openobserve/openobserve-enterprise:<tag>` (or the OSS image, depending on your chart values).
 - If a pod is stuck in `ImagePullBackOff`, check `kubectl -n openobserve describe pod <name>` and verify outbound internet from the cluster.
 :::

--- a/docs/administration/maintenance/operator-guide/simd.md
+++ b/docs/administration/maintenance/operator-guide/simd.md
@@ -47,7 +47,7 @@ nodeSelector:
   querier: *AVX_NODE_SELECTOR
   compactor: *AVX_NODE_SELECTOR
   router: *AVX_NODE_SELECTOR
-  alertmanager: *AVX_NODE_SELECTOR
+  scheduler: *AVX_NODE_SELECTOR
 ```
 
 ### With `openobserve-standalone`
@@ -59,4 +59,3 @@ image:
 nodeSelector:
   feature.node.kubernetes.io/cpu-cpuid.AVX512F: "true"
 ```
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ keywords: openobserve, architecture, tutorial
 
 # OpenObserve Architecture and Deployment Modes
 
-OpenObserve is an observability platform with a distributed architecture composed of five node types — Router, Ingester, Compactor, Querier, and AlertManager — that runs in either single-node mode (SQLite with local disk or object storage) or high-availability mode (NATS, PostgreSQL, and object storage).
+OpenObserve is an observability platform with a distributed architecture composed of five node types — Router, Ingester, Compactor, Querier, and Scheduler — that runs in either single-node mode (SQLite with local disk or object storage) or high-availability mode (NATS, PostgreSQL, and object storage).
 
 This page explains how OpenObserve is structured: the deployment modes you can run it in, what each component does, how data flows from ingest to query, and how the system keeps your data durable. It is useful if you are sizing a deployment, troubleshooting a cluster, or evaluating OpenObserve against other observability backends.
 
@@ -41,7 +41,7 @@ HA mode does not support local disk storage. Please refer to [HA Deployment](adm
 - Object storage (Amazon S3, GCS, MinIO, or Azure Blob) for parquet files
 - PostgreSQL for metadata
 - NATS for cluster coordination
-- At least one node of each type (Router, Ingester, Compactor, Querier, AlertManager)
+- At least one node of each type (Router, Ingester, Compactor, Querier, Scheduler)
 
 <img src="images/arch-ha.webp" alt="HA architecture using NATS and s3" width="80%">
 
@@ -51,7 +51,7 @@ In OpenObserve HA mode, the following node types can be scaled horizontally to a
 - Querier
 - Ingester
 - Compactor
-- AlertManager
+- Scheduler
 
 HA mode uses NATS as a cluster coordinator as well as for cluster events and storing the nodes' information.
 
@@ -78,7 +78,7 @@ At the EBS levels, additional in-app replication mostly adds cost and complexity
 
 At a high level, data and requests move through these components:
 
-Router → Ingester → Compactor → Querier → AlertManager.
+Router → Ingester → Compactor → Querier → Scheduler.
 
 | Component | Role | Stateful? | Scales horizontally? |
 | --- | --- | --- | --- |
@@ -86,7 +86,7 @@ Router → Ingester → Compactor → Querier → AlertManager.
 | Ingester | Receives ingest requests, converts data to parquet, and writes it to object storage | Yes (buffers in WAL, Memtable, and local parquet) | Yes |
 | Compactor | Merges small files into big files, enforces retention, and updates file list indices | No | Yes |
 | Querier | Executes search queries | No (fully stateless) | Yes |
-| AlertManager | Runs alert queries and report jobs and sends notifications | No | Yes |
+| Scheduler | Runs alert queries and report jobs and sends notifications | No | Yes |
 
 ### Router
 
@@ -163,9 +163,9 @@ The federated search spans over multiple OpenObserve clusters:
 4. `WORKER clusters` execute the query as described above. One of the nodes in each cluster becomes a `LEADER querier` and calls other `WORKER queriers` in the same cluster. The results from all workers and leaders are merged by `LEADER cluster`.
 5. `LEADER cluster` collects, merges and sends the result back to the user.
 
-### AlertManager
+### Scheduler
 
-The AlertManager node runs the standard alert queries, reports jobs and sends notifications.
+The Scheduler node runs the standard alert queries, reports jobs and sends notifications.
 
 ## Next steps
 

--- a/docs/enterprise-setup/amazon-eks.md
+++ b/docs/enterprise-setup/amazon-eks.md
@@ -471,7 +471,7 @@ STATUS: deployed
 REVISION: 1
 ```
 
-- ~12 pods, every one `READY 1/1` (or `2/2` for NATS) and `STATUS Running`. Components: NATS x3, postgres x2, openfga, alertmanager, router, ingester, querier, compactor, openfga-init.
+- ~12 pods, every one `READY 1/1` (or `2/2` for NATS) and `STATUS Running`. Components: NATS x3, postgres x2, openfga, scheduler, router, ingester, querier, compactor, openfga-init.
 - Service account annotation: your `ROLE_ARN` from Step 2.
 - Image: `o2cr.ai/openobserve/openobserve-enterprise:<tag>`.
 :::

--- a/docs/enterprise-setup/azure-aks.md
+++ b/docs/enterprise-setup/azure-aks.md
@@ -373,14 +373,14 @@ Re-run `kubectl get pods` every minute or so for about 5 minutes. Progression:
 
 1. Pods start in `Init:0/1` or `Pending`.
 2. NATS, OpenFGA, and Postgres come up first.
-3. Ingester, querier, alertmanager, compactor, and router follow once Postgres is ready.
+3. Ingester, querier, scheduler, compactor, and router follow once Postgres is ready.
 4. Final state: every pod `1/1 Running` (or `2/2` for NATS) with stable `RESTARTS`.
 
 **Expected output**
 
 ```
 NAME                                     READY   STATUS    RESTARTS   AGE
-openobserve-alertmanager-0               1/1     Running   0          5m
+openobserve-scheduler-0               1/1     Running   0          5m
 openobserve-compactor-XXXXXXXXX-XXXXX    1/1     Running   0          5m
 openobserve-ingester-0                   1/1     Running   0          5m
 openobserve-nats-0                       2/2     Running   0          5m

--- a/docs/enterprise-setup/google-gke.md
+++ b/docs/enterprise-setup/google-gke.md
@@ -391,7 +391,7 @@ oo-nats-0                                  2/2     Running   0          2m
 oo-nats-1                                  2/2     Running   0          2m
 oo-nats-2                                  2/2     Running   0          2m
 oo-nats-box-...                            1/1     Running   0          2m
-oo-openobserve-alertmanager-0              1/1     Running   0          2m
+oo-openobserve-scheduler-0              1/1     Running   0          2m
 oo-openobserve-compactor-...               1/1     Running   0          2m
 oo-openobserve-dex-...                     1/1     Running   0          2m
 oo-openobserve-ingester-0                  1/1     Running   0          2m
@@ -614,7 +614,7 @@ Issues are grouped by theme. Each entry notes the step where it tends to surface
 
 **Quota and PVCs**
 
-- **Querier and alertmanager pods `Pending`, PVCs stuck `Pending`, events show `QUOTA_EXCEEDED ... SSD_TOTAL_GB`** (Step 7). Your `SSD_TOTAL_GB` quota is exceeded by node boot disks plus the default 100 GiB cache PVCs.
+- **Querier and scheduler pods `Pending`, PVCs stuck `Pending`, events show `QUOTA_EXCEEDED ... SSD_TOTAL_GB`** (Step 7). Your `SSD_TOTAL_GB` quota is exceeded by node boot disks plus the default 100 GiB cache PVCs.
 
     **Fix:** Pick one path.
 
@@ -631,7 +631,7 @@ Issues are grouped by theme. Each entry notes the step where it tends to surface
     In `values.yaml`, change four `size: 100Gi` entries to `size: 20Gi`:
 
     ```yaml
-    alertmanager:
+    scheduler:
       persistence:
         size: 20Gi
 

--- a/docs/enterprise-setup/terraform.md
+++ b/docs/enterprise-setup/terraform.md
@@ -172,7 +172,7 @@ module "openobserve" {
     querier      = 2
     router       = 2
     compactor    = 1
-    alertmanager = 1
+    scheduler = 1
   }
 
   meta_store          = "postgres"
@@ -198,7 +198,7 @@ module "openobserve" {
   persistence = {
     ingester     = { size = "100Gi", storage_class = "gp3" }
     querier      = { size = "100Gi", storage_class = "gp3" }
-    alertmanager = { size = "10Gi",  storage_class = "gp3" }
+    scheduler = { size = "10Gi",  storage_class = "gp3" }
   }
 
   resources = {
@@ -296,7 +296,7 @@ Reference data (256 GB/day):
                      │  ingester ◄────► querier                    │
                      │  (WAL + disk)   (disk cache)                 │
                      │      │              │                        │
-                     │  compactor      alertmanager                 │
+                     │  compactor      scheduler                 │
                      │      │                                        │
                      │  NATS (bundled or external)                  │
                      │      │                                        │

--- a/docs/reference/api/traces/index.md
+++ b/docs/reference/api/traces/index.md
@@ -24,8 +24,8 @@ This documentation provides comprehensive guidance on using the OpenObserve API 
 When a user performs a search query in OpenObserve:
 
 - The **trace** represents the entire search operation from query initiation to result return.
-- **Spans** might include: alert manager evaluation, query processing, gRPC search execution, cache operations, database interactions.
-- You can see the complete flow showing how the operation moves through different OpenObserve services (alert manager → querier → search services).
+- **Spans** might include: scheduler evaluation, query processing, gRPC search execution, cache operations, database interactions.
+- You can see the complete flow showing how the operation moves through different OpenObserve services (scheduler → querier → search services).
 - Each span shows the duration and status of individual OpenObserve components involved in processing the search request.
 :::
 

--- a/docs/user-guide/account-administration/management/nodes.md
+++ b/docs/user-guide/account-administration/management/nodes.md
@@ -39,7 +39,7 @@ By default, `root` users and `Admins` with access to the `_meta` organization ca
 - **Querier**: Responds to user queries and retrieves data from storage.  
 - **Compactor**: Merges smaller data files and applies retention policies.  
 - **Router**: Routes API requests and serves the OpenObserve user interface.  
-- **Alert Manager**: Manages alerting rules and runs scheduled tasks.
+- **Scheduler**: Manages alerting rules and runs scheduled tasks.
 
 ## View ky metrics
 
@@ -73,7 +73,7 @@ Each node displays the following metrics in a tabular format with progress bars 
 - **Filters**: 
 
     - **Region and Cluster (for super-cluster setup):** View nodes by deployment zone.  
-    - **Node Type**: Filter nodes by type, such as Ingester, Querier, or Alert Manager.  
+    - **Node Type**: Filter nodes by type, such as Ingester, Querier, or Scheduler.
     - **Status:** Show online or offline nodes.  
     - **CPU/Memory Usage:** Set value ranges to find over-utilized or under-utilized nodes.   
     - **TCP Connections**: Filter by connection state or count.  

--- a/docs/user-guide/advanced/query-tuning/monitor-download-queue-size-and-disk-cache-metrics.md
+++ b/docs/user-guide/advanced/query-tuning/monitor-download-queue-size-and-disk-cache-metrics.md
@@ -52,7 +52,7 @@ After plotting the chart, you will calculate the cache efficiency to evaluate ov
 When OpenObserve high-availability mode or multi-cluster mode is deployed in Kubernetes:
 
 - One cluster may host multiple namespaces.
-- Each namespace may include multiple nodes or services with different roles, such as querier, ingester, compactor, router, alert manager, and actions. 
+- Each namespace may include multiple nodes or services with different roles, such as querier, ingester, compactor, router, scheduler, and actions.
 - Each node or service may be deployed across multiple pods. 
 
 > In OpenObserve single node deployment, a single node handles all the roles. 

--- a/docs/user-guide/analytics/alerts/alert-history.md
+++ b/docs/user-guide/analytics/alerts/alert-history.md
@@ -28,7 +28,7 @@ Each row represents one alert evaluation.
 - **Alert Name**: The name of the configured alert.
 - **Type**: Indicates whether the alert is Scheduled or Real-time.
 - **Is Silenced**: Shows whether the alert was silenced during evaluation.
-- **Timestamp**: Time when the alert manager picked up the alert for evaluation.
+- **Timestamp**: Time when the scheduler picked up the alert for evaluation.
 - **Start Time** and **End Time**: The time range of data evaluated.
 - **Duration**: How long the alert condition remained true.
 - **Status**: The result of the alert evaluation.
@@ -82,5 +82,5 @@ This process applies only to users who have access to the `_meta` organization.
 ## Why you might see a skipped status
 A **skipped** status appears when a scheduled alert runs later than its expected window. <br>
 For example, an alert configured with a 5-minute period and 5-minute frequency is scheduled to run at 12:00 PM. <br>It should normally evaluate data from 11:55 to 12:00.
-If the alert manager experiences a delay and runs the job at 12:05 PM, it evaluates the current aligned window (12:00 to 12:05) instead of the earlier one.<br> The earlier window (11:55 to 12:00) is marked as skipped to indicate that evaluation for that range did not occur because of delay in job pickup or data availability.
+If the scheduler experiences a delay and runs the job at 12:05 PM, it evaluates the current aligned window (12:00 to 12:05) instead of the earlier one.<br> The earlier window (11:55 to 12:00) is marked as skipped to indicate that evaluation for that range did not occur because of delay in job pickup or data availability.
 

--- a/docs/user-guide/analytics/alerts/scheduled-alerts.md
+++ b/docs/user-guide/analytics/alerts/scheduled-alerts.md
@@ -164,7 +164,7 @@ You can apply this to logs, metrics, or traces.
 
 When a scheduled alert with Multi-window Selector runs:
 
-1. The alert manager executes your SQL query for each window (current + past windows)
+1. The scheduler executes your SQL query for each window (current + past windows)
 2. Results are passed to your VRL function for comparison
 3. The VRL output is checked against your threshold condition
 4. If the condition is met, a notification is sent
@@ -215,7 +215,7 @@ Set the time range to evaluate per run (e.g., last 30 minutes) in the **Compare 
 
 Click **Add Comparison Window** and select the historical window to compare against (e.g., 1 day ago).
 
-The alert manager will run two queries at runtime:
+The scheduler will run two queries at runtime:
 
 1. Current window (e.g., 9:30–10:00 AM today)
 2. Past window (e.g., 9:30–10:00 AM yesterday)
@@ -299,7 +299,7 @@ Select a destination, optionally add a row template with fields from your VRL ou
 
 Yes. Every window — current and past — uses the same duration defined by the period.
 
-**Does the alert manager run multiple queries within one window?**
+**Does the scheduler run multiple queries within one window?**
 
 No. It runs one query per window. Frequency controls *when* the queries run; period controls *what time range* each query covers.
 

--- a/docs/user-guide/data-exploration/federated-search/federated-search-architecture.md
+++ b/docs/user-guide/data-exploration/federated-search/federated-search-architecture.md
@@ -23,7 +23,7 @@ When you need scale, multiple specialized nodes work together as a cluster. Each
 - **Querier**: Processes queries in parallel with other queriers
 - **Ingester**: Receives and stores data in object storage
 - **Compactor**: Optimizes files and enforces retention
-- **Alertmanager**: Executes alerts and sends notifications
+- **Scheduler**: Executes alerts and sends notifications
 
 A single cluster handles more data and provides higher availability than a single node.
 

--- a/docs/user-guide/data-exploration/traces/traces.md
+++ b/docs/user-guide/data-exploration/traces/traces.md
@@ -130,7 +130,7 @@ Apply the environment variable changes and restart the service.
 3. From the left navigation menu, go to **Traces**. 
 4. Select the trace stream. 
 5. Set the time range to the last few minutes, and open the newest trace. 
-6. You should see spans from services such as querier, ingester, or alertmanager.
+6. You should see spans from services such as querier, ingester, or scheduler.
 :::
 
 ## Configure to monitor an external application
@@ -183,7 +183,7 @@ To configure this:
 2. In your OpenObserve instance, go to Traces. 
 3. Select the trace stream. 
 4. Set the time range to the last few minutes, and open the newest trace. 
-5. You should see spans from services such as querier, ingester, or alertmanager.
+5. You should see spans from services such as querier, ingester, or scheduler.
 :::
 
 ## Configure and view log and trace correlation 

--- a/docs/user-guide/data-processing/pipelines/pipeline-history.md
+++ b/docs/user-guide/data-processing/pipelines/pipeline-history.md
@@ -43,5 +43,5 @@ When querying pipeline history over a time range, the range is capped by the `ma
 - **Query Time**: Time taken by the SQL query within the pipeline to execute. This helps measure query performance.
 - **Source Node**: Node responsible for executing the run. This helps identify where the execution occurred for debugging and performance monitoring.<br>
 Example: <br>
-**Source Node**: `o2-openobserve-alertmanager-0`
+**Source Node**: `o2-openobserve-scheduler-0`
 - **Error**: The error message describing why the run failed. Populated for runs with a `failed` status; empty otherwise.

--- a/docs/user-guide/data-processing/pipelines/pipelines.md
+++ b/docs/user-guide/data-processing/pipelines/pipelines.md
@@ -119,7 +119,7 @@ The transformed data is written to one or more destinations.
 Use scheduled pipelines for tasks that require processing at fixed intervals instead of continuously, such as generating periodic reports and processing historical data in batches.
 
 :::note[Cache for scheduled pipelines]
-OpenObserve maintains a cache for scheduled pipelines to prevent the alert manager from making unnecessary database calls. This cache becomes particularly beneficial when the number of scheduled pipelines is high. For example, with 500 scheduled pipelines, the cache eliminates 500 separate database queries each time the pipelines are triggered, significantly improving performance.
+OpenObserve maintains a cache for scheduled pipelines to prevent the scheduler from making unnecessary database calls. This cache becomes particularly beneficial when the number of scheduled pipelines is high. For example, with 500 scheduled pipelines, the cache eliminates 500 separate database queries each time the pipelines are triggered, significantly improving performance.
 :::
 
 ## Next steps


### PR DESCRIPTION
## Summary

- update architecture, configuration, deployment, UI, alerts, pipelines, traces, and query-tuning docs to use the Scheduler role
- update example pod names and Helm/Terraform configuration keys
- preserve references to the external Prometheus/Grafana Alertmanager product

## Why

This documents the coordinated node-role rename and its deployment-facing terminology.

## Coordination

- Core PR: https://github.com/openobserve/openobserve/pull/13696
- Enterprise PR: https://github.com/openobserve/o2-enterprise/pull/2376
- Helm PR: https://github.com/openobserve/openobserve-helm-chart/pull/240

This PR is part of the coordinated Scheduler rename across OpenObserve core, Enterprise, Helm, and docs.

## Verification

- rebased onto current `main`
- `git diff --check`
- repository-wide search confirms remaining Alertmanager references describe the external Prometheus/Grafana component
- MkDocs build not run locally because `mkdocs` is not installed