### PR TITLE
docs: document ZO_SSRF_ALLOW_LOOPBACK and ZO_SKIP_SSRF_CHECKS

### DIFF
--- a/docs/administration/configuration/environment-variables.md
+++ b/docs/administration/configuration/environment-variables.md
@@ -49,6 +49,8 @@ In high-load environments, alerts or reports can run large, resource-intensive q
 | ZO_ROUTE_TIMEOUT | 600 | Timeout value for the router node in seconds. |
 | ZO_ROUTE_MAX_CONNECTIONS | 1024 | Sets the maximum number of simultaneous connections per type of scheme for the Router node role. |
 | ZO_CORS_ALLOWED_ORIGINS | | Comma-separated list of origins allowed to make cross-origin (CORS) requests to the OpenObserve server. When empty, all origins are allowed. Example: `https://app.example.com,https://admin.example.com`. |
+| ZO_SSRF_ALLOW_LOOPBACK | false | Allow outbound requests, such as webhook alert destinations and URL-based enrichment tables, to target loopback addresses (`127.0.0.1`, `localhost`, `::1`). Part of OpenObserve's SSRF (Server-Side Request Forgery) protection, which blocks these targets by default. Does not allow other private network ranges, such as `10.0.0.0/8`, `172.16.0.0/12`, or `192.168.0.0/16`; use `ZO_SKIP_SSRF_CHECKS` for those. Enable only in trusted environments, such as CI/CD pipelines or single-node self-hosted setups where the server needs to send requests to itself. |
+| ZO_SKIP_SSRF_CHECKS | false | Disable SSRF protection for outbound requests made by the server for features that check it, such as webhook alert destinations and URL-based enrichment tables, allowing URLs that target loopback addresses, private network ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), link-local addresses, and cloud metadata endpoints (for example, `169.254.169.254`). Use this in a self-hosted deployment to reach a notification service or another system on a private network, such as a homelab. Enable only when you trust every destination URL configured on this instance. |
 
 
 ## Data Storage and Directories

--- a/docs/user-guide/account-administration/management/alert-destinations.md
+++ b/docs/user-guide/account-administration/management/alert-destinations.md
@@ -21,6 +21,10 @@ You can use this destination to:
   - Send notifications to **Slack** or **Microsoft Teams channels**.
 :::
 
+:::warning[Private and local network addresses are blocked by default]
+For SSRF protection, OpenObserve blocks Webhook URLs pointing to loopback or private network addresses, such as a self-hosted Ntfy server on your LAN. In a self-hosted deployment, set `ZO_SKIP_SSRF_CHECKS=true` to allow any private address, or `ZO_SSRF_ALLOW_LOOPBACK=true` for loopback only. See [Network and Communication](../../../administration/configuration/environment-variables.md#network-and-communication).
+:::
+
 ### Prerequisites
 :::accordion[Set up an alert template.]
 This allows you to define the content and layout of the alert message.

--- a/docs/user-guide/account-administration/management/alert-destinations.md
+++ b/docs/user-guide/account-administration/management/alert-destinations.md
@@ -22,7 +22,7 @@ You can use this destination to:
 :::
 
 :::warning[Private and local network addresses are blocked by default]
-For SSRF protection, OpenObserve blocks Webhook URLs pointing to loopback or private network addresses, such as a self-hosted Ntfy server on your LAN. In a self-hosted deployment, set `ZO_SKIP_SSRF_CHECKS=true` to allow any private address, or `ZO_SSRF_ALLOW_LOOPBACK=true` for loopback only. See [Network and Communication](../../../administration/configuration/environment-variables.md#network-and-communication).
+For SSRF protection, OpenObserve blocks Webhook URLs pointing to loopback or private network addresses, such as a self-hosted Ntfy server on your LAN. In a self-hosted deployment, set `ZO_SKIP_SSRF_CHECKS=true` to allow any private address, or `ZO_SSRF_ALLOW_LOOPBACK=true` for loopback only. See [Network and Communication](https://openobserve.ai/docs/administration/configuration/environment-variables/#network-and-communication).
 :::
 
 ### Prerequisites


### PR DESCRIPTION
Follow-up to openobserve/openobserve#13265: a self-hosted user asked for an opt-in way to point webhook alert destinations at private/local network addresses, which OpenObserve blocks by default as SSRF protection. Neither env var that answers this was documented anywhere.

- `environment-variables.md`: adds both `ZO_SSRF_ALLOW_LOOPBACK` and `ZO_SKIP_SSRF_CHECKS` to the Network and Communication section.
- `alert-destinations.md`: adds a warning callout on the Webhook tab explaining the block and how to opt out, linking to the reference.

Traced the actual guard logic in `src/config/src/utils/ssrf_guard.rs` (o2 repo) to get the distinction right: `ZO_SSRF_ALLOW_LOOPBACK` only exempts loopback addresses (`127.0.0.1`/`localhost`/`::1`); general private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) stay blocked unless `ZO_SKIP_SSRF_CHECKS` is set instead. This matters because the correct answer for the linked issue's actual use case (a private-LAN webhook, not loopback) is `ZO_SKIP_SSRF_CHECKS`, not the `ZO_SSRF_ALLOW_LOOPBACK` suggested in the Slack thread.

Re-verified the guard logic against current `openobserve/openobserve` main before opening this PR (unchanged since the original review).

**Verified** with a full local `pnpm build`: SEO check and check-links both pass, no broken links.