### PR TITLE
docs(migration): rewrite dashboards & alerts guides for the Dashboard Migrator

### DIFF
--- a/docs/migration/meta.json
+++ b/docs/migration/meta.json
@@ -3,6 +3,8 @@
     "migrate-database",
     "migrate-file-list-partition",
     "migrate-from-grafana-to-openobserve",
-    "migrate-from-datadog-to-openobserve"
+    "migrate-from-datadog-to-openobserve",
+    "migrate-from-kibana-to-openobserve",
+    "migrate-from-cloudwatch-to-openobserve"
   ]
 }

--- a/docs/migration/migrate-from-cloudwatch-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-cloudwatch-to-openobserve/dashboards-and-alerts.md
@@ -1,0 +1,87 @@
+---
+title: Migrating Dashboards
+metaTitle: Migrate CloudWatch Dashboards to OpenObserve
+description: "Convert AWS CloudWatch dashboards into OpenObserve dashboards with the Dashboard Migrator. Metric widgets become SQL queries over the CloudWatch metrics log stream."
+---
+
+# Migrating Dashboards
+
+## Overview
+
+CloudWatch dashboards are JSON documents of metric widgets. There are two ways to move them to OpenObserve:
+
+1. **Automated** — the [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) converts CloudWatch dashboard JSON into OpenObserve dashboards, turning each metric widget into a SQL query over your CloudWatch metrics stream.
+2. **Manual** — recreate each dashboard by hand.
+
+For most teams the automated path handles the bulk of the work; the manual path is a fallback and a way to understand what changed.
+
+## Migrate automatically with the Dashboard Migrator
+
+The [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) is a free web tool that converts dashboards from CloudWatch — and Datadog, Grafana, and Kibana — into OpenObserve-native objects. For CloudWatch it reads a dashboard's `widgets` array and produces an OpenObserve dashboard with the widgets, layout, and variables translated.
+
+### How it works
+
+1. **Load Dashboards** — paste or upload the dashboard JSON, or browse your dashboards directly from AWS (the tool provides a read-only CloudFormation template to grant it access).
+2. **Connect (optional)** — point the tool at your OpenObserve instance so it can read your live stream catalog and validate the stream name.
+3. **Review** — inspect the translated widgets and queries.
+4. **Export** — create the dashboards directly in OpenObserve, or download JSON to import.
+
+### How CloudWatch metrics map to SQL
+
+Because CloudWatch metrics arrive as a logs stream (see the [overview](index.md)), every metric widget becomes a SQL query over that stream:
+
+| CloudWatch concept | OpenObserve SQL |
+|---|---|
+| Metric `CPUUtilization` in `AWS/EC2` | `WHERE namespace = 'AWS/EC2' AND metric_name = 'CPUUtilization'` |
+| Statistic **Average** | `sum(value_sum) / sum(value_count)` |
+| Statistic **Sum** | `sum(value_sum)` |
+| Statistic **Min** / **Max** | `min(value_min)` / `max(value_max)` |
+| Dimension `InstanceId=i-123` | `WHERE dimensions_instanceid = 'i-123'` |
+| Period / time range | Time filter on `_timestamp` |
+
+### What's skipped
+
+The migrator flags widgets it can't convert, rather than guessing:
+
+- **Logs Insights widgets** — these query log data, not metrics; they're skipped with a note to recreate as OpenObserve SQL.
+- **Alarm widgets** — CloudWatch alarms are not migrated (see below).
+
+## Export your CloudWatch configuration first
+
+Pull a static snapshot before you start:
+
+```bash
+# List dashboards
+aws cloudwatch list-dashboards --region us-east-1
+
+# Fetch one dashboard body
+aws cloudwatch get-dashboard --dashboard-name <name> --region us-east-1
+```
+
+The `get-dashboard` response wraps the body in a `DashboardBody` string; the migrator accepts either that wrapper or the raw `{ "widgets": [...] }` body.
+
+## Migrating manually
+
+If you prefer to rebuild by hand, translate each metric widget to a SQL query over the metrics stream. For example, an **Average** of `CPUUtilization` for `AWS/EC2` across all instances:
+
+```sql
+SELECT _timestamp, sum(value_sum) / sum(value_count) AS avg_cpu
+FROM cloudwatch_metrics
+WHERE namespace = 'AWS/EC2' AND metric_name = 'CPUUtilization'
+GROUP BY _timestamp
+```
+
+Add `dimensions_<name>` filters to narrow to specific instances, regions, or auto-scaling groups, and use the same aggregation mapping shown above for Sum/Min/Max.
+
+## CloudWatch alarms
+
+CloudWatch alarms are not migrated by the Dashboard Migrator. To move an alarm, recreate it as an OpenObserve [scheduled alert](../../user-guide/analytics/alerts/index.md): take the alarm's metric, statistic, and threshold, express them as a SQL query (using the same `value_sum` / `value_count` mapping), and attach the notification destination. See the [Alerts documentation](../../user-guide/analytics/alerts/index.md) for details.
+
+## Next steps
+
+- [OpenObserve Dashboards Documentation](../../user-guide/analytics/dashboards/index.md) — dashboard builder, panel types, and variables
+- [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/index.md) — recreate CloudWatch alarms as OpenObserve alerts
+
+---
+
+[Back to Overview](index.md)

--- a/docs/migration/migrate-from-cloudwatch-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-cloudwatch-to-openobserve/dashboards-and-alerts.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating Dashboards
 metaTitle: Migrate CloudWatch Dashboards to OpenObserve
-description: "Convert AWS CloudWatch dashboards into OpenObserve dashboards with the Dashboard Migrator. Metric widgets become SQL queries over the CloudWatch metrics log stream."
+description: "Convert AWS CloudWatch dashboards to OpenObserve with the Dashboard Migrator. Metric widgets become SQL over the metrics stream."
 ---
 
 # Migrating Dashboards

--- a/docs/migration/migrate-from-cloudwatch-to-openobserve/index.md
+++ b/docs/migration/migrate-from-cloudwatch-to-openobserve/index.md
@@ -1,0 +1,94 @@
+---
+title: Overview
+metaTitle: Migrate from CloudWatch to OpenObserve
+description: "Migrate AWS CloudWatch dashboards and metrics to OpenObserve. Stream CloudWatch metrics via Firehose in OpenTelemetry format, then convert dashboards with the Dashboard Migrator."
+---
+
+# Migrate from CloudWatch to OpenObserve
+
+If you're using Amazon CloudWatch for AWS infrastructure metrics and dashboards and want to move to OpenObserve, this guide walks you through the migration. The [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) converts CloudWatch dashboards into OpenObserve dashboards automatically, and CloudWatch Metric Streams carry the underlying data across.
+
+Migrating CloudWatch has two parts:
+
+1. **The data** — stream CloudWatch metrics into OpenObserve using CloudWatch Metric Streams → Kinesis Firehose in OpenTelemetry format. The metrics land in a log stream with a fixed column shape (namespace, metric name, dimensions, sum/count/min/max).
+2. **The dashboards** — convert your CloudWatch dashboards into OpenObserve dashboards with the Dashboard Migrator, which turns each metric widget into a SQL query over that stream.
+
+## Table of Contents
+
+1. [Overview](index.md) — why migrate and what changes
+2. [Migrating Dashboards](dashboards-and-alerts.md) — convert CloudWatch dashboards with the Dashboard Migrator
+
+---
+
+## Why Migrate?
+
+CloudWatch is convenient when you're already in AWS, but it bills per custom metric, per alarm, per dashboard, and per ingested log GB, and it keeps metrics for a limited retention window. As your footprint grows, the cost and the operational opacity both climb.
+
+OpenObserve stores the same metrics as Apache Parquet on object storage (up to **140x more efficient**), keeps data as long as you want, and lets you query metrics, logs, and traces in one place with SQL.
+
+## What OpenObserve Changes
+
+| | CloudWatch | OpenObserve |
+|---|---|---|
+| **Pricing model** | Per custom metric, alarm, dashboard, log GB | Storage + compute only |
+| **Storage backend** | AWS-managed, fixed retention | Apache Parquet on S3 / GCS / Azure Blob / local disk |
+| **Query language** | CloudWatch Metrics Insights / Logs Insights | SQL |
+| **Dashboards** | CloudWatch dashboard JSON | OpenObserve dashboard builder |
+| **Cross-signal correlation** | Separate consoles for metrics vs. logs | Unified logs, metrics, traces in one UI |
+| **Lock-in** | AWS-specific formats | Open standards; data lives in your bucket |
+
+## How CloudWatch metrics reach OpenObserve
+
+CloudWatch metrics are ingested into OpenObserve as a **logs** stream via a CloudWatch Metric Stream:
+
+```
+CloudWatch → Kinesis Data Firehose (OpenTelemetry format) → OpenObserve
+```
+
+The metric stream flattens each metric into a row with these columns, which is what the dashboard migrator then queries:
+
+| Column | Meaning |
+|---|---|
+| `namespace` | The CloudWatch namespace (e.g., `AWS/EC2`) |
+| `metric_name` | The metric name (e.g., `CPUUtilization`) |
+| `dimensions_<name>` | One column per dimension, lowercased |
+| `region` | The AWS region |
+| `unit` | The metric unit |
+| `value_sum`, `value_count`, `value_min`, `value_max` | Aggregated sample values over the period |
+| `_timestamp` | The sample time |
+
+See the [OpenObserve ingestion docs](../../ingestion/logs/kinesis-firehose.md) for the Firehose setup.
+
+## Before You Start
+
+- **Export your dashboards:** note which CloudWatch dashboards you actually use, and export them via the AWS API (`get-dashboard`) or the migrator's "browse from AWS" option.
+- **Confirm the metric stream:** make sure your CloudWatch Metric Stream → Firehose → OpenObserve pipeline is running before you migrate dashboards, so the queries have data to validate against.
+
+## Set Up OpenObserve
+
+Before migrating, get OpenObserve running:
+
+::::tabs
+:::tab[OpenObserve Cloud]
+
+Sign up at [cloud.openobserve.ai](https://cloud.openobserve.ai). No infrastructure to manage.
+
+After logging in, navigate to **Data Sources** to find your ingestion credentials and endpoint URLs.
+:::
+:::tab[Self-Hosted]
+
+Download OpenObserve for your platform from the [downloads page](https://openobserve.ai/downloads/).
+
+After installation, access the UI at `http://localhost:5080` and navigate to **Data Sources** to find your ingestion credentials and ready-to-use configuration snippets.
+:::
+::::
+
+## Next Steps
+
+- [Migrating Dashboards](dashboards-and-alerts.md) — convert CloudWatch dashboards with the Dashboard Migrator
+- [OpenObserve Ingestion](../../ingestion/index.md) — stream CloudWatch metrics and other signals into OpenObserve
+
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/migration/migrate-from-cloudwatch-to-openobserve/index.md
+++ b/docs/migration/migrate-from-cloudwatch-to-openobserve/index.md
@@ -1,7 +1,7 @@
 ---
 title: Overview
 metaTitle: Migrate from CloudWatch to OpenObserve
-description: "Migrate AWS CloudWatch dashboards and metrics to OpenObserve. Stream CloudWatch metrics via Firehose in OpenTelemetry format, then convert dashboards with the Dashboard Migrator."
+description: "Migrate AWS CloudWatch dashboards and metrics to OpenObserve via Firehose in OpenTelemetry format and the Dashboard Migrator."
 ---
 
 # Migrate from CloudWatch to OpenObserve

--- a/docs/migration/migrate-from-cloudwatch-to-openobserve/meta.json
+++ b/docs/migration/migrate-from-cloudwatch-to-openobserve/meta.json
@@ -1,0 +1,6 @@
+{
+  "pages": [
+    "index",
+    "dashboards-and-alerts"
+  ]
+}

--- a/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating Dashboards & Monitors
 metaTitle: Migrate Dashboards & Monitors from Datadog to OpenObserve
-description: "Migrate Datadog dashboards and monitors to OpenObserve with the automated Dashboard Migrator, or translate queries to PromQL and SQL by hand. Covers composite alerts, multi-alerts, warning/critical levels, and SLOs."
+description: "Migrate Datadog dashboards and monitors to OpenObserve with the Dashboard Migrator, or by hand in PromQL and SQL. Covers composite alerts and SLOs."
 ---
 
 # Migrating Dashboards & Monitors

--- a/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/dashboards-and-alerts.md
@@ -1,26 +1,56 @@
 ---
 title: Migrating Dashboards & Monitors
 metaTitle: Migrate Dashboards & Monitors from Datadog to OpenObserve
-description: "Migrate Datadog dashboards and monitors to OpenObserve. Translate queries to PromQL and SQL, set up notification channels, and use the AI Assistant."
+description: "Migrate Datadog dashboards and monitors to OpenObserve with the automated Dashboard Migrator, or translate queries to PromQL and SQL by hand. Covers composite alerts, multi-alerts, warning/critical levels, and SLOs."
 ---
 
 # Migrating Dashboards & Monitors
 
 ## Overview
 
-There is no automatic converter for Datadog dashboards or monitors; both need to be recreated in OpenObserve. That said, the effort is lower than it sounds:
+Dashboards and monitors are the main thing that makes Datadog feel sticky: they encode your team's knowledge of what "healthy" looks like, in Datadog's proprietary query DSL. There are two ways to move them to OpenObserve:
 
-- **Most metric panels port over cleanly.** Datadog `avg:metric{tag:value}` expressions have direct PromQL equivalents. Once you know the pattern, most panels translate mechanically.
-- For logs, OpenObserve uses SQL with full-text functions (`match_all()`, `str_match()`, `re_match()`).
-- **Monitor types become alert rules.** PromQL-based or SQL-based alerts cover all the Datadog monitor types (metric, log, anomaly threshold, composite) you actually use day to day.
-- **The AI Assistant can translate queries for you.** Paste a Datadog query into the OpenObserve AI Assistant and ask for the PromQL or SQL equivalent. That removes the main friction point.
+1. **Automated** — the [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) converts Datadog dashboards and monitors into OpenObserve dashboards and alerts, translating queries, thresholds, layout, and variables automatically.
+2. **Manual** — recreate each dashboard and monitor by hand, translating Datadog query syntax to PromQL or SQL yourself (or with the AI Assistant).
 
-Think of this as a forced cleanup. Datadog dashboards and monitor lists tend to accumulate panels and rules that nobody looks at anymore. Recreating from scratch is a good opportunity to keep only what's genuinely useful.
+For most teams the automated path handles the bulk of the work. The manual path is a fallback for the pieces the migrator flags for review, and a way to understand exactly what changed under the hood.
 
+## Migrate automatically with the Dashboard Migrator
 
-## Export Your Datadog Configuration First
+The [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) is a free web tool that converts dashboards and alert rules from Datadog — and Grafana, Kibana, and CloudWatch — into OpenObserve-native objects. For Datadog it has two flows:
 
-Before you start rebuilding, pull a static snapshot of what you have. Both endpoints are part of the Datadog public API:
+- **Dashboards** — converts Datadog dashboards into OpenObserve dashboards: metric panels become PromQL, log and trace panels become SQL, and the panel layout, tabs, and template variables carry over.
+- **Monitors** — converts Datadog monitors into OpenObserve alerts: metric monitors become PromQL alerts with their operator, threshold, and evaluation window mapped; log and trace monitors are flagged for SQL completion.
+
+### How it works
+
+The workflow is four steps:
+
+1. **Load** — paste or upload the JSON you export from Datadog's API (`GET /api/v1/dashboard` and `GET /api/v1/monitor`).
+2. **Connect (optional)** — point the tool at your OpenObserve instance so it can read your live stream catalog and validate stream names against what actually exists. This is what makes the output schema-validated and import-clean.
+3. **Review** — inspect the migrated panels and queries, correct stream mappings, and override any variable defaults before exporting.
+4. **Export** — create the dashboards and alerts directly in OpenObserve, or download JSON you can import yourself.
+
+As it migrates, it reports a coverage tally per object — **migrated**, **needs review**, and **skipped** — so you can see at a glance how much work remains.
+
+### What it translates and what it flags
+
+The migrator handles the mechanical majority and flags the rest for a human:
+
+| Datadog source | Migration result |
+|---|---|
+| Metric panels / metric monitors (`avg:metric{tag}`) | Fully translated to PromQL with labels, aggregations, and thresholds mapped. |
+| Log / trace panels and monitors | Flagged for review — the query must be written as OpenObserve SQL against the right stream. |
+| Template variables | Carried over as OpenObserve dashboard variables. |
+| `anomalies()`, `forecast()`, `outliers()` monitors | Migrated as a plain threshold on the underlying metric and flagged to tune manually. |
+
+:::tip[Feed it your real export]
+The migrator consumes the same JSON the Datadog API returns. Export your dashboards and monitors before you start (see below) and keep the files — they are the input to both the automated and manual paths.
+:::
+
+## Export your Datadog configuration first
+
+Pull a static snapshot of what you have. Both endpoints are part of the Datadog public API:
 
 ```bash
 # Dashboards
@@ -34,12 +64,13 @@ curl -X GET "https://api.datadoghq.com/api/v1/monitor" \
   -H "DD-APPLICATION-KEY: $DD_APP_KEY" > monitors.json
 ```
 
-Now you have a static record to work from. The JSON contains the title, query, and notification config for every dashboard and monitor.
+The JSON contains the title, query, and notification config for every dashboard and monitor — everything the migrator needs, and everything you need if you recreate by hand.
 
+## Migrating dashboards manually
 
-## Migrating Dashboards
+If you prefer to rebuild by hand, or want to verify what the migrator produced, here is the translation it is applying.
 
-### What Changes
+### What changes
 
 | Element | Datadog | OpenObserve |
 |---|---|---|
@@ -50,17 +81,7 @@ Now you have a static record to work from. The JSON contains the title, query, a
 | Template variables | Datadog template variables | OpenObserve dashboard variables |
 | Notebooks | Datadog Notebooks | Dashboard + SQL panels |
 
-### How to Approach It
-
-**Step 1: Inventory your dashboards**
-
-Walk the exported `dashboards.json`. For each dashboard:
-
-- Which widgets are actually used (drop the rest; most dashboards have at least one stale panel)
-- Which data type each widget queries (metric / log / trace)
-- Which Datadog tags are referenced; these become PromQL labels or SQL columns
-
-**Step 2: Translate queries**
+### Translate queries
 
 Datadog-to-PromQL examples for metric panels:
 
@@ -83,10 +104,10 @@ Datadog log search to SQL examples for log panels:
 | `service:api status:error \| count by status_code` | `SELECT status_code, count(*) FROM default WHERE service = 'api' AND level = 'error' GROUP BY status_code` |
 
 :::tip[Use the AI Assistant]
-Instead of translating queries by hand, use the **AI Assistant** in the OpenObserve UI. Paste a Datadog query and ask: *"Convert this Datadog query to OpenObserve PromQL"* (for metrics) or *"...to OpenObserve SQL"* (for logs). It handles tag-name normalization, function mapping, and aggregation syntax in one shot, which is especially useful for complex multi-condition queries.
+Instead of translating queries by hand, use the **AI Assistant** in the OpenObserve UI. Paste a Datadog query and ask: *"Convert this Datadog query to OpenObserve PromQL"* (for metrics) or *"...to OpenObserve SQL"* (for logs). It handles tag-name normalization, function mapping, and aggregation syntax in one shot — especially useful for complex multi-condition queries.
 :::
 
-**Step 3: Recreate in OpenObserve**
+### Recreate in OpenObserve
 
 OpenObserve has a built-in drag-and-drop dashboard builder. For each panel:
 
@@ -97,21 +118,23 @@ OpenObserve has a built-in drag-and-drop dashboard builder. For each panel:
 
 For template variables, set them up as dashboard variables and reference them in queries with `$variable_name`, the same pattern as Datadog.
 
+## Migrating monitors manually
 
-## Migrating Monitors
+### What changes
 
-### What Changes
-
-| Monitor Type | Datadog | OpenObserve |
+| Monitor type | Datadog | OpenObserve |
 |---|---|---|
 | Metric monitor | Datadog query DSL with threshold | PromQL alert with threshold |
 | Log monitor | Log search + threshold | SQL-based scheduled alert |
 | APM / Trace monitor | APM query | PromQL on RED metrics or SQL on traces |
-| Anomaly / Forecast | Datadog Watchdog/Anomaly | Manual thresholds (no AI auto-detect today) |
-| Composite | Logical AND/OR of monitors | Composite alert in OpenObserve |
-| Notification channels | Slack, PagerDuty, email, webhook (configured per monitor) | Built-in destinations (Slack, Email, PagerDuty, Webhook), configured once and reused |
+| Anomaly / Forecast | Watchdog / `anomalies()` / `forecast()` | Anomaly detection (Enterprise) or explicit thresholds |
+| Composite | Logical AND/OR of monitors | [Composite alert](../../user-guide/analytics/alerts/composite-alerts.md) with `AND`/`OR`/`NOT` |
+| Multi alert (grouped) | `group by` on a tag, fires per group | Group-by alert (see [Alert Conditions](../../user-guide/analytics/alerts/alert-conditions.md#group-by)) |
+| Notification channels | Slack, PagerDuty, email, webhook (per monitor) | Built-in destinations, configured once and reused |
 
-### Step 1: Inventory Your Current Monitors
+OpenObserve alerts carry **two firing severities — Warning and Critical** — rather than a single alert state, so a Datadog monitor that defines both a `warning` and a `critical` threshold maps to the same two-level model.
+
+### Step 1: Inventory your current monitors
 
 Walk the exported `monitors.json`. For each monitor, note:
 
@@ -119,17 +142,17 @@ Walk the exported `monitors.json`. For each monitor, note:
 - Threshold and comparison operator
 - Evaluation interval / window
 - Notification channel(s)
-- Whether the monitor still fires usefully (now is a great time to drop the ones that never trigger or always fire)
+- Whether the monitor still fires usefully (drop the ones that never trigger or always fire)
 
-### Step 2: Set Up Notification Destinations
+### Step 2: Set up notification destinations
 
 Set up notification destinations in OpenObserve **before** recreating rules, so you can test end-to-end as you go.
 
 OpenObserve supports: **Slack, Email, PagerDuty, and Webhook**.
 
-See the [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/index.md) for setup instructions.
+See the [OpenObserve Alert Destinations Documentation](../../user-guide/account-administration/management/alert-destinations.md) for setup instructions.
 
-### Step 3: Recreate Alert Rules
+### Step 3: Recreate alert rules
 
 **Metric monitor to PromQL alert:**
 
@@ -148,13 +171,21 @@ See the [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/ind
 
 **Composite monitor:**
 
-Datadog composite monitors combine other monitors with `&&` / `||`. In OpenObserve, create a **composite alert** that references the constituent alerts the same way.
+Datadog composite monitors combine other monitors with `&&` / `||`. OpenObserve has a native [composite alert](../../user-guide/analytics/alerts/composite-alerts.md) that references the constituent alerts the same way, with `AND`, `OR`, and `NOT` (plus parentheses).
+
+**Multi alert (grouped monitor):**
+
+A Datadog monitor with `group by` fires separately for each tag value. In OpenObserve, enable **Group by** in the alert condition to evaluate the same threshold per group, and it notifies you with the groups that triggered.
+
+**Warning + critical thresholds:**
+
+Where a Datadog monitor defines a `warning` threshold below its `critical` threshold, keep the same split in OpenObserve: Warning is the "heads-up" severity, Critical is the page.
 
 :::tip[Use the AI Assistant]
 The same AI Assistant that converts dashboard queries works here. Paste a Datadog monitor query and threshold and ask it to produce the OpenObserve PromQL or SQL equivalent. This is faster and less error-prone than translating complex multi-condition queries by hand.
 :::
 
-### Step 4: Verify Alerts
+### Step 4: Verify alerts
 
 1. Open **Alerts** in the OpenObserve UI and confirm each rule shows an **Active** status.
 2. Check the **Last Evaluated** timestamp; rules should update on their configured interval.
@@ -168,22 +199,22 @@ The same AI Assistant that converts dashboard queries works here. Paste a Datado
 - **PromQL returns no data:** Confirm metric and label names in the Metrics explorer. Datadog uses `.` in metric names, OpenObserve uses `_`. Same for tags with dashes.
 - **Spurious fires after migration:** Datadog monitors often have implicit `no_data_timeframe` and `notify_no_data` behavior. Configure the equivalent in OpenObserve so a missing-data state doesn't immediately page.
 
-
 ## SLOs & Watchdog
 
-- **SLOs:** Datadog SLO objects don't have a direct equivalent. Use OpenObserve **scheduled pipelines** to pre-aggregate the SLI (e.g., `good_events / total_events`), then alert on a burn-rate threshold.
-- **Watchdog (anomaly auto-detect):** Watchdog is a Datadog-proprietary ML feature with no direct OpenObserve equivalent today. Migrate Watchdog alerts to explicit threshold rules. In practice most teams find the explicit rules clearer once they're forced to define what "anomaly" actually means.
+- **SLOs:** OpenObserve has native SLO support, so Datadog SLOs migrate cleanly instead of being rebuilt with pipelines. Define an SLO as a **count**, **time-slice**, or **alert-based** SLI over a rolling 7/30/90-day window, then alert on **burn rate** or **error budget** consumption. See the [SLO documentation](../../user-guide/analytics/slos/index.md) and [Alerting on SLOs](../../user-guide/analytics/slos/slo-alerts.md).
+- **Watchdog (anomaly auto-detect):** Watchdog is Datadog-proprietary, but OpenObserve offers its own [anomaly detection](../../user-guide/analytics/alerts/anomaly-detection.md) *(Enterprise self-hosted)* for ML-based detection without hand-set thresholds. Where you want explicit control, migrate Watchdog alerts to threshold rules — most teams find the explicit rules clearer once they're forced to define what "anomaly" actually means.
 
-
-## Next Steps
+## Next steps
 
 - [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/index.md): full reference for alert rule types, conditions, and notification channels
-- [OpenObserve Dashboards Documentation](https://openobserve.ai/docs/user-guide/analytics/dashboards/): dashboard builder, panel types, and variables
-- [OpenObserve Full-Text Search Functions](https://openobserve.ai/docs/reference/sql-functions/full-text-search/): SQL function reference for log queries (`match_all()`, `str_match()`, `re_match()`)
-- [OpenObserve Scheduled Pipelines](https://openobserve.ai/docs/user-guide/data-processing/pipelines/create-and-use-scheduled-pipeline/): pre-aggregate expensive queries for SLOs and dashboards
+- [Composite Alerts](../../user-guide/analytics/alerts/composite-alerts.md): combine existing alerts with boolean logic
+- [Alert Conditions and Filters](../../user-guide/analytics/alerts/alert-conditions.md): condition builder, aggregation functions, and group-by (multi-alerts)
+- [Service Level Objectives (SLOs)](../../user-guide/analytics/slos/index.md): measure and alert on reliability targets
+- [OpenObserve Dashboards Documentation](../../user-guide/analytics/dashboards/index.md): dashboard builder, panel types, and variables
+- [OpenObserve Full-Text Search Functions](../../reference/sql-functions/full-text-search.md): SQL function reference for log queries (`match_all()`, `str_match()`, `re_match()`)
+- [OpenObserve Scheduled Pipelines](../../user-guide/data-processing/pipelines/create-and-use-scheduled-pipeline.md): pre-aggregate expensive queries for dashboards
 
-
-## Need Help?
+## Need help?
 
 - Join our [Community Slack](https://short.openobserve.ai/community)
 - Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/migration/migrate-from-datadog-to-openobserve/index.md
+++ b/docs/migration/migrate-from-datadog-to-openobserve/index.md
@@ -17,7 +17,7 @@ The goal is to switch the backend with minimal disruption: in most cases the Dat
 3. [Migrating Metrics](metrics.md): migrate Datadog Agent, DogStatsD, and OTel-based metric sources
 4. [Migrating Traces](traces.md): migrate Datadog APM to OTLP
 5. [Migrating Logs](logs.md): migrate Datadog Agent logs, Fluent Bit, and Vector
-6. [Migrating Dashboards & Monitors](dashboards-and-alerts.md): recreate Datadog dashboards and monitors
+6. [Migrating Dashboards & Monitors](dashboards-and-alerts.md): migrate Datadog dashboards and monitors
 
 
 ## Why Migrate?
@@ -65,7 +65,7 @@ Before changing any configs, inventory what you're running:
 - **DogStatsD usage:** which applications emit custom metrics via DogStatsD (port `8125` by default).
 - **APM tracers:** which services use `dd-trace-*` libraries (Java, Python, Node.js, Go, Ruby, .NET, PHP).
 - **Log pipelines:** how logs reach Datadog today, whether Agent log collection, Fluent Bit/Vector with Datadog output, direct API ingest, or cloud integrations (CloudWatch, Azure Monitor).
-- **Dashboards & monitors:** export them via the Datadog API now so you have a static record to recreate against.
+- **Dashboards & monitors:** export them via the Datadog API now so you have a static record to migrate against.
 
 A migration path exists for every one of these. See the per-signal pages.
 
@@ -95,7 +95,7 @@ The recommended order:
 1. **Stand up an OpenTelemetry Collector** alongside your existing Datadog Agent fleet. The Collector becomes the translation layer between Datadog wire formats (DogStatsD, Datadog Agent API, Datadog APM intake) and OTLP.
 2. **Dual-write for a short period.** Point the Datadog Agent and OTel Collector at the same applications so you can compare metrics side by side in Datadog and OpenObserve. This catches any mapping issues (counter vs. sum, histogram bucketing) before you cut over.
 3. **Migrate signal by signal**, starting with metrics, then traces, then logs. Each signal is independent, so you can finish one before starting the next.
-4. **Recreate dashboards and monitors** in OpenObserve. There is no automatic converter, but PromQL/SQL equivalents are direct in most cases, and the OpenObserve AI Assistant can translate query syntax for you.
+4. **Migrate dashboards and monitors** to OpenObserve. Use the [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) to convert Datadog dashboards and monitors automatically; for the remainder, PromQL/SQL equivalents are direct in most cases, and the OpenObserve AI Assistant can translate query syntax for you.
 5. **Decommission Datadog Agents** once dashboards, monitors, and on-call workflows have been moved over.
 
 ## Next Steps
@@ -104,7 +104,7 @@ The recommended order:
 - [Migrating Metrics](metrics.md): Datadog Agent, DogStatsD, OTel Collector
 - [Migrating Traces](traces.md): migrate Datadog APM to OTLP
 - [Migrating Logs](logs.md): migrate Datadog Agent logs and shipper-based pipelines
-- [Migrating Dashboards & Monitors](dashboards-and-alerts.md): recreate Datadog dashboards and monitors
+- [Migrating Dashboards & Monitors](dashboards-and-alerts.md): migrate Datadog dashboards and monitors
 
 
 ## Need Help?

--- a/docs/migration/migrate-from-grafana-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-grafana-to-openobserve/dashboards-and-alerts.md
@@ -1,27 +1,76 @@
 ---
 title: Migrating Dashboards & Alerts
 metaTitle: "Migrate Dashboards & Alerts from Grafana to OpenObserve"
-description: "Migrate Grafana dashboards and Alertmanager rules to OpenObserve. Covers LogQL to SQL translation, PromQL compatibility, and notification channels."
+description: "Migrate Grafana dashboards and Alertmanager rules to OpenObserve with the automated Dashboard Migrator, or translate queries by hand. Covers LogQL to SQL translation, PromQL compatibility, contact points, and notification policies."
 ---
 
 # Migrating Dashboards & Alerts
 
 ## Overview
 
-There is no automatic converter for dashboards or alerts — both need to be manually recreated in OpenObserve. That said, the effort is lower than it sounds:
+Grafana dashboards and alert rules are the main artifact that ties you to the LGTM stack. There are two ways to move them to OpenObserve:
 
-- **PromQL-based panels and alerts work as-is.** If your Grafana dashboards query Mimir metrics, the same PromQL query runs in OpenObserve unchanged.
-- **LogQL needs to be translated to SQL.** OpenObserve uses SQL for log and trace queries. The logic is the same — the syntax is different.
-- **The AI Assistant in OpenObserve can do the translation for you.** Instead of manually mapping LogQL to SQL, paste your query into the AI Assistant and ask it to convert. This removes the main friction point for both dashboards and alerts.
-![AI Assistant in OpenObserve](../../images/migration/lgtm/grafana-logql-to-sql.gif)
+1. **Automated** — the [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) converts Grafana dashboards, alert rules, contact points, and notification policies into OpenObserve dashboards, alerts, and destinations automatically.
+2. **Manual** — recreate each dashboard and rule by hand, translating LogQL to SQL yourself (or with the AI Assistant).
 
-Think of this as a forced cleanup. Grafana dashboards and alert rule lists tend to accumulate panels and rules that nobody looks at anymore. Recreating from scratch is a good opportunity to keep only what's genuinely useful.
+For most teams the automated path handles the bulk of the work; the manual path is a fallback for the pieces the migrator flags for review.
 
----
+## Migrate automatically with the Dashboard Migrator
 
-## Migrating Dashboards
+The [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) is a free web tool that converts dashboards and alert rules from Grafana — and Datadog, Kibana, and CloudWatch — into OpenObserve-native objects. For Grafana it has two flows:
 
-### What Changes
+- **Dashboards** — converts Grafana dashboards into OpenObserve dashboards: PromQL panels are preserved as-is, LogQL panels become SQL, and the panel layout, rows, and template variables carry over.
+- **Alerts** — converts Grafana alert rules into OpenObserve alerts, mapping each rule's evaluator and threshold to an alert condition and window. If you upload the full alerting archive, it also converts **contact points → destinations**, and resolves notification policies and mute timings onto each rule.
+
+### Dashboard flow
+
+1. **Load** — paste or upload Grafana dashboard JSON, or connect to your Grafana instance (via a service account) to pull dashboards directly.
+2. **Connect (optional)** — point the tool at your OpenObserve instance so it can read your live stream catalog and validate stream names.
+3. **Review** — inspect the migrated panels and queries, correct stream mappings, and override any variable defaults.
+4. **Export** — create the dashboards directly in OpenObserve, or download JSON you can import yourself.
+
+### Alert flow
+
+1. **Load Alert Rules** — paste or upload the rules JSON (Grafana → Alerting → Alert rules → Export), or upload the full alerting archive with contact points and policies.
+2. **Connect (optional)** — link OpenObserve to resolve destinations against your real setup.
+3. **Destinations** — review the contact points converted to OpenObserve destinations, and fill in any redacted secrets (webhook URLs, tokens).
+4. **Review** — inspect the translated alerts, thresholds, and destination assignments.
+5. **Export** — create the alerts directly in OpenObserve, or download JSON to import via Alerts → Import.
+
+:::tip[Grafana redacts secrets on export]
+Grafana's provisioning export replaces webhook URLs and tokens with `[redacted]`. The migrator flags these so you can re-enter them when it converts contact points to destinations.
+:::
+
+### What it translates and what it flags
+
+| Grafana source | Migration result |
+|---|---|
+| PromQL panels and rules | Preserved as-is (multi-line queries flattened) — run unchanged in OpenObserve. |
+| LogQL panels and rules | Translated to SQL; flag for review on complex `json`/`label_format` stages. |
+| Template variables | Carried over as OpenObserve dashboard variables. |
+| Alert evaluator + threshold | Mapped to an OpenObserve condition, operator, and look-back window. |
+| Contact points | Converted to OpenObserve destinations (webhook, email, Slack, PagerDuty, etc.). |
+| Notification policies & mute timings | Resolved onto each alert's destinations so the routing carries over. |
+
+## Export your Grafana configuration first
+
+Pull a static snapshot before you start. Dashboards and rules come from different places:
+
+```bash
+# Dashboards (list, then fetch each by uid)
+curl -s "https://<grafana>/api/search?type=dash-db" \
+  -H "Authorization: Bearer $GRAFANA_TOKEN" > dashboards-list.json
+
+# Alert rules (export per group from the UI: Alerting → Alert rules → Export)
+```
+
+The migrator can also read dashboards straight from Grafana if you create a service account token (**Administration → Service accounts**). For alert rules, export the group JSON from the UI, or download the alerting archive (rules, contact points, notification policies, mute timings, and templates) if you want to migrate the full routing setup.
+
+## Migrating dashboards manually
+
+If you prefer to rebuild by hand, here is the translation the migrator applies.
+
+### What changes
 
 | Element | Grafana (LGTM) | OpenObserve |
 |---|---|---|
@@ -31,21 +80,9 @@ Think of this as a forced cleanup. Grafana dashboards and alert rule lists tend 
 | Dashboard builder | Grafana UI | OpenObserve built-in dashboard builder |
 | Variables / template vars | Grafana variables | OpenObserve dashboard variables |
 
-### How to Approach It
-
-**Step 1: Inventory your dashboards**
-
-In Grafana, go to **Dashboards** and note all dashboards in use. For each one, identify:
-
-- Which panels are actually used (remove the rest)
-- Which data source each panel queries (Mimir, Loki, or Tempo)
-- Whether the panel uses PromQL, LogQL, or both
-
-**Step 2: Translate LogQL queries to SQL**
+### Translate LogQL queries to SQL
 
 This is the only part that requires real work. For each LogQL panel, you need an equivalent SQL query.
-
-LogQL → SQL translation examples:
 
 | LogQL | OpenObserve SQL |
 |---|---|
@@ -54,10 +91,10 @@ LogQL → SQL translation examples:
 | `rate({job="nginx"} \|= "timeout"[5m])` | `SELECT count(*) / 300 FROM default WHERE job = 'nginx' AND match_all('timeout')` |
 
 :::tip[Use the AI Assistant]
-Instead of translating queries by hand, use the **AI Assistant** (available in the OpenObserve UI) to convert LogQL to SQL. Paste your existing LogQL query and ask: *"Convert this LogQL query to OpenObserve SQL."* It handles the function mapping and syntax differences accurately and quickly, especially for complex filter and aggregation patterns.
+Instead of translating queries by hand, use the **AI Assistant** (available in the OpenObserve UI) to convert LogQL to SQL. Paste your existing LogQL query and ask: *"Convert this LogQL query to OpenObserve SQL."* It handles the function mapping and syntax differences accurately, especially for complex filter and aggregation patterns.
 :::
 
-**Step 3: Recreate in OpenObserve**
+### Recreate in OpenObserve
 
 OpenObserve has a built-in drag-and-drop dashboard builder with 18+ chart types. For each panel:
 
@@ -66,38 +103,37 @@ OpenObserve has a built-in drag-and-drop dashboard builder with 18+ chart types.
 3. Paste your translated query (or PromQL if it's a metrics panel).
 4. Configure the visualization type, axes, and thresholds.
 
----
+## Migrating alerts manually
 
-## Migrating Alerts
+### What changes
 
-### What Changes
-
-| Alert Type | Grafana | OpenObserve |
+| Alert type | Grafana | OpenObserve |
 |---|---|---|
 | Metric alerts (PromQL) | Grafana-managed or Mimir ruler rules | Same PromQL — create as a metric alert |
 | Log alerts (LogQL) | LogQL threshold alerts | SQL-based scheduled alert |
-| Notification channels | Alertmanager config | Built-in destinations (Slack, Email, PagerDuty, Webhook) |
+| Composite / multi-condition | Grafana expressions (`refId` chains) | [Composite alert](../../user-guide/analytics/alerts/composite-alerts.md) or group-by |
+| Notification channels | Contact points + notification policies | Built-in [destinations](../../user-guide/account-administration/management/alert-destinations.md), configured once and reused |
 
-### Step 1: Inventory Your Current Alerts
+OpenObserve alerts carry **two firing severities — Warning and Critical** — so a rule with both a warning and a critical threshold maps to the same two-level model.
 
-In Grafana, go to **Alerting → Alert Rules** and export or record all active rules. For each rule, note:
+### Step 1: Inventory your current alerts
+
+In Grafana, go to **Alerting → Alert Rules** and export all active rules. For each rule, note:
 
 - The query it uses (PromQL or LogQL)
 - The evaluation interval and threshold
-- The notification channel (Slack, PagerDuty, email, webhook)
+- The contact point / notification policy it routes to
 - Whether the alert is still useful — now is a good time to drop alerts nobody acts on
 
-### Step 2: Set Up Notification Channels
+### Step 2: Set up destinations
 
 Set up your notification destinations in OpenObserve before recreating rules, so you can test end-to-end as you go.
 
-OpenObserve supports: **Slack, Email, PagerDuty, and Webhook**.
+OpenObserve supports: **Slack, Email, PagerDuty, Webhook**, and more.
 
-![Alert Destinations in OpenObserve](../../images/migration/lgtm/alert-destinations.png)
+See the [OpenObserve Alert Destinations Documentation](../../user-guide/account-administration/management/alert-destinations.md) for setup instructions.
 
-See the [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/index.md) for setup instructions.
-
-### Step 3: Recreate Alert Rules
+### Step 3: Recreate alert rules
 
 **PromQL metric alerts — direct port, no changes:**
 
@@ -114,12 +150,10 @@ See the [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/ind
 | `rate({service="payments"} \|= "timeout"[5m]) > 0.05` | `SELECT count(*) / 300 FROM default WHERE service = 'payments' AND match_all('timeout')` with threshold > 0.05 |
 
 :::tip[Use the AI Assistant]
-The same AI Assistant that converts LogQL for dashboards works here too. Paste your LogQL alert query and ask it to produce the OpenObserve SQL equivalent. This is faster and less error-prone than translating complex multi-condition LogQL by hand.
+The same AI Assistant that converts LogQL for dashboards works here too. Paste your LogQL alert query and ask it to produce the OpenObserve SQL equivalent.
 :::
 
-   
-
-### Step 4: Verify Alerts
+### Step 4: Verify alerts
 
 1. Open **Alerts** in the OpenObserve UI and confirm each rule shows an **Active** or **Normal** status.
 2. Check the **Last Evaluated** timestamp — rules should update on their configured interval.
@@ -129,17 +163,16 @@ The same AI Assistant that converts LogQL for dashboards works here too. Paste y
 **Troubleshooting:**
 
 - **Rule never fires:** Run the SQL query in the Logs or Metrics explorer first to confirm it returns data before using it in an alert.
-- **No notification received:** Test the notification channel config (Slack webhook URL, SMTP settings) independently before attaching it to a rule.
+- **No notification received:** Test the destination config (Slack webhook URL, SMTP settings) independently before attaching it to a rule.
 - **PromQL returns no data:** Check that the metric name and label values are present in the Metrics explorer — case mismatch is the most common cause.
 
----
-
-## Next Steps
+## Next steps
 
 - [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/index.md) — full reference for alert rule types, conditions, and notification channels
-- [OpenObserve Dashboards Documentation](https://openobserve.ai/docs/user-guide/analytics/dashboards/) — dashboard builder, panel types, and variables
-- [OpenObserve Full-Text Search Functions](https://openobserve.ai/docs/reference/sql-functions/full-text-search/) — complete SQL function reference for log queries (`match_all()`, `str_match()`, `re_match()`)
-- [OpenObserve Scheduled Pipelines](https://openobserve.ai/docs/user-guide/data-processing/pipelines/create-and-use-scheduled-pipeline/) — pre-aggregate expensive queries, equivalent to Mimir recording rules
+- [Composite Alerts](../../user-guide/analytics/alerts/composite-alerts.md) — combine existing alerts with boolean logic
+- [OpenObserve Dashboards Documentation](../../user-guide/analytics/dashboards/index.md) — dashboard builder, panel types, and variables
+- [OpenObserve Full-Text Search Functions](../../reference/sql-functions/full-text-search.md) — SQL function reference for log queries (`match_all()`, `str_match()`, `re_match()`)
+- [OpenObserve Scheduled Pipelines](../../user-guide/data-processing/pipelines/create-and-use-scheduled-pipeline.md) — pre-aggregate expensive queries, equivalent to Mimir recording rules
 
 ---
 

--- a/docs/migration/migrate-from-grafana-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-grafana-to-openobserve/dashboards-and-alerts.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating Dashboards & Alerts
 metaTitle: "Migrate Dashboards & Alerts from Grafana to OpenObserve"
-description: "Migrate Grafana dashboards and Alertmanager rules to OpenObserve with the automated Dashboard Migrator, or translate queries by hand. Covers LogQL to SQL translation, PromQL compatibility, contact points, and notification policies."
+description: "Migrate Grafana dashboards and Alertmanager rules to OpenObserve with the Dashboard Migrator, or by hand. Covers LogQL to SQL and PromQL compatibility."
 ---
 
 # Migrating Dashboards & Alerts

--- a/docs/migration/migrate-from-grafana-to-openobserve/index.md
+++ b/docs/migration/migrate-from-grafana-to-openobserve/index.md
@@ -15,7 +15,7 @@ If you're currently running your observability stack on LGTM — Loki for logs, 
 3. [Migrating Metrics](metrics.md) — migrate from Mimir or Prometheus remote write
 4. [Migrating Traces](traces.md) — migrate from Tempo
 5. [Migrating Logs](logs.md) — migrate from Loki
-6. [Migrating Dashboards & Alerts](dashboards-and-alerts.md) — recreate Grafana dashboards and Alertmanager rules
+6. [Migrating Dashboards & Alerts](dashboards-and-alerts.md) — migrate Grafana dashboards and Alertmanager rules
 
 ---
 
@@ -104,4 +104,4 @@ After installation, access the UI at `http://localhost:5080` and navigate to **D
 - [Migrating Metrics](metrics.md) — migrate from Mimir or Prometheus remote write
 - [Migrating Traces](traces.md) — migrate from Tempo
 - [Migrating Logs](logs.md) — migrate from Loki
-- [Migrating Dashboards & Alerts](dashboards-and-alerts.md) — recreate Grafana dashboards and Alertmanager rules
+- [Migrating Dashboards & Alerts](dashboards-and-alerts.md) — migrate Grafana dashboards and Alertmanager rules

--- a/docs/migration/migrate-from-kibana-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-kibana-to-openobserve/dashboards-and-alerts.md
@@ -1,0 +1,110 @@
+---
+title: Migrating Dashboards & Visualizations
+metaTitle: Migrate Kibana Dashboards & Visualizations to OpenObserve
+description: "Convert Kibana saved-object exports into OpenObserve dashboards with the Dashboard Migrator. Lucene and KQL queries translate to SQL, and index patterns map to streams."
+---
+
+# Migrating Dashboards & Visualizations
+
+## Overview
+
+Kibana dashboards and visualizations encode your team's query logic in Lucene/KQL and the Elasticsearch aggregation DSL. There are two ways to move them to OpenObserve:
+
+1. **Automated** — the [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) converts a Kibana saved-object export (`.ndjson`) into OpenObserve dashboards, translating queries, aggregations, and layout automatically.
+2. **Manual** — recreate each dashboard by hand, rewriting Lucene/KQL as SQL.
+
+For most teams the automated path handles the bulk of the work; the manual path is a fallback and a way to understand what changed.
+
+## Migrate automatically with the Dashboard Migrator
+
+The [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) is a free web tool that converts dashboards from Kibana — and Datadog, Grafana, and CloudWatch — into OpenObserve-native objects. For Kibana it reads a saved-object export and produces OpenObserve dashboards with the panels, layout, and queries translated.
+
+### How it works
+
+1. **Upload Export** — paste or upload the `.ndjson` (or `.json`) saved-object export from Kibana.
+2. **Choose Dashboards** — pick one, several, or all of the dashboards in the export.
+3. **Connect & Map** — link OpenObserve and map each Kibana **index pattern** to an OpenObserve **stream**.
+4. **Review** — inspect the translated panels and queries.
+5. **Export** — create the dashboards directly in OpenObserve, or download JSON to import.
+
+As it migrates, it reports a coverage tally per object — **migrated**, **needs review**, and **skipped** — so you can see how much work remains.
+
+### What it translates and what it flags
+
+| Kibana source | Migration result |
+|---|---|
+| Lucene / KQL queries | Translated to SQL (`WHERE` clauses, `match_all()` for full-text). |
+| Aggregations (avg, min, max, terms, date histogram) | Converted to SQL aggregations and `GROUP BY`. |
+| Field names | Mapped to OpenObserve columns — `@timestamp` becomes `_timestamp`, `.keyword` is stripped, names are normalized. |
+| Index patterns | Mapped to OpenObserve streams (you pick the mapping). |
+| Layout | Panel positions and sizes carried over to the OpenObserve grid. |
+
+## Export your Kibana configuration first
+
+Pull a static snapshot before you start. In Kibana:
+
+1. Go to **Stack Management → Saved Objects**.
+2. Select the dashboards, visualizations, and index patterns you want to move.
+3. Click **Export**, then choose **Export all** to download the `.ndjson` file.
+
+Keep the file — it is the input to the migrator, and your reference if you recreate anything by hand.
+
+## Migrating manually
+
+If you prefer to rebuild by hand, here is the translation the migrator applies.
+
+### What changes
+
+| Element | Kibana | OpenObserve |
+|---|---|---|
+| Query language | Lucene / KQL | SQL |
+| Full-text search | `message: "timeout"` | `match_all('timeout')` |
+| Aggregations | Elasticsearch aggregation DSL | SQL `AVG()`, `MIN()`, `GROUP BY`, time buckets |
+| Time field | `@timestamp` | `_timestamp` |
+| Data source | Index pattern | Stream |
+| Dashboard builder | Kibana Lens / TSVB | OpenObserve dashboard builder |
+
+### Translate queries
+
+Lucene/KQL to SQL examples:
+
+| Kibana query | OpenObserve SQL |
+|---|---|
+| `status:500` | `SELECT * FROM default WHERE status = '500'` |
+| `message: "timeout"` | `SELECT * FROM default WHERE match_all('timeout')` |
+| `response:>=400 AND response:<500` | `SELECT * FROM default WHERE response >= 400 AND response < 500` |
+| `service:api AND level:error` | `SELECT * FROM default WHERE service = 'api' AND level = 'error'` |
+| `NOT service:test` | `SELECT * FROM default WHERE service != 'test'` |
+
+Aggregation examples:
+
+| Kibana aggregation | OpenObserve SQL |
+|---|---|
+| Average of `response_time` | `SELECT avg(response_time) FROM default` |
+| Terms (top values) of `status` | `SELECT status, count(*) FROM default GROUP BY status` |
+| Date histogram over `@timestamp` (1m) | `SELECT histogram(_timestamp, INTERVAL '1 minute') AS ts, count(*) FROM default GROUP BY ts` |
+
+:::tip[Use the AI Assistant]
+Instead of translating by hand, use the **AI Assistant** in the OpenObserve UI. Paste a Lucene/KQL query and ask: *"Convert this Kibana query to OpenObserve SQL."* It handles field mapping, function translation, and aggregation syntax in one shot.
+:::
+
+### Recreate in OpenObserve
+
+1. Open **Dashboards** → **New Dashboard** in the OpenObserve UI.
+2. Add a panel and select the signal type (Logs, Metrics, or Traces).
+3. Paste your translated SQL.
+4. Configure the visualization type, axes, and thresholds.
+
+## Kibana alerting rules
+
+Kibana's built-in alerting rules are not migrated by the Dashboard Migrator — it converts dashboards and visualizations. To move a Kibana alert, recreate it as an OpenObserve [scheduled alert](../../user-guide/analytics/alerts/index.md): take the rule's Lucene/KQL query, translate it to SQL as above, and attach the threshold and destination. See the [Alerts documentation](../../user-guide/analytics/alerts/index.md) for details.
+
+## Next steps
+
+- [OpenObserve Dashboards Documentation](../../user-guide/analytics/dashboards/index.md) — dashboard builder, panel types, and variables
+- [OpenObserve Alerts Documentation](../../user-guide/analytics/alerts/index.md) — recreate Kibana alerting rules as OpenObserve alerts
+- [OpenObserve Full-Text Search Functions](../../reference/sql-functions/full-text-search.md) — SQL function reference for log queries (`match_all()`, `str_match()`, `re_match()`)
+
+---
+
+[Back to Overview](index.md)

--- a/docs/migration/migrate-from-kibana-to-openobserve/dashboards-and-alerts.md
+++ b/docs/migration/migrate-from-kibana-to-openobserve/dashboards-and-alerts.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating Dashboards & Visualizations
 metaTitle: Migrate Kibana Dashboards & Visualizations to OpenObserve
-description: "Convert Kibana saved-object exports into OpenObserve dashboards with the Dashboard Migrator. Lucene and KQL queries translate to SQL, and index patterns map to streams."
+description: "Convert Kibana saved-object exports into OpenObserve dashboards with the Dashboard Migrator. Lucene and KQL translate to SQL."
 ---
 
 # Migrating Dashboards & Visualizations

--- a/docs/migration/migrate-from-kibana-to-openobserve/index.md
+++ b/docs/migration/migrate-from-kibana-to-openobserve/index.md
@@ -1,7 +1,7 @@
 ---
 title: Overview
 metaTitle: Migrate from Kibana to OpenObserve
-description: "Migrate Kibana dashboards and visualizations to OpenObserve with the automated Dashboard Migrator. Lucene and KQL queries become SQL, and saved-object exports convert in minutes."
+description: "Migrate Kibana dashboards and visualizations to OpenObserve with the Dashboard Migrator; Lucene and KQL queries become SQL."
 ---
 
 # Migrate from Kibana to OpenObserve

--- a/docs/migration/migrate-from-kibana-to-openobserve/index.md
+++ b/docs/migration/migrate-from-kibana-to-openobserve/index.md
@@ -1,0 +1,88 @@
+---
+title: Overview
+metaTitle: Migrate from Kibana to OpenObserve
+description: "Migrate Kibana dashboards and visualizations to OpenObserve with the automated Dashboard Migrator. Lucene and KQL queries become SQL, and saved-object exports convert in minutes."
+---
+
+# Migrate from Kibana to OpenObserve
+
+If you're running Kibana on top of Elasticsearch for log exploration and dashboards and want to move to OpenObserve, this guide walks you through moving your dashboards and visualizations. The [OpenObserve Dashboard Migrator](https://migration.openobserve.ai/) converts Kibana saved-object exports into OpenObserve dashboards automatically, translating Lucene and KQL queries to SQL.
+
+Kibana is a visualization layer over Elasticsearch, so migrating it has two independent parts:
+
+1. **The data** — move your Elasticsearch data into OpenObserve streams. This is a standard ingestion task (OpenTelemetry Collector, Filebeat, Logstash, or Fluent Bit) and has nothing to do with the dashboard work.
+2. **The dashboards and visualizations** — convert your saved objects into OpenObserve dashboards. This is what the Dashboard Migrator automates.
+
+## Table of Contents
+
+1. [Overview](index.md) — why migrate and what changes
+2. [Migrating Dashboards & Visualizations](dashboards-and-alerts.md) — convert Kibana saved objects with the Dashboard Migrator
+
+---
+
+## Why Migrate?
+
+Kibana is a capable visualization tool, but running it means operating the whole Elastic stack — and most of that cost is spent on things you don't get visibility value from.
+
+### License and vendor lock-in
+
+Elasticsearch and Kibana are licensed under the SSPL, which is restrictive for teams offering Elasticsearch as a service. The query language (Lucene/KQL), the saved-object export format, and the aggregation DSL are all Elastic-specific.
+
+OpenObserve is open source and speaks open protocols (OpenTelemetry, Prometheus Remote Write, Loki Push API, plain JSON), and queries your data with SQL — a language your team already knows.
+
+### Operational cost
+
+The Elastic stack is heavyweight: a JVM per node with large heap allocation, separate Elasticsearch, Kibana, and (usually) Logstash or Beats deployments, and careful index/shard lifecycle management. OpenObserve is a single binary (or Helm chart) that stores data as Apache Parquet on object storage — **up to 140x more efficient** — with no JVM, no index management, and no shard tuning.
+
+### Storage cost
+
+Elasticsearch keeps every field indexed by default, which balloons disk usage and memory. OpenObserve stores raw events as Parquet columns and indexes only what you tell it to, so the same data costs a fraction of the disk.
+
+## What OpenObserve Changes
+
+| | Kibana / Elasticsearch | OpenObserve |
+|---|---|---|
+| **Components to run** | Elasticsearch + Kibana (+ Beats/Logstash) | 1 binary or 1 Helm chart |
+| **Storage backend** | Inverted index per shard (JVM) | Apache Parquet on S3 / GCS / Azure Blob / local disk |
+| **Storage cost** | High — full-field indexing | Up to 140x more efficient |
+| **Query language** | Lucene / KQL + aggregation DSL | SQL (plus PromQL for metrics) |
+| **Dashboards** | Kibana saved objects | OpenObserve dashboard builder |
+| **Lock-in** | Elastic-specific formats | Open standards; data lives in your bucket as Parquet |
+| **Deployment** | Self-hosted (or Elastic Cloud) | Self-host or OpenObserve Cloud |
+
+## Before You Start
+
+Before migrating, export a snapshot of what you have:
+
+- **Dashboards and visualizations:** in Kibana, go to **Stack Management → Saved Objects** and export everything (or the dashboards you actually use) as an `.ndjson` file. This is the input to the Dashboard Migrator.
+- **Index patterns:** note which index patterns your visualizations reference — the migrator maps these to OpenObserve streams.
+- **Data sources:** confirm how data reaches Elasticsearch today (Beats, Logstash, Fluent Bit, application SDKs), so you can repoint it at OpenObserve.
+
+## Set Up OpenObserve
+
+Before migrating, get OpenObserve running:
+
+::::tabs
+:::tab[OpenObserve Cloud]
+
+Sign up at [cloud.openobserve.ai](https://cloud.openobserve.ai). No infrastructure to manage.
+
+After logging in, navigate to **Data Sources** to find your ingestion credentials and endpoint URLs.
+:::
+:::tab[Self-Hosted]
+
+Download OpenObserve for your platform from the [downloads page](https://openobserve.ai/downloads/).
+
+After installation, access the UI at `http://localhost:5080` and navigate to **Data Sources** to find your ingestion credentials and ready-to-use configuration snippets.
+:::
+::::
+
+## Next Steps
+
+- [Migrating Dashboards & Visualizations](dashboards-and-alerts.md) — convert Kibana saved objects with the Dashboard Migrator
+- [OpenObserve Ingestion](../../ingestion/index.md) — get your logs, metrics, and traces into OpenObserve
+
+## Need Help?
+
+- Join our [Community Slack](https://short.openobserve.ai/community)
+- Or [Contact support](https://openobserve.ai/contactus/)

--- a/docs/migration/migrate-from-kibana-to-openobserve/meta.json
+++ b/docs/migration/migrate-from-kibana-to-openobserve/meta.json
@@ -1,0 +1,6 @@
+{
+  "pages": [
+    "index",
+    "dashboards-and-alerts"
+  ]
+}


### PR DESCRIPTION
## Summary

Updates the migration guides to reflect the [Dashboard Migrator](https://migration.openobserve.ai/), which now automates dashboard and alert migration from Datadog, Grafana, Kibana, and CloudWatch — replacing the previous "no automatic converter, recreate by hand" guidance.

## Changes

- **Datadog** — rewrote `dashboards-and-alerts.md` to lead with the automated migrator; updated monitor mapping for composite alerts, group-by multi-alerts, warning/critical levels, and native SLOs. Fixed stale "no automatic converter" wording in `index.md`.
- **Grafana** — rewrote `dashboards-and-alerts.md` to cover the migrator (dashboards + alert rules + contact points → destinations + notification policies/mute timings). Fixed "recreate" wording in `index.md`.
- **New: Kibana** — new `migrate-from-kibana-to-openobserve/` section covering the `.ndjson` flow and Lucene/KQL → SQL translation.
- **New: CloudWatch** — new `migrate-from-cloudwatch-to-openobserve/` section covering Metric Streams ingestion and metrics-as-logs SQL mapping.
- Registered both new sections in `docs/migration/meta.json`.