### PR TITLE
fix(search): unescape table-cell content in the search index

### DIFF
--- a/app/api/search.json/route.ts
+++ b/app/api/search.json/route.ts
@@ -1,5 +1,22 @@
 import { createFromSource } from 'fumadocs-core/search/server';
 import { source } from '@/lib/source';
+import path from 'node:path';
+
+/**
+ * Undo the CommonMark backslash-escaping that `fumadocs-core`'s remark-structure
+ * plugin applies when it stringifies a table cell back into plain text for the
+ * search index (it round-trips through `mdast-util-to-markdown`, which escapes
+ * ASCII punctuation defensively so the emitted string stays valid Markdown).
+ * A table row like `| ZO_FILE_FORMAT | ... |` is indexed as the literal
+ * string `ZO\_FILE\_FORMAT` — nobody searches with the backslashes, so every
+ * variable/term with an underscore, asterisk, bracket, or backtick in a table
+ * (i.e. most of the env var / config reference tables on this site) was
+ * unsearchable. Headings and paragraphs go through the same stringifier and
+ * can carry the same escaping, so this runs over both.
+ */
+function unescapeMarkdown(text: string): string {
+  return text.replace(/\\([!-/:-@[-`{-~])/g, '$1');
+}
 
 /**
  * Prebuilt search index. `output: 'export'` means this must be a static file,
@@ -12,8 +29,27 @@ import { source } from '@/lib/source';
  * `/docs/api/search/`, which has no `index.html` and served the 404 page, so
  * the client threw instead of loading an index. Anything with a file extension
  * is passed through untouched.
+ *
+ * `buildIndex` re-implements Fumadocs' own default (see `buildIndexDefault` in
+ * fumadocs-core's `search/server`) purely to run `unescapeMarkdown` over the
+ * structured data it hands to the indexer - everything else is unchanged.
  */
 export const revalidate = false;
 export const dynamic = 'force-static';
 
-export const { staticGET: GET } = createFromSource(source);
+export const { staticGET: GET } = createFromSource(source, {
+  buildIndex: (page) => {
+    const raw = page.data.structuredData;
+
+    return {
+      title: page.data.title ?? path.basename(page.path, path.extname(page.path)),
+      description: page.data.description,
+      url: page.url,
+      id: page.url,
+      structuredData: {
+        headings: raw.headings.map((h) => ({ ...h, content: unescapeMarkdown(h.content) })),
+        contents: raw.contents.map((c) => ({ ...c, content: unescapeMarkdown(c.content) })),
+      },
+    };
+  },
+});


### PR DESCRIPTION
**Bug:** table content, such as env var names in the environment-variables reference page, never shows up in the docs site search, even though the page content is correct and the search index is fresh.

**Root cause:** fumadocs-core's `remark-structure` plugin stringifies table-cell AST nodes back into text via `mdast-util-to-markdown` (a real Markdown serializer meant to round-trip), which backslash-escapes ASCII punctuation defensively. A table row like `| ZO_FILE_FORMAT | ... |` was indexed as the literal string `ZO\_FILE\_FORMAT`. Users search without backslashes, so it never matched. Confirmed by inspecting the actual built `out/api/search.json`: every table-cell entry across the site carried this escaping; headings/paragraphs were unaffected.

**Fix:** `app/api/search.json/route.ts` now passes a custom `buildIndex` to `createFromSource` that strips CommonMark backslash-escapes from both `headings[].content` and `contents[].content` before they reach the indexer. Everything else is unchanged from Fumadocs'own default `buildIndexDefault`.

**Verified** with a full local `pnpm build`, comparing the generated `search.json` before/after: 33,976 total index entries both times (nothing dropped or duplicated), and zero remaining backslash-escaped entries site-wide after the fix (previously every table-cell entry had one).