### PR TITLE
fix: convert MkDocs admonitions to remark directives on 13 pages

### DIFF
--- a/docs/user-guide/account-administration/identity-and-access-management/organizations.md
+++ b/docs/user-guide/account-administration/identity-and-access-management/organizations.md
@@ -49,8 +49,9 @@ To delegate organization management to users in enterprise mode:
 
     - **Create**: Add new organizations
     - **Update**: Modify organization details
-    !!! note "Note"
-        By default, OpenObserve displays the list of organizations a user belongs to. You do not need to explicitly grant permission to view or retrieve organization details.
+    :::note[Note]
+    By default, OpenObserve displays the list of organizations a user belongs to. You do not need to explicitly grant permission to view or retrieve organization details.
+    :::
 6. Click **Save**. <br>
 ![Grant Organization Management Access in OpenObserve](../../../images/organization-role-permission.png)
 

--- a/docs/user-guide/analytics/dashboards/variables/variables-in-openobserve.md
+++ b/docs/user-guide/analytics/dashboards/variables/variables-in-openobserve.md
@@ -36,9 +36,9 @@ To create a variable:
     - **Type of Variable**: Query Values
     - **Name**: pod
 
-        !!! Note
-            Variable names must be unique within a dashboard. If you enter a name that already exists, OpenObserve shows `Variable with same name already exists.` and does not save the variable.
-
+        :::note
+        Variable names must be unique within a dashboard. If you enter a name that already exists, OpenObserve shows `Variable with same name already exists.` and does not save the variable.
+        :::
     - **Label**: Pod
     - **Stream Type**: logs
     - **Stream**: `default`

--- a/docs/user-guide/data-exploration/rum/mobile/android.md
+++ b/docs/user-guide/data-exploration/rum/mobile/android.md
@@ -9,10 +9,10 @@ This guide walks through adding [OpenObserve](https://openobserve.ai) Real User 
 
 New to mobile RUM in general? Start with the [Mobile RUM Overview](./index.md) for the concepts — sessions, views, actions, resources, errors — that this guide assumes.
 
-!!! warning "Alpha status"
+:::warning[Alpha status]
 
-    The Android SDK is currently published as `0.1.0-alpha5`. It is ready to integrate and evaluate — pin the exact version and test upgrades, since some configuration details may change before the stable release.
-
+The Android SDK is currently published as `0.1.0-alpha5`. It is ready to integrate and evaluate — pin the exact version and test upgrades, since some configuration details may change before the stable release.
+:::
 ## What you get
 
 Once integrated, OpenObserve RUM automatically captures:
@@ -139,14 +139,14 @@ Register the `Application` class in your manifest so it actually runs:
 
 That is the whole setup. `OpenObserve.initialize` starts the core SDK, `Rum.enable` turns on RUM with the automatic instrumentation you configured, and data begins flowing to your OpenObserve instance.
 
-!!! note "The connection model"
+:::note[The connection model]
 
-    You pass the **client token** to `Configuration.Builder`, the **RUM application id** to `RumConfiguration.Builder`, and point `useCustomEndpoint` at your OpenObserve instance's base URL — the SDK appends the RUM intake path automatically. There is no separate "organization" field; your organization is part of the ingestion endpoint and token. The built-in `useSite(...)` managed-cloud presets (US1, EU1, and so on) are still being wired up for OpenObserve Cloud in this alpha, so use the custom-endpoint approach for self-hosted and today's setups.
+You pass the **client token** to `Configuration.Builder`, the **RUM application id** to `RumConfiguration.Builder`, and point `useCustomEndpoint` at your OpenObserve instance's base URL — the SDK appends the RUM intake path automatically. There is no separate "organization" field; your organization is part of the ingestion endpoint and token. The built-in `useSite(...)` managed-cloud presets (US1, EU1, and so on) are still being wired up for OpenObserve Cloud in this alpha, so use the custom-endpoint approach for self-hosted and today's setups.
+:::
+:::note[Consent gating]
 
-!!! note "Consent gating"
-
-    Nothing is collected until tracking consent is `GRANTED`. If you show a consent dialog, initialize with `TrackingConsent.PENDING` and call `OpenObserve.setTrackingConsent(TrackingConsent.GRANTED)` once the user agrees. See [Security & Privacy](./security-privacy.md).
-
+Nothing is collected until tracking consent is `GRANTED`. If you show a consent dialog, initialize with `TrackingConsent.PENDING` and call `OpenObserve.setTrackingConsent(TrackingConsent.GRANTED)` once the user agrees. See [Security & Privacy](./security-privacy.md).
+:::
 ## Step 3 — Configuration options
 
 ### Core options (`Configuration.Builder`)
@@ -367,10 +367,10 @@ This installs native signal handlers that capture crashes in your native librari
 
 If you ship a release build with R8/ProGuard, your stack traces arrive obfuscated, and NDK crashes arrive as raw addresses. To make them readable, OpenObserve publishes an **Android Gradle plugin** (id `io.openobserve.openobserve-sdk-android-gradle-plugin`) that uploads your R8/ProGuard **mapping files** and **NDK symbol files** as part of your build, so OpenObserve can deobfuscate and symbolicate crash reports automatically.
 
-!!! note
+:::note
 
-    The plugin's build-script configuration DSL is being finalized in the current alpha. Apply the plugin id above, then follow the current setup instructions in the [SDK's GitHub repository](https://github.com/openobserve) for wiring the upload task and credentials — the exact DSL is documented there and evolving quickly. See [Error & Crash Tracking](./error-tracking.md) for how symbolicated crashes appear in OpenObserve.
-
+The plugin's build-script configuration DSL is being finalized in the current alpha. Apply the plugin id above, then follow the current setup instructions in the [SDK's GitHub repository](https://github.com/openobserve) for wiring the upload task and credentials — the exact DSL is documented there and evolving quickly. See [Error & Crash Tracking](./error-tracking.md) for how symbolicated crashes appear in OpenObserve.
+:::
 ## Step 12 — Session Replay (optional)
 
 Add the `o2-sdk-android-session-replay` artifact to record privacy-first playback of user sessions. Enable it with a sample rate and privacy levels:

--- a/docs/user-guide/data-exploration/rum/mobile/best-practices.md
+++ b/docs/user-guide/data-exploration/rum/mobile/best-practices.md
@@ -7,10 +7,10 @@ description: Production guidance for mobile RUM — sampling strategy, batch siz
 
 This guide collects the decisions that separate a mobile RUM setup that just works in a demo from one that is healthy, affordable, and trustworthy in production — across React Native, Android, and iOS. It assumes you have a working integration from one of the [platform guides](./index.md) and focuses on the choices you make around it: how much to sample, how to batch, how to keep cost and volume under control, how to keep releases comparable, and how to verify everything before you ship. Every setting mentioned here maps to a real SDK option; where a platform differs, that is called out.
 
-!!! warning "Alpha status"
+:::warning[Alpha status]
 
-    The mobile SDKs are published as `0.1.0-alpha.x` (React Native `0.1.0-alpha.5`, Android `0.1.0-alpha5`, iOS `0.1.0-alpha.4`). They are ready to integrate and evaluate. Pin exact versions, test upgrades deliberately, and watch release notes — the version-management section below covers this in detail.
-
+The mobile SDKs are published as `0.1.0-alpha.x` (React Native `0.1.0-alpha.5`, Android `0.1.0-alpha5`, iOS `0.1.0-alpha.4`). They are ready to integrate and evaluate. Pin exact versions, test upgrades deliberately, and watch release notes — the version-management section below covers this in detail.
+:::
 ## Sampling strategy — pick each rate for what it costs
 
 The single most important cost-and-value lever in mobile RUM is sampling, and the mistake to avoid is treating it as one number. There are three independent sample rates, and they exist because the three data types they gate have wildly different volume and value.

--- a/docs/user-guide/data-exploration/rum/mobile/error-tracking.md
+++ b/docs/user-guide/data-exploration/rum/mobile/error-tracking.md
@@ -9,10 +9,10 @@ Errors and crashes are the highest-signal data your mobile app produces — they
 
 If you are new to the mobile SDKs, start with the [Mobile RUM Overview](./index.md) and the per-platform setup guides for [React Native](./react-native.md), [Android](./android.md), and [iOS](./ios.md) — this page assumes the SDK is already initialized and pointed at your OpenObserve instance.
 
-!!! warning "Alpha status"
+:::warning[Alpha status]
 
-    The mobile SDKs are early releases (`0.1.0-alpha.x`). The error and crash APIs shown here are stable enough to integrate and evaluate, but pin exact versions and expect some rough edges — a few build-time tools are still being finalized, and those are called out explicitly below.
-
+The mobile SDKs are early releases (`0.1.0-alpha.x`). The error and crash APIs shown here are stable enough to integrate and evaluate, but pin exact versions and expect some rough edges — a few build-time tools are still being finalized, and those are called out explicitly below.
+:::
 ## Handled errors vs. crashes
 
 These are two different things, and OpenObserve treats them differently:

--- a/docs/user-guide/data-exploration/rum/mobile/index.md
+++ b/docs/user-guide/data-exploration/rum/mobile/index.md
@@ -46,10 +46,10 @@ OpenObserve ships one SDK per mobile ecosystem. They are independent packages bu
 
 The React Native SDK wraps the native Android and iOS SDKs, so a React Native app gets native crash reporting, native view tracking, and native network instrumentation underneath the JavaScript layer.
 
-!!! warning "Alpha status"
+:::warning[Alpha status]
 
-    The mobile SDKs are currently early alpha releases (`0.1.0-alpha.x`). They are ready to integrate and evaluate, but pin exact versions and expect small configuration details to change before the stable release.
-
+The mobile SDKs are currently early alpha releases (`0.1.0-alpha.x`). They are ready to integrate and evaluate, but pin exact versions and expect small configuration details to change before the stable release.
+:::
 ## How it connects to OpenObserve
 
 Every mobile SDK uses the same connection model, so once you understand it for one platform it carries over to the others. You need three things from your OpenObserve instance's **Data → Data Sources → Real User Monitoring** page:
@@ -60,10 +60,10 @@ Every mobile SDK uses the same connection model, so once you understand it for o
 
 You configure the SDK with the client token and application id, and point its **custom endpoint** at your instance's base URL; the SDK appends the RUM intake path automatically. There is no separate "organization" field on mobile — your organization is part of the ingestion endpoint and token. Standard fields — `env` (for example `production` or `staging`), `service` (your app identifier), and `version` — round out the configuration and let you slice data by environment and release in OpenObserve.
 
-!!! note
+:::note
 
-    The built-in managed-cloud `site` presets (US1, EU1, and so on) are still being wired up for OpenObserve Cloud in this alpha. For self-hosted instances and today's setups, use the custom-endpoint approach — every platform guide shows exactly how.
-
+The built-in managed-cloud `site` presets (US1, EU1, and so on) are still being wired up for OpenObserve Cloud in this alpha. For self-hosted instances and today's setups, use the custom-endpoint approach — every platform guide shows exactly how.
+:::
 ## What you'll do to get started
 
 The flow is the same on every platform, and each guide walks through it end to end:

--- a/docs/user-guide/data-exploration/rum/mobile/ios.md
+++ b/docs/user-guide/data-exploration/rum/mobile/ios.md
@@ -9,10 +9,10 @@ This guide walks through adding [OpenObserve](https://openobserve.ai) Real User 
 
 New to mobile RUM in general? Start with the [Mobile RUM Overview](./index.md) for the concepts — sessions, views, actions, resources, errors — that this guide assumes.
 
-!!! warning "Alpha status"
+:::warning[Alpha status]
 
-    The iOS SDK is currently published as `0.1.0-alpha.4`. It is ready to integrate and evaluate — pin the exact version and test upgrades, since some configuration details may change before the stable release.
-
+The iOS SDK is currently published as `0.1.0-alpha.4`. It is ready to integrate and evaluate — pin the exact version and test upgrades, since some configuration details may change before the stable release.
+:::
 ## What you get
 
 Once integrated, OpenObserve RUM automatically captures:
@@ -118,14 +118,14 @@ RUM.enable(
 
 Those two calls initialize the SDK, enable RUM, and start the automatic instrumentation you configured. Data now flows to your OpenObserve instance, which appends the RUM intake path to your custom endpoint automatically.
 
-!!! note "No organization field"
+:::note[No organization field]
 
-    There is no separate "organization" setting on mobile — your organization is part of the ingestion endpoint URL and token. The built-in managed-cloud `site` presets (`.us1`, `.eu1`, and so on) are still being wired up for OpenObserve Cloud in this alpha; for self-hosted and today's setups, use `customEndpoint` as shown above.
+There is no separate "organization" setting on mobile — your organization is part of the ingestion endpoint URL and token. The built-in managed-cloud `site` presets (`.us1`, `.eu1`, and so on) are still being wired up for OpenObserve Cloud in this alpha; for self-hosted and today's setups, use `customEndpoint` as shown above.
+:::
+:::note[Consent gating]
 
-!!! note "Consent gating"
-
-    Nothing is collected until tracking consent is `.granted`. If you show a consent dialog, initialize with `.pending` and call `OpenObserve.set(trackingConsent: .granted)` once the user agrees. See [Security & Privacy](./security-privacy.md).
-
+Nothing is collected until tracking consent is `.granted`. If you show a consent dialog, initialize with `.pending` and call `OpenObserve.set(trackingConsent: .granted)` once the user agrees. See [Security & Privacy](./security-privacy.md).
+:::
 Set `OpenObserve.verbosityLevel = .debug` during development to see the SDK's internal logs while you verify the integration; lower or remove it in production.
 
 ## Step 3 — Configuration options

--- a/docs/user-guide/data-exploration/rum/mobile/performance-monitoring.md
+++ b/docs/user-guide/data-exploration/rum/mobile/performance-monitoring.md
@@ -10,10 +10,10 @@ Performance is what your users actually feel: how long the app takes to open, ho
 
 If you are just getting set up, start with the [Mobile RUM Overview](./index.md) and your platform guide ([React Native](./react-native.md), [Android](./android.md), [iOS](./ios.md)). This page assumes the SDK is already initialized and RUM is enabled.
 
-!!! warning "Alpha status"
+:::warning[Alpha status]
 
-    The mobile SDKs are early releases (`0.1.0-alpha.x`). The performance metrics described here are collected today; pin your exact SDK version and re-test on upgrades, since defaults and option names may still change.
-
+The mobile SDKs are early releases (`0.1.0-alpha.x`). The performance metrics described here are collected today; pin your exact SDK version and re-test on upgrades, since defaults and option names may still change.
+:::
 ## What performance data you get
 
 Once RUM is running, OpenObserve automatically captures, per session and per view:
@@ -202,10 +202,10 @@ RUM.enable(
 )
 ```
 
-!!! note
+:::note
 
-    Setting `appHangThreshold` on iOS is what turns app-hang reporting on — it defaults to off. Choose a value that catches real hangs without flagging brief, expected pauses (0.25s is a reasonable starting point).
-
+Setting `appHangThreshold` on iOS is what turns app-hang reporting on — it defaults to off. Choose a value that catches real hangs without flagging brief, expected pauses (0.25s is a reasonable starting point).
+:::
 ## Network and resource performance
 
 Every tracked network call is recorded as a RUM **resource** with its full timing breakdown, HTTP status, and payload size. Because resources are attached to the view that issued them, you can see exactly which requests made a screen slow.
@@ -286,10 +286,10 @@ RUM.enable(
 )
 ```
 
-!!! note
+:::note
 
-    The `tracecontext` header type (W3C) is what OpenObserve reads to stitch the mobile resource to the backend trace. A request only gets trace headers if its host is in your first-party list — otherwise the SDK still records timing, status, and size, just without the end-to-end link.
-
+The `tracecontext` header type (W3C) is what OpenObserve reads to stitch the mobile resource to the backend trace. A request only gets trace headers if its host is in your first-party list — otherwise the SDK still records timing, status, and size, just without the end-to-end link.
+:::
 ## Frustration signals
 
 Performance numbers describe the app; frustration signals describe the *user*. The SDK automatically detects patterns that mean someone is struggling — most importantly **rage taps**, where a user taps the same element repeatedly because nothing responds. These are captured as RUM actions flagged as frustrated.

--- a/docs/user-guide/data-exploration/rum/mobile/react-native.md
+++ b/docs/user-guide/data-exploration/rum/mobile/react-native.md
@@ -9,10 +9,10 @@ This guide walks through adding [OpenObserve](https://openobserve.ai) Real User 
 
 New to mobile RUM in general? Start with the [Mobile RUM Overview](./index.md) for the concepts (sessions, views, actions, resources, errors) that this guide assumes.
 
-!!! warning "Alpha status"
+:::warning[Alpha status]
 
-    The React Native SDK is currently published as `0.1.0-alpha.5`. It is ready to integrate and evaluate — pin the exact version and test upgrades, since some configuration details may change before the stable release.
-
+The React Native SDK is currently published as `0.1.0-alpha.5`. It is ready to integrate and evaluate — pin the exact version and test upgrades, since some configuration details may change before the stable release.
+:::
 ## What you get
 
 Once integrated, OpenObserve RUM automatically captures:
@@ -123,10 +123,10 @@ export default function App() {
 
 That single provider initializes the SDK, enables RUM, and starts the automatic instrumentation you turned on. Data now flows to your OpenObserve instance.
 
-!!! note "Consent gating"
+:::note[Consent gating]
 
-    Nothing is collected until tracking consent is `granted`. If you show a consent dialog, initialize with `TrackingConsent.PENDING` and call `OoSdkReactNative.setTrackingConsent(TrackingConsent.GRANTED)` once the user agrees. See [Security & Privacy](./security-privacy.md).
-
+Nothing is collected until tracking consent is `granted`. If you show a consent dialog, initialize with `TrackingConsent.PENDING` and call `OoSdkReactNative.setTrackingConsent(TrackingConsent.GRANTED)` once the user agrees. See [Security & Privacy](./security-privacy.md).
+:::
 ## Step 3 — Configuration options
 
 ### Core options

--- a/docs/user-guide/data-exploration/rum/mobile/security-privacy.md
+++ b/docs/user-guide/data-exploration/rum/mobile/security-privacy.md
@@ -7,10 +7,10 @@ description: Mobile RUM privacy controls — tracking consent, PII handling, Ses
 
 Real User Monitoring is powerful precisely because it watches real people use your app — which means it can capture things you never intended to collect. The OpenObserve mobile SDKs are built so that privacy is the default, not an afterthought: nothing is gathered until the user consents, Session Replay masks everything sensitive out of the box, and you can redact or drop any event before it leaves the device. This guide covers the full privacy and data-control surface across [React Native](./react-native.md), [Android](./android.md), and [iOS](./ios.md) so you can integrate RUM without compromising your users' trust or your compliance posture.
 
-!!! warning "Alpha status"
+:::warning[Alpha status]
 
-    The mobile SDKs are early releases (`0.1.0-alpha.x`). The privacy primitives described here — consent, masking, event mappers, encryption at rest — are present today. Pin exact versions and re-verify these controls when you upgrade.
-
+The mobile SDKs are early releases (`0.1.0-alpha.x`). The privacy primitives described here — consent, masking, event mappers, encryption at rest — are present today. Pin exact versions and re-verify these controls when you upgrade.
+:::
 ## The tracking-consent model
 
 Every mobile SDK gates all collection behind a three-state consent value. This is the single most important privacy control, because it decides whether the SDK does anything at all.

--- a/docs/user-guide/data-processing/pipelines/create-and-use-real-time-pipeline.md
+++ b/docs/user-guide/data-processing/pipelines/create-and-use-real-time-pipeline.md
@@ -60,39 +60,40 @@ If you remove this default destination and add only filtered routes, events that
     3. Enter a value in the **Value** input box.
     4. Add more conditions if needed.
 
-    !!! note "Important"
-        **Condition nodes require a stream schema.** <br>
-        If you create a new stream in **Step 3** and do not define any fields, the **Condition** editor does not display field names.
-        To use conditions, add at least one field while creating the source stream or ingest sample data so that the schema is inferred.
-    !!! note "Guidelines"
-        - Use an empty string to check for empty values. For example, `app_name != ""`
-        - Use null to check for null values. For example, `app_name != null`
-        - If the condition does not match, the record is dropped.
-        - If the record does not contain the specified field, it is also dropped.
-
+    :::note[Important]
+    **Condition nodes require a stream schema.** <br>
+    If you create a new stream in **Step 3** and do not define any fields, the **Condition** editor does not display field names.
+    To use conditions, add at least one field while creating the source stream or ingest sample data so that the schema is inferred.
+    :::
+    :::note[Guidelines]
+    - Use an empty string to check for empty values. For example, `app_name != ""`
+    - Use null to check for null values. For example, `app_name != null`
+    - If the condition does not match, the record is dropped.
+    - If the record does not contain the specified field, it is also dropped.
+    :::
 3. If you add a Function node:
 
     Use a Function node to transform events using a VRL function.
     > A Function does not require predefined fields. You can use it even if the source stream has no schema. <br>
-    !!! note "To create a new function:"
-        ![create-new-function](../../../images/create-new-function.png)
+    :::note[To create a new function:]
+    ![create-new-function](../../../images/create-new-function.png)
 
-        1. Enable **Create new function** toggle.
-        2. In the **Associate Function** tab, enter the function name. 
-        3. Open the **Query** tab. 
-        4. Select the stream type, stream name, and duration for which you want to query the data. 
-        5. Click the **Run Query** option at the top-right corner of the **Query** tab. 
-        6. In the **Function** tab, write a VRL function. 
-        7. Click the **Test Function** button at the top-right corner of the screen. 
-        8. Click **Save** to save the function. 
-
+    1. Enable **Create new function** toggle.
+    2. In the **Associate Function** tab, enter the function name. 
+    3. Open the **Query** tab. 
+    4. Select the stream type, stream name, and duration for which you want to query the data. 
+    5. Click the **Run Query** option at the top-right corner of the **Query** tab. 
+    6. In the **Function** tab, write a VRL function. 
+    7. Click the **Test Function** button at the top-right corner of the screen. 
+    8. Click **Save** to save the function. 
+    :::
 4. The **After Flattening** toggle is enabled by default. It ensures the function processes normalized data. Disable this toggle only if you need the original structure.
 
-    !!! note "Guidelines"
-        - **RBF (Run Before Flattening)**: Function executes before data structure is flattened. 
-        - **RAF (Run After Flattening)**: Function executes after data structure is flattened. 
-        ![After flattening](../../../images/after-flattening.png)
-
+    :::note[Guidelines]
+    - **RBF (Run Before Flattening)**: Function executes before data structure is flattened. 
+    - **RAF (Run After Flattening)**: Function executes after data structure is flattened. 
+    ![After flattening](../../../images/after-flattening.png)
+    :::
 5. Click **Save** to confirm the transform node.
 :::
 
@@ -107,21 +108,20 @@ A destination defines where the processed events are written. You can forward da
 2. In the **Associate Stream** panel, configure the destination stream.
 3. Select an existing stream or create a new one. Stream creation follows the same configuration as shown in Step 3.  
 
-    !!! note "Note"
-        - For real-time pipelines, you can select **logs**, **metrics**, or **traces** as the destination stream type.  
-        - **Enrichment_tables** as a destination stream is only available for scheduled pipelines. It cannot be used as a destination in real-time pipelines.
-
-    !!! note "Dynamic stream names"
-        You can configure the stream name dynamically with curly braces.  
-        Example: `static_text_{fieldname}_postfix`  
-        Static text before and after the braces is optional.
-
-    !!! warning "Default destination and data loss"
-        When you select a source stream for a real-time pipeline, OpenObserve automatically adds a destination that points back to the same stream. This default destination ensures that all ingested events continue to be stored in the source stream.  
-        If you remove this default destination and only keep filtered routes, events that do not match any condition are dropped and are not written to the source stream.  
-        Add at least one catch-all route back to the original stream if you want to preserve all events.
-
-
+    :::note[Note]
+    - For real-time pipelines, you can select **logs**, **metrics**, or **traces** as the destination stream type.  
+    - **Enrichment_tables** as a destination stream is only available for scheduled pipelines. It cannot be used as a destination in real-time pipelines.
+    :::
+    :::note[Dynamic stream names]
+    You can configure the stream name dynamically with curly braces.  
+    Example: `static_text_{fieldname}_postfix`  
+    Static text before and after the braces is optional.
+    :::
+    :::warning[Default destination and data loss]
+    When you select a source stream for a real-time pipeline, OpenObserve automatically adds a destination that points back to the same stream. This default destination ensures that all ingested events continue to be stored in the source stream.  
+    If you remove this default destination and only keep filtered routes, events that do not match any condition are dropped and are not written to the source stream.  
+    Add at least one catch-all route back to the original stream if you want to preserve all events.
+    :::
 **To add an external destination:** 
 ![stream-destination](../../../images/stream-destination.png)
 

--- a/docs/user-guide/data-processing/pipelines/create-and-use-scheduled-pipeline.md
+++ b/docs/user-guide/data-processing/pipelines/create-and-use-scheduled-pipeline.md
@@ -68,33 +68,33 @@ Scheduled pipelines do not use a **Stream** node as the source. They always begi
     3. Enter a value in the **Value** input box.
     4. Add more conditions if needed.
 
-    !!! note "Guidelines"
-        - Use an empty string to check for empty values. For example, `app_name != ""`
-        - Use null to check for null values. For example, `app_name != null`
-        - If the condition does not match, the record is dropped.
-        - If the record does not contain the specified field, it is also dropped.
-
+    :::note[Guidelines]
+    - Use an empty string to check for empty values. For example, `app_name != ""`
+    - Use null to check for null values. For example, `app_name != null`
+    - If the condition does not match, the record is dropped.
+    - If the record does not contain the specified field, it is also dropped.
+    :::
 3. If you add a Function node:
 
     Use a Function node to transform events using a VRL function.
     > A Function does not require predefined fields. You can use it even if the source stream has no schema. <br>
-    !!! note "To create a new function:"
+    :::note[To create a new function:]
 
-        1. Enable **Create new function** toggle.
-        2. In the **Associate Function** tab, enter the function name. 
-        3. Open the **Query** tab. 
-        4. Select the stream type, stream name, and duration for which you want to query the data. 
-        5. Click the **Run Query** option at the top-right corner of the **Query** tab. 
-        6. In the **Function** tab, write a VRL function. 
-        7. Click the **Test Function** button at the top-right corner of the screen. 
-        8. Click **Save** to save the function. 
-
+    1. Enable **Create new function** toggle.
+    2. In the **Associate Function** tab, enter the function name. 
+    3. Open the **Query** tab. 
+    4. Select the stream type, stream name, and duration for which you want to query the data. 
+    5. Click the **Run Query** option at the top-right corner of the **Query** tab. 
+    6. In the **Function** tab, write a VRL function. 
+    7. Click the **Test Function** button at the top-right corner of the screen. 
+    8. Click **Save** to save the function. 
+    :::
 4. The **After Flattening** toggle is enabled by default. It ensures the function processes normalized data. Disable this toggle only if you need the original structure.
 
-    !!! note "Guidelines"
-        - **RBF (Run Before Flattening)**: Function executes before data structure is flattened. 
-        - **RAF (Run After Flattening)**: Function executes after data structure is flattened. 
-
+    :::note[Guidelines]
+    - **RBF (Run Before Flattening)**: Function executes before data structure is flattened. 
+    - **RAF (Run After Flattening)**: Function executes after data structure is flattened. 
+    :::
 5. Click **Save** to confirm the transform node.
 :::
 

--- a/docs/user-guide/data-processing/streams/streams-in-openobserve.md
+++ b/docs/user-guide/data-processing/streams/streams-in-openobserve.md
@@ -107,19 +107,18 @@ The new stream appears on the Streams page. Ingest data into the stream to popul
         For detailed information about each field type and index strategy, see [Field and Index Types in Streams](data-type-and-index-type-in-streams.md)
     This creates a user-defined schema at stream creation. Learn more about [user defined schema](schema-settings.md#user-defined-schema-uds).  
 
-    ??? info "Click to see how User-defined Schema works."
-        Let us say you define the following fields while creating a stream:
+    :::accordion[Click to see how User-defined Schema works.]
+    Let us say you define the following fields while creating a stream:
 
-        - job (String)
-        - code (Integer)
-        - message (String)
+    - job (String)
+    - code (Integer)
+    - message (String)
 
-        After you ingest data into this stream:
+    After you ingest data into this stream:
 
-        - These fields (job, code, message) will appear under User Defined Schema in the [Stream Details](stream-details.md) page.
-        - Any additional fields not defined earlier will appear under All Fields.
-
-
+    - These fields (job, code, message) will appear under User Defined Schema in the [Stream Details](stream-details.md) page.
+    - Any additional fields not defined earlier will appear under All Fields.
+    :::
 5. Click **Create Stream**.
 :::
 ::::


### PR DESCRIPTION
## What

30 admonitions across 13 pages still used the MkDocs syntax (`!!! note "Title"` / `??? info "Title"`), which nothing in the Fumadocs pipeline processes — they rendered as literal `!!!` text with their indented bodies turned into code blocks. Found while building the SLO docs (#530).

Converted to the site's existing directive syntax (`:::note[Title]`, `:::warning[...]`, `:::accordion[...]`), which `lib/remark/mkdocs-directives.ts` already maps onto Callout / Details components. No new machinery.

Affected: the 8 Mobile RUM pages, both pipeline guides, streams-in-openobserve (the one `???` collapsible), organizations, and dashboard variables.

## Verified

- `pnpm build` clean, check-links passes.
- Built HTML swept: no literal `!!! type` / `??? type` remains anywhere.
- Visually checked the three risky shapes in the rendered site: a top-level warning callout (Android RUM), back-to-back callouts nested in a numbered list (real-time pipeline), and the collapsible inside a list (streams) — all render correctly and list flow around them is intact.

Conversion was scripted (fence-aware, preserves list indentation, dedents bodies); every diff eyeballed.