### PR TITLE
fix(docs): React Native RUM session-replay customEndpoint no longer n…

### DIFF
--- a/docs/user-guide/data-exploration/rum/mobile/best-practices.md
+++ b/docs/user-guide/data-exploration/rum/mobile/best-practices.md
@@ -9,7 +9,7 @@ This guide collects the decisions that separate a mobile RUM setup that just wor
 
 !!! note "Versions (Beta)"
 
-    The mobile SDKs are at React Native `0.1.1`, Android `0.1.0`, and iOS `0.1.0`. Pin exact versions, test upgrades deliberately, and watch release notes — the version-management section below covers this in detail.
+    The mobile SDKs are at React Native `0.1.2`, Android `0.1.0`, and iOS `0.1.0`. Pin exact versions, test upgrades deliberately, and watch release notes — the version-management section below covers this in detail.
 
 ## Sampling strategy — pick each rate for what it costs
 
@@ -238,10 +238,10 @@ Automatic instrumentation already produces reasonable names — screens from you
 
 ```tsx
 // Good: stable, readable view name; variable data goes in attributes
-await OoRum.startView('order-detail', 'Order Detail', { 'order.id': orderId });
+await O2Rum.startView('order-detail', 'Order Detail', { 'order.id': orderId });
 
 // Avoid: id in the name explodes cardinality and breaks aggregation
-await OoRum.startView(orderId, `Order ${orderId}`);
+await O2Rum.startView(orderId, `Order ${orderId}`);
 ```
 
 ## Automatic vs manual instrumentation — start automatic, fill gaps manually
@@ -265,9 +265,9 @@ Ship with consent gating from day one rather than retrofitting it. Every SDK has
 
 ```tsx
 // Initialize pending, then grant after the user agrees
-import { OoSdkReactNative, TrackingConsent } from '@openobserve/mobile-react-native';
+import { O2SdkReactNative, TrackingConsent } from '@openobserve/mobile-react-native';
 
-OoSdkReactNative.setTrackingConsent(TrackingConsent.GRANTED);
+O2SdkReactNative.setTrackingConsent(TrackingConsent.GRANTED);
 ```
 
 ### Android
@@ -346,13 +346,13 @@ Raise verbosity in non-prod builds and lower or remove it in production — debu
 These SDKs are on early `0.1.x` releases, so treat version management as part of your production hygiene:
 
 - **Pin exact versions**, not ranges. Configuration details can still change between `0.1.x` releases, and a floating range can pull a breaking change into a build without you noticing.
-- **Keep React Native's layers aligned.** The JavaScript package wraps native Android and iOS code and pins the native versions it needs — these are not the same number as the npm version (React Native `0.1.1` pins Android `0.1.0` and iOS `0.1.0`). Let the package bring its own native versions rather than overriding them, and after upgrading the JS package run `pod install` again and rebuild both platforms so the native side matches.
+- **Keep React Native's layers aligned.** The JavaScript package wraps native Android and iOS code and pins the native versions it needs — these are not the same number as the npm version (React Native `0.1.2` pins Android `0.1.0` and iOS `0.1.0`). Let the package bring its own native versions rather than overriding them, and after upgrading the JS package run `pod install` again and rebuild both platforms so the native side matches.
 - **Test every upgrade in a non-prod build** using the verification steps above before it reaches production.
 - **Read the release notes** for each SDK on every bump and watch for breaking changes to configuration and API surface.
 
 ```bash
 # Pin exact versions — no ^ or ~ ranges
-npm install @openobserve/mobile-react-native@0.1.1
+npm install @openobserve/mobile-react-native@0.1.2
 ```
 
 ```groovy

--- a/docs/user-guide/data-exploration/rum/mobile/error-tracking.md
+++ b/docs/user-guide/data-exploration/rum/mobile/error-tracking.md
@@ -11,7 +11,7 @@ If you are new to the mobile SDKs, start with the [Mobile RUM Overview](./index.
 
 !!! note "Versions (Beta)"
 
-    The mobile SDKs are at React Native `0.1.1`, Android `0.1.0`, and iOS `0.1.0`. The error and crash APIs shown here are settled, but pin exact versions: a few build-time symbol-upload tools are still being finalized, and those are called out explicitly below.
+    The mobile SDKs are at React Native `0.1.2`, Android `0.1.0`, and iOS `0.1.0`. The error and crash APIs shown here are settled, but pin exact versions: a few build-time symbol-upload tools are still being finalized, and those are called out explicitly below.
 
 ## Handled errors vs. crashes
 
@@ -42,16 +42,16 @@ Automatic capture only sees faults that reach the top of the stack. Everything y
 
 ### React Native
 
-Use the `OoRum.addError` singleton method. Its signature is `addError(message, source, stacktrace, context?, timestampMs?, fingerprint?)`:
+Use the `O2Rum.addError` singleton method. Its signature is `addError(message, source, stacktrace, context?, timestampMs?, fingerprint?)`:
 
 ```tsx
-import { OoRum, ErrorSource } from '@openobserve/mobile-react-native';
+import { O2Rum, ErrorSource } from '@openobserve/mobile-react-native';
 
 try {
   await submitOrder(cart);
 } catch (e) {
   const err = e as Error;
-  await OoRum.addError(
+  await O2Rum.addError(
     err.message,
     ErrorSource.SOURCE,
     err.stack ?? '',
@@ -118,7 +118,7 @@ Automatic grouping is right most of the time, but it can be too coarse (two unre
 - **React Native** — pass the `fingerprint` argument (the last parameter of `addError`):
 
   ```tsx
-  await OoRum.addError(
+  await O2Rum.addError(
     err.message,
     ErrorSource.SOURCE,
     err.stack ?? '',

--- a/docs/user-guide/data-exploration/rum/mobile/index.md
+++ b/docs/user-guide/data-exploration/rum/mobile/index.md
@@ -48,7 +48,7 @@ The React Native SDK wraps the native Android and iOS SDKs, so a React Native ap
 
 !!! note "Versions (Beta)"
 
-    The mobile SDKs are at React Native `0.1.1`, Android `0.1.0`, and iOS `0.1.0`. Pin exact versions and expect small configuration details to change across early `0.1.x` releases.
+    The mobile SDKs are at React Native `0.1.2`, Android `0.1.0`, and iOS `0.1.0`. Pin exact versions and expect small configuration details to change across early `0.1.x` releases.
 
 ## How it connects to OpenObserve
 
@@ -104,7 +104,7 @@ The SDKs are built for production: data is collected asynchronously off the main
 
 ### Are the mobile SDKs production-ready?
 
-The mobile SDKs are in Beta, at React Native 0.1.1, Android 0.1.0, and iOS 0.1.0. The API surface is settled and the data model matches OpenObserve's browser RUM, but you should pin exact versions, test upgrades, and expect some configuration details — particularly managed-cloud endpoint presets and build-time symbol upload — to be finalized in upcoming 0.1.x releases.
+The mobile SDKs are in Beta, at React Native 0.1.2, Android 0.1.0, and iOS 0.1.0. The API surface is settled and the data model matches OpenObserve's browser RUM, but you should pin exact versions, test upgrades, and expect some configuration details — particularly managed-cloud endpoint presets and build-time symbol upload — to be finalized in upcoming 0.1.x releases.
 
 ### How is Mobile RUM different from OpenObserve's browser RUM?
 

--- a/docs/user-guide/data-exploration/rum/mobile/performance-monitoring.md
+++ b/docs/user-guide/data-exploration/rum/mobile/performance-monitoring.md
@@ -12,7 +12,7 @@ If you are just getting set up, start with the [Mobile RUM Overview](./index.md)
 
 !!! note "Versions (Beta)"
 
-    The mobile SDKs are at React Native `0.1.1`, Android `0.1.0`, and iOS `0.1.0`. The performance metrics described here are collected today; pin your exact SDK version and re-test on upgrades, since defaults and option names may still change across early `0.1.x` releases.
+    The mobile SDKs are at React Native `0.1.2`, Android `0.1.0`, and iOS `0.1.0`. The performance metrics described here are collected today; pin your exact SDK version and re-test on upgrades, since defaults and option names may still change across early `0.1.x` releases.
 
 ## What performance data you get
 
@@ -55,17 +55,17 @@ Views are captured automatically when you enable view tracking, and you can also
 
 ```tsx
 // Automatic (recommended) — via @openobserve/mobile-react-navigation
-OoRumReactNavigationTracking.startTrackingViews(navigationRef);
+O2RumReactNavigationTracking.startTrackingViews(navigationRef);
 
 // Manual — name and time a screen yourself
-import { OoRum } from '@openobserve/mobile-react-native';
+import { O2Rum } from '@openobserve/mobile-react-native';
 
-await OoRum.startView('checkout', 'Checkout');
+await O2Rum.startView('checkout', 'Checkout');
 // ...screen is visible...
-await OoRum.stopView('checkout');
+await O2Rum.stopView('checkout');
 
 // Add a custom timing marker within the current view
-await OoRum.addTiming('content_ready');
+await O2Rum.addTiming('content_ready');
 ```
 
 ### Android

--- a/docs/user-guide/data-exploration/rum/mobile/react-native.md
+++ b/docs/user-guide/data-exploration/rum/mobile/react-native.md
@@ -11,7 +11,7 @@ New to mobile RUM in general? Start with the [Mobile RUM Overview](./index.md) f
 
 !!! note "Version (Beta)"
 
-    The React Native SDK is published as `0.1.1` on npm. Pin the exact version and test upgrades deliberately, since configuration details can still change across early `0.1.x` releases.
+    The React Native SDK is published as `0.1.2` on npm. Pin the exact version and test upgrades deliberately, since configuration details can still change across early `0.1.x` releases. Session Replay's `customEndpoint` handling changed in `0.1.2` — see [Step 10](#step-10-session-replay-optional).
 
 ## What you get
 
@@ -125,7 +125,7 @@ That single provider initializes the SDK, enables RUM, and starts the automatic 
 
 !!! note "Consent gating"
 
-    Nothing is collected until tracking consent is `granted`. If you show a consent dialog, initialize with `TrackingConsent.PENDING` and call `OoSdkReactNative.setTrackingConsent(TrackingConsent.GRANTED)` once the user agrees. See [Security & Privacy](./security-privacy.md).
+    Nothing is collected until tracking consent is `granted`. If you show a consent dialog, initialize with `TrackingConsent.PENDING` and call `O2SdkReactNative.setTrackingConsent(TrackingConsent.GRANTED)` once the user agrees. See [Security & Privacy](./security-privacy.md).
 
 ## Step 3 — Configuration options
 
@@ -173,7 +173,7 @@ Install `@openobserve/mobile-react-navigation` and start tracking once you have 
 ```tsx
 import { useRef } from 'react';
 import { NavigationContainer, useNavigationContainerRef } from '@react-navigation/native';
-import { OoRumReactNavigationTracking } from '@openobserve/mobile-react-navigation';
+import { O2RumReactNavigationTracking } from '@openobserve/mobile-react-navigation';
 
 function Root() {
   const navigationRef = useNavigationContainerRef();
@@ -182,7 +182,7 @@ function Root() {
     <NavigationContainer
       ref={navigationRef}
       onReady={() => {
-        OoRumReactNavigationTracking.startTrackingViews(navigationRef);
+        O2RumReactNavigationTracking.startTrackingViews(navigationRef);
       }}
     >
       {/* screens */}
@@ -191,18 +191,18 @@ function Root() {
 }
 ```
 
-This starts and stops a RUM view automatically on every navigation, including Android hardware back-press exits. Stop tracking with `OoRumReactNavigationTracking.stopTrackingViews(navigationRef)`.
+This starts and stops a RUM view automatically on every navigation, including Android hardware back-press exits. Stop tracking with `O2RumReactNavigationTracking.stopTrackingViews(navigationRef)`.
 
 ### Manually
 
 When automatic tracking does not fit (custom navigators, modals, tab changes you want named yourself), drive views directly:
 
 ```tsx
-import { OoRum } from '@openobserve/mobile-react-native';
+import { O2Rum } from '@openobserve/mobile-react-native';
 
-await OoRum.startView('checkout', 'Checkout');
+await O2Rum.startView('checkout', 'Checkout');
 // ...user is on the screen...
-await OoRum.stopView('checkout');
+await O2Rum.stopView('checkout');
 ```
 
 ## Step 5 — Track user actions
@@ -210,9 +210,9 @@ await OoRum.stopView('checkout');
 With `trackInteractions: true`, taps and gestures are captured automatically and named from the element's `accessibilityLabel` (or a custom `actionNameAttribute` prop you configure). To record actions explicitly:
 
 ```tsx
-import { OoRum, RumActionType } from '@openobserve/mobile-react-native';
+import { O2Rum, RumActionType } from '@openobserve/mobile-react-native';
 
-await OoRum.addAction(RumActionType.TAP, 'Add to cart', { productId: 'sku-42' });
+await O2Rum.addAction(RumActionType.TAP, 'Add to cart', { productId: 'sku-42' });
 ```
 
 `RumActionType` values: `TAP`, `SCROLL`, `SWIPE`, `BACK`, `CUSTOM`.
@@ -224,11 +224,11 @@ With `trackResources: true`, the SDK proxies `fetch` and `XMLHttpRequest` and re
 To record a resource manually (for a non-HTTP transport, for example):
 
 ```tsx
-import { OoRum } from '@openobserve/mobile-react-native';
+import { O2Rum } from '@openobserve/mobile-react-native';
 
-await OoRum.startResource('req-1', 'GET', 'https://api.example.com/cart');
+await O2Rum.startResource('req-1', 'GET', 'https://api.example.com/cart');
 // ...request completes...
-await OoRum.stopResource('req-1', 200, 'fetch', 1024);
+await O2Rum.stopResource('req-1', 200, 'fetch', 1024);
 ```
 
 `propagatorTypes` for first-party hosts can be `tracecontext` (W3C — what OpenObserve reads), `b3`, or `b3multi`.
@@ -238,12 +238,12 @@ await OoRum.stopResource('req-1', 200, 'fetch', 1024);
 With `trackErrors: true`, unhandled JavaScript exceptions are captured automatically. Report handled errors yourself so you can see failures that you caught and recovered from:
 
 ```tsx
-import { OoRum, ErrorSource } from '@openobserve/mobile-react-native';
+import { O2Rum, ErrorSource } from '@openobserve/mobile-react-native';
 
 try {
   await checkout();
 } catch (e) {
-  await OoRum.addError(
+  await O2Rum.addError(
     (e as Error).message,
     ErrorSource.SOURCE,
     (e as Error).stack ?? '',
@@ -259,10 +259,10 @@ try {
 Attach the logged-in user so you can measure user-level impact (respecting consent). `id` is required:
 
 ```tsx
-import { OoSdkReactNative } from '@openobserve/mobile-react-native';
+import { O2SdkReactNative } from '@openobserve/mobile-react-native';
 
 // after login
-OoSdkReactNative.setUserInfo({
+O2SdkReactNative.setUserInfo({
   id: 'user-123',
   name: 'Ada Lovelace',
   email: 'ada@example.com',
@@ -270,14 +270,14 @@ OoSdkReactNative.setUserInfo({
 });
 
 // on logout
-OoSdkReactNative.clearUserInfo();
+O2SdkReactNative.clearUserInfo();
 ```
 
 Add global attributes that attach to every RUM event, log, and span — useful for release channel, feature flags, or A/B buckets:
 
 ```tsx
-OoSdkReactNative.addAttribute('feature_flag.new_checkout', true);
-OoSdkReactNative.addAttribute('build.channel', 'beta');
+O2SdkReactNative.addAttribute('feature_flag.new_checkout', true);
+O2SdkReactNative.addAttribute('build.channel', 'beta');
 ```
 
 ## Step 9 — Logs (optional)
@@ -285,10 +285,10 @@ OoSdkReactNative.addAttribute('build.channel', 'beta');
 The same SDK forwards structured logs to OpenObserve:
 
 ```tsx
-import { OoLogs } from '@openobserve/mobile-react-native';
+import { O2Logs } from '@openobserve/mobile-react-native';
 
-OoLogs.info('Checkout started', { cartValue: 89.9 });
-OoLogs.error('Payment declined', { reason: 'insufficient_funds' });
+O2Logs.info('Checkout started', { cartValue: 89.9 });
+O2Logs.error('Payment declined', { reason: 'insufficient_funds' });
 ```
 
 Logs are correlated with the active RUM session, so you can pivot from a session to its logs in OpenObserve.
@@ -304,10 +304,19 @@ await SessionReplay.enable({
   replaySampleRate: 20, // replay is heavier — sample lower than sessions
   textAndInputPrivacyLevel: TextAndInputPrivacyLevel.MASK_ALL,
   touchPrivacyLevel: TouchPrivacyLevel.HIDE,
+  // Session Replay does NOT inherit rumConfiguration.customEndpoint — give
+  // it its own base URL, same shape as the one above. As of SDK 0.1.2 the
+  // bridge appends /replay itself; appending it here too double-appends the
+  // path and every upload gets rejected with 401.
+  customEndpoint: OPENOBSERVE_ENDPOINT,
 });
 ```
 
-Wrap any subtree you never want recorded in `<OoPrivacyView>`. Replay defaults are privacy-preserving (all text and inputs masked, touches hidden). See [Security & Privacy](./security-privacy.md) for the full privacy model.
+!!! warning "Do not append `/replay` yourself"
+
+    Prior to SDK `0.1.2`, `customEndpoint` here needed the full `/replay` URL spelled out. As of `0.1.2` the bridge appends `/replay` automatically — same as RUM and Logs above. Passing `` `${OPENOBSERVE_ENDPOINT}/replay` `` now double-appends the path and every segment upload is rejected with `401`, which looks exactly like a bad token unless you inspect the actual request URL.
+
+Wrap any subtree you never want recorded in `<SessionReplayView.Hide>` (import `SessionReplayView` from the same package — `SessionReplayView.MaskAll` and `SessionReplayView.MaskNone` are also available for finer-grained control). Replay defaults are privacy-preserving (all text and inputs masked, touches hidden). See [Security & Privacy](./security-privacy.md) for the full privacy model.
 
 ## Performance and overhead
 
@@ -361,7 +370,7 @@ Both come from **Data → Data Sources → Real User Monitoring** in your OpenOb
 
 ### How do I track screens with React Navigation?
 
-Install @openobserve/mobile-react-navigation and call OoRumReactNavigationTracking.startTrackingViews(navigationRef) once you have a navigation container ref. It automatically starts and stops RUM views as the user navigates, including Android hardware back-press exits. You can also track views manually with OoRum.startView / OoRum.stopView.
+Install @openobserve/mobile-react-navigation and call O2RumReactNavigationTracking.startTrackingViews(navigationRef) once you have a navigation container ref. It automatically starts and stops RUM views as the user navigates, including Android hardware back-press exits. You can also track views manually with O2Rum.startView / O2Rum.stopView.
 
 ### Does the React Native SDK capture native crashes?
 
@@ -373,4 +382,4 @@ Use sessionSampleRate (0–100) to keep a percentage of sessions, resourceTraceS
 
 ### Can I attach the logged-in user to RUM sessions?
 
-Yes. Call OoSdkReactNative.setUserInfo({ id, name, email, ...extra }) after login (id is required) and OoSdkReactNative.clearUserInfo() on logout. User info is attached to all subsequent RUM events, logs, and traces. Only collect identifying data with the appropriate consent — set TrackingConsent accordingly.
+Yes. Call O2SdkReactNative.setUserInfo({ id, name, email, ...extra }) after login (id is required) and O2SdkReactNative.clearUserInfo() on logout. User info is attached to all subsequent RUM events, logs, and traces. Only collect identifying data with the appropriate consent — set TrackingConsent accordingly.

--- a/docs/user-guide/data-exploration/rum/mobile/security-privacy.md
+++ b/docs/user-guide/data-exploration/rum/mobile/security-privacy.md
@@ -9,7 +9,7 @@ Real User Monitoring is powerful precisely because it watches real people use yo
 
 !!! note "Versions (Beta)"
 
-    The mobile SDKs are at React Native `0.1.1`, Android `0.1.0`, and iOS `0.1.0`. The privacy primitives described here — consent, masking, event mappers, encryption at rest — are present today. Pin exact versions and re-verify these controls when you upgrade.
+    The mobile SDKs are at React Native `0.1.2`, Android `0.1.0`, and iOS `0.1.0`. The privacy primitives described here — consent, masking, event mappers, encryption at rest — are present today. Pin exact versions and re-verify these controls when you upgrade.
 
 ## The tracking-consent model
 
@@ -27,12 +27,12 @@ You can change consent at any point in the app's lifecycle. When a user withdraw
 
 ### React Native
 
-Set consent at init through `OpenObserveProviderConfiguration`, and change it later with the static method on `OoSdkReactNative`:
+Set consent at init through `OpenObserveProviderConfiguration`, and change it later with the static method on `O2SdkReactNative`:
 
 ```tsx
 import {
   OpenObserveProviderConfiguration,
-  OoSdkReactNative,
+  O2SdkReactNative,
   TrackingConsent,
 } from '@openobserve/mobile-react-native';
 
@@ -50,9 +50,9 @@ const config = new OpenObserveProviderConfiguration(
 );
 
 // Later, from your consent dialog handler
-OoSdkReactNative.setTrackingConsent(TrackingConsent.GRANTED);
+O2SdkReactNative.setTrackingConsent(TrackingConsent.GRANTED);
 // Or when the user opts out
-OoSdkReactNative.setTrackingConsent(TrackingConsent.NOT_GRANTED);
+O2SdkReactNative.setTrackingConsent(TrackingConsent.NOT_GRANTED);
 ```
 
 ### Android
@@ -102,16 +102,16 @@ RUM lets you attach a user identity to every session so you can answer "which us
 ### React Native
 
 ```tsx
-import { OoSdkReactNative } from '@openobserve/mobile-react-native';
+import { O2SdkReactNative } from '@openobserve/mobile-react-native';
 
 // After login — id is required, everything else is optional
-OoSdkReactNative.setUserInfo({ id: 'user-123', name: 'Ada', email: 'ada@example.com' });
+O2SdkReactNative.setUserInfo({ id: 'user-123', name: 'Ada', email: 'ada@example.com' });
 
 // On logout
-OoSdkReactNative.clearUserInfo();
+O2SdkReactNative.clearUserInfo();
 
 // On a deletion / full opt-out request
-OoSdkReactNative.clearAllData();
+O2SdkReactNative.clearAllData();
 ```
 
 ### Android
@@ -163,17 +163,18 @@ await SessionReplay.enable({
   textAndInputPrivacyLevel: TextAndInputPrivacyLevel.MASK_ALL,       // default
   imagePrivacyLevel: ImagePrivacyLevel.MASK_ALL,                     // default
   touchPrivacyLevel: TouchPrivacyLevel.HIDE,                         // default
+  customEndpoint: 'https://your-openobserve-instance:5080', // bare base URL — the bridge appends /replay itself (SDK 0.1.2+)
 });
 ```
 
-For finer control, wrap any subtree you never want recorded in `<OoPrivacyView>` — it is hidden from replay regardless of the global level:
+For finer control, wrap any subtree you never want recorded in `<SessionReplayView.Hide>` — it is hidden from replay regardless of the global level. `SessionReplayView.MaskAll`, `.MaskNone`, and the lower-level `.Privacy` are also available:
 
 ```tsx
-import { OoPrivacyView } from '@openobserve/mobile-react-native-session-replay';
+import { SessionReplayView } from '@openobserve/mobile-react-native-session-replay';
 
-<OoPrivacyView>
+<SessionReplayView.Hide>
   <CreditCardForm />
-</OoPrivacyView>
+</SessionReplayView.Hide>
 ```
 
 ### Android
@@ -341,7 +342,7 @@ No. If you initialize with tracking consent set to PENDING, the SDK buffers noth
 
 ### How do I stop tracking a user who opts out later?
 
-Call the tracking-consent setter with NOT_GRANTED at runtime — OoSdkReactNative.setTrackingConsent on React Native, OpenObserve.setTrackingConsent on Android, or OpenObserve.set(trackingConsent:) on iOS. New events stop being collected immediately. To also erase everything already stored on the device but not yet uploaded, call clearAllData().
+Call the tracking-consent setter with NOT_GRANTED at runtime — O2SdkReactNative.setTrackingConsent on React Native, OpenObserve.setTrackingConsent on Android, or OpenObserve.set(trackingConsent:) on iOS. New events stop being collected immediately. To also erase everything already stored on the device but not yet uploaded, call clearAllData().
 
 ### What does Session Replay capture by default, and is it safe?
 

--- a/docs/user-guide/data-exploration/rum/setup.md
+++ b/docs/user-guide/data-exploration/rum/setup.md
@@ -225,39 +225,52 @@ Or with yarn:
 yarn add @openobserve/mobile-react-native @openobserve/mobile-react-native-session-replay
 ```
 
+iOS also needs the native pods linked after install:
+
+```bash
+npx pod-install
+```
+
 ### Initialize the SDK
+
+Build the configuration with `OpenObserveProviderConfiguration` and wrap your app tree in `OpenObserveProvider` — this single component initializes the SDK, enables RUM and Logs, and starts any automatic instrumentation you turn on:
 
 ```javascript
 import {
-  OpenObserve,
-  O2Rum,
-  O2Logs,
-  RumConfiguration,
-  LogsConfiguration,
+  OpenObserveProvider,
+  OpenObserveProviderConfiguration,
   TrackingConsent,
 } from '@openobserve/mobile-react-native';
 
-await OpenObserve.initialize(
-  clientToken: 'your-client-token-here',
-  env: 'production',
-  service: 'my-react-native-app',
-  site: 'https://your-instance.example.com',
-  trackingConsent: TrackingConsent.GRANTED,
-);
+const OPENOBSERVE_ENDPOINT = 'https://your-instance.example.com/rum/v1/default';
 
-await O2Rum.enable(
-  RumConfiguration.builder('my-react-native-app')
-    .useCustomEndpoint('https://your-instance.example.com/rum/v1/default/rum')
-    .trackUserInteractions()
-    .trackLongTasks()
-    .build(),
+const config = new OpenObserveProviderConfiguration(
+  'your-client-token-here', // clientToken
+  'production',             // env
+  TrackingConsent.GRANTED,
+  {
+    // The SDK appends /rum and /logs to these base URLs itself.
+    rumConfiguration: {
+      applicationId: 'my-react-native-app',
+      customEndpoint: OPENOBSERVE_ENDPOINT,
+      trackInteractions: true,
+      trackResources: true,
+      trackErrors: true,
+    },
+    logsConfiguration: {
+      customEndpoint: OPENOBSERVE_ENDPOINT,
+    },
+  },
 );
+config.service = 'my-react-native-app';
 
-await O2Logs.enable(
-  LogsConfiguration.builder()
-    .useCustomEndpoint('https://your-instance.example.com/rum/v1/default/logs')
-    .build(),
-);
+export default function App() {
+  return (
+    <OpenObserveProvider configuration={config}>
+      {/* your navigation container and app tree */}
+    </OpenObserveProvider>
+  );
+}
 ```
 
 ### Navigation Tracking (Optional)
@@ -265,11 +278,11 @@ await O2Logs.enable(
 Track screen views automatically with React Navigation:
 
 ```bash
-npm install @openobserve/mobile-react-native-navigation
+npm install @openobserve/mobile-react-navigation
 ```
 
 ```javascript
-import { O2RumReactNavigationTracking } from '@openobserve/mobile-react-native-navigation';
+import { O2RumReactNavigationTracking } from '@openobserve/mobile-react-navigation';
 
 <NavigationContainer
   ref={navigationRef}
@@ -286,14 +299,22 @@ Without navigation tracking, you can record views manually with `O2Rum.startView
 ### Session Replay
 
 ```javascript
-import { O2SessionReplay, SessionReplayConfiguration } from '@openobserve/mobile-react-native-session-replay';
+import { SessionReplay } from '@openobserve/mobile-react-native-session-replay';
 
-O2SessionReplay.enable(
-  SessionReplayConfiguration.builder(100)
-    .useCustomEndpoint('https://your-instance.example.com/rum/v1/default/replay')
-    .build(),
-);
+SessionReplay.enable({
+  replaySampleRate: 20, // replay is heavier — sample lower than sessions
+  startRecordingImmediately: true,
+  // Session Replay does NOT inherit rumConfiguration.customEndpoint — give
+  // it its own base URL, same shape as the one above. As of SDK 0.1.2 the
+  // bridge appends /replay itself; appending it here too double-appends
+  // the path and every upload gets rejected with 401.
+  customEndpoint: OPENOBSERVE_ENDPOINT,
+}).catch(() => {});
 ```
+
+!!! warning "Session Replay's `customEndpoint` changed in SDK 0.1.2"
+
+    Before `0.1.2`, this needed the full `.../replay` URL spelled out. As of `0.1.2` the bridge appends `/replay` automatically, matching RUM and Logs above. If you're on an older version, append `/replay` to `OPENOBSERVE_ENDPOINT` yourself; on `0.1.2`+, don't — a manually appended `/replay` now double-appends the path and gets rejected with `401`, which looks exactly like a bad token.
 
 ---
 
@@ -571,15 +592,19 @@ After deploying your application with RUM enabled:
 
 ### Mobile: Endpoint URLs
 
-The single most common reason one signal arrives while another does not is an incorrect endpoint URL. On native mobile SDKs (Android, iOS), `useCustomEndpoint` / `customEndpoint` is used verbatim — the SDK appends nothing. Pass the complete per-feature URL:
+The single most common reason one signal arrives while another does not is an incorrect endpoint URL, and native iOS/Android and React Native behave differently here:
 
-| Feature | URL suffix |
-|---------|-----------|
-| RUM | `/rum/v1/{org}/rum` |
-| Logs | `/rum/v1/{org}/logs` |
-| Session Replay | `/rum/v1/{org}/replay` |
+- **Native iOS and Android** — `useCustomEndpoint` / `customEndpoint` is used verbatim; the SDK appends nothing. Pass the complete per-feature URL:
 
-For example: `https://your-instance.example.com/rum/v1/default/rum`
+  | Feature | URL suffix |
+  |---------|-----------|
+  | RUM | `/rum/v1/{org}/rum` |
+  | Logs | `/rum/v1/{org}/logs` |
+  | Session Replay | `/rum/v1/{org}/replay` |
+
+  For example: `https://your-instance.example.com/rum/v1/default/rum`
+
+- **React Native** — the bridge appends the feature suffix itself. Pass the *same bare base URL* (`https://your-instance.example.com/rum/v1/default`) to `rumConfiguration.customEndpoint`, `logsConfiguration.customEndpoint`, **and** Session Replay's `customEndpoint` (SDK `0.1.2`+ for Session Replay — see the React Native Session Replay section above). Appending a suffix yourself double-appends it and the request is rejected with `401`.
 
 ### Mobile: No Data from Emulator / Device
 
@@ -595,11 +620,15 @@ For example: `https://your-instance.example.com/rum/v1/default/rum`
 
 - **All platforms**: ensure the session replay feature is enabled *separately* from RUM — it does not inherit RUM's endpoint
 - **Browser**: call `startSessionReplayRecording()` after `openobserveRum.init()`
-- **Mobile**: pass the full `/replay` endpoint to `SessionReplay.enable(...)`, not the RUM endpoint
+- **Native iOS / Android**: pass the full `/replay` endpoint to `SessionReplay.enable(...)`, not the RUM endpoint
+- **React Native**: pass the *bare base URL* (no `/replay` suffix) — the bridge appends it itself as of SDK `0.1.2`. On older versions, append `/replay` yourself.
 
 ### Requests Return 401 or 403
 
-The `clientToken` is your org's **RUM token**, not the ingestion passcode. If it was rotated, regenerate it from the **Ingestion** &rarr; **RUM** page and rebuild your app.
+Two common causes:
+
+- The `clientToken` is your org's **RUM token**, not the ingestion passcode. If it was rotated, regenerate it from the **Ingestion** &rarr; **RUM** page and rebuild your app.
+- **React Native Session Replay specifically**: appending `/replay` to `customEndpoint` yourself on SDK `0.1.2`+ double-appends the path (the bridge already adds it), which is also rejected with `401`. Pass the bare base URL instead — see "Mobile: Endpoint URLs" above.
 
 ### Views / Screens All Named the Same
 


### PR DESCRIPTION
…eeds /replay

SDK 0.1.2's native RN bridge now appends /replay to customEndpoint itself (matching RUM/Logs), but every doc page still told users to append it manually. That produces a double /replay/replay path, which the backend rejects with 401 — indistinguishable from a bad token unless you inspect the URL. Updates setup.md's React Native section, mobile/react-native.md, and mobile/security-privacy.md, plus the affected troubleshooting entries.

While auditing this, setup.md's React Native "Initialize the SDK" and "Session Replay" snippets turned out to reference an API that doesn't exist in the published SDK at all (OpenObserve.initialize(), O2Rum.enable(RumConfiguration.builder(...)), O2SessionReplay, SessionReplayConfiguration.builder(...) — none of these are exported). Replaced with the real API (OpenObserveProviderConfiguration + OpenObserveProvider + SessionReplay.enable({...}), verified against the package's type exports), and fixed the navigation package name (@openobserve/mobile-react-native-navigation doesn't exist; it's @openobserve/mobile-react-navigation).

Also swept every RUM mobile doc for leftover pre-rebrand Oo* naming (OoRum, OoLogs, OoSdkReactNative, OoRumReactNavigationTracking -> O2*) and a non-existent <OoPrivacyView> component, replaced with the real <SessionReplayView.Hide> (verified against source — .MaskAll, .MaskNone, and .Privacy are also available). Bumped the React Native version pin from 0.1.1 to 0.1.2 everywhere it's quoted, since that's the version the /replay fix ships in.