### PR TITLE
fix: give next build its own dist dir so it cannot corrupt a running dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # --- Next.js / Fumadocs build output ---------------------------------------
 /.next
+/.next-build
 /out
 /.source
 next-env.d.ts

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,12 @@ const withMDX = createMDX();
 const config = {
   // Static HTML export -> `out/`, synced to s3://<bucket>/docs as before.
   output: 'export',
+  // `next build` and `next dev` share `.next` by default, so a build run
+  // while the dev server is up corrupts its incremental state — the dev
+  // overlay then shows "(stale)" and bogus errors like `missing param
+  // "/[[...slug]]"` until a restart. The build script sets NEXT_DIST_DIR
+  // so the two never touch the same directory.
+  distDir: process.env.NEXT_DIST_DIR || '.next',
   // The site is served from https://openobserve.ai/docs
   basePath: '/docs',
   // MkDocs used directory-style URLs (/docs/getting-started/). Keep them.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check:seo": "node scripts/check-seo.mjs",
     "check:links": "node scripts/check-links.mjs",
     "dev": "node scripts/copy-assets.mjs && next dev -p 3030",
-    "build": "next build",
+    "build": "NEXT_DIST_DIR=.next-build next build",
     "postbuild": "node scripts/post-export.mjs && node scripts/check-links.mjs",
     "start": "next start",
     "postinstall": "fumadocs-mdx"


### PR DESCRIPTION
## What

`next build` and `next dev` share `.next` by default. Running a build while the dev server is up corrupts the dev server's incremental state — the overlay then reports the Next.js version as **(stale)** and throws bogus runtime errors such as:

> Page "/[[...slug]]/page" is missing param "/[[...slug]]" in "generateStaticParams()", which is required with "output: export" config.

until the server is restarted. This bit today while docs builds (#530, #531) ran repeatedly under a long-lived `pnpm dev`.

## Fix

- `pnpm build` sets `NEXT_DIST_DIR=.next-build`, routed through `distDir` in `next.config.mjs` (defaults to `.next` for everything else).
- `.next-build` gitignored.

## Verified

Started a fresh dev server, then ran a full `pnpm build` (with pre/post scripts) underneath it: build output unchanged (470 pages, check-links clean), the two dist dirs coexist, and dev pages still return 200 with no overlay errors afterward — the exact sequence that previously required a restart.