### PR TITLE
docs(ai): trim llm-applications.md and link to Evaluations/Experiments

### DIFF
--- a/docs/integration/ai/llm-applications.md
+++ b/docs/integration/ai/llm-applications.md
@@ -3,31 +3,29 @@ title: LLM Applications
 description: "Monitor, trace, and debug LLM apps in production with OpenObserve and OpenTelemetry: track token usage, latency, cost, model metadata, and errors per call."
 ---
 
-# **LLM Observability with OpenObserve**
+# LLM Observability with OpenObserve
 
 Monitor, trace, and debug your LLM-powered applications in production using OpenObserve and OpenTelemetry.
 
-## **What is LLM Observability?**
+## What is LLM Observability?
 
-LLM Observability gives you visibility into the behaviour of large language model calls inside your application , similar to traditional APM, but purpose-built for AI workloads.
+LLM Observability gives you visibility into the behavior of large language model calls inside your application, similar to traditional APM but purpose-built for AI workloads. With it you can track:
 
-With it you can track:
+* **Token usage**: prompt, completion, and total tokens per request
+* **Latency**: end-to-end duration of every LLM call
+* **Model metadata**: model name, temperature, max tokens, and other parameters
+* **Errors**: rate limit events, API failures, and timeouts with full context
 
-* **Token usage**: prompt, completion, and total tokens per request  
-* **Latency** : end-to-end duration of every LLM call  
-* **Model metadata** : model name, temperature, max tokens, and other parameters  
-* **Errors** : rate limit events, API failures, and timeouts with full context
+Under the hood, LLM Observability is just OpenTelemetry: there's nothing special about LLM traces compared to regular distributed traces. Any OpenTelemetry-compatible SDK or exporter can ship traces to OpenObserve.
 
-**Under the hood:** LLM Observability is OpenTelemetry. There is nothing special about LLM traces compared to regular distributed traces, the work happens on the server side. Any OpenTelemetry-compatible SDK or exporter can ship traces to OpenObserve.
+## Prerequisites
 
-## **Prerequisites**
-
-* Python 3.8+  
-* [`uv`](https://github.com/astral-sh/uv) package manager (or `pip`)  
-* An [OpenObserve](https://openobserve.ai/) account (cloud or self-hosted)  
+* Python 3.8+
+* [`uv`](https://github.com/astral-sh/uv) package manager (or `pip`)
+* An [OpenObserve](https://openobserve.ai/) account (cloud or self-hosted)
 * Your OpenObserve **organisation ID** and **Base64-encoded auth token**
 
-## **Configuration**
+## Configuration
 
 Create a `.env` file in your project root:
 
@@ -39,7 +37,7 @@ OPENOBSERVE_URL=https://api.openobserve.ai/
 # Your OpenObserve organisation slug or ID
 OPENOBSERVE_ORG=your_org_id
 
-# Basic auth token — Base64-encoded "email:password"
+# Basic auth token: copy the ready-made value from Data Sources > Custom > Traces > OTel Collector
 OPENOBSERVE_AUTH_TOKEN="Basic <your_base64_token>"
 
 # Enable or disable tracing (default: true)
@@ -50,6 +48,10 @@ OPENAI_API_KEY="your-openai-key"
 ANTHROPIC_API_KEY="your-anthropic-key"
 ```
 
+Find your `OPENOBSERVE_ORG` and `OPENOBSERVE_AUTH_TOKEN` under **Data Sources > Custom > Traces > OTel Collector** in OpenObserve. It shows a ready-made endpoint and `Authorization` header you can copy directly, so you never have to Base64-encode credentials by hand.
+
+![Data Sources - Custom - OTel Collector, showing the ready-made endpoint and Authorization header](../../images/migration/lgtm/opentelemetry.png)
+
 | Variable | Description | Required |
 | ----- | ----- | ----- |
 | `OPENOBSERVE_URL` | Base URL of your OpenObserve instance | Yes |
@@ -58,50 +60,49 @@ ANTHROPIC_API_KEY="your-anthropic-key"
 | `OPENOBSERVE_ENABLED` | Toggle tracing on/off | No (default: `true`) |
 | `OPENAI_API_KEY` | Only needed by the bundled OpenAI example | No |
 
-## **Option A : Quickstart with the bundled example**
+## Option A: Quickstart with the bundled example
 
 Clone the SDK repository and run the included OpenAI example to see traces flowing into OpenObserve with minimal setup.
 
-**1\. Clone the repository**
+**1. Clone the repository**
 
 ```shell
 git clone https://github.com/openobserve/openobserve-python-sdk/
 cd openobserve-python-sdk
 ```
 
-**2\. Install dependencies**
+**2. Install dependencies**
 
 ```shell
 uv pip install openobserve-telemetry-sdk openai opentelemetry-instrumentation-openai python-dotenv
 uv pip install -r requirements.txt
 ```
 
-**3\. Add your `.env` file** to the project root (see Configuration above), including `OPENAI_API_KEY`.
+**3. Add your `.env` file** to the project root (see Configuration above), including `OPENAI_API_KEY`.
 
-**4\. Run the example**
+**4. Run the example**
 
 ```shell
 uv run examples/openai_example.py
 ```
 
-Open your **OpenObserve dashboard → Traces** to see the spans appear.
+Open your **OpenObserve dashboard > Traces** to see the spans appear.
 
 ![LLM Traces](../images/llm-applications/llm-tokens-cost-latency.png)
 
-
-## **Option B: Integrate into your own project using the OpenObserve SDK**
+## Option B: Integrate into your own project using the OpenObserve SDK
 
 Use this if you want the simplest possible integration without cloning the repository.
 
-**1\. Install dependencies**
+**1. Install dependencies**
 
 ```shell
 uv pip install openobserve-telemetry-sdk opentelemetry-instrumentation-openai dotenv
 ```
 
-**2\. Initialise the SDK at your application entry point and  Use your LLM client as normal**
+**2. Initialize the SDK at your application entry point, then use your LLM client as normal**
 
-Sample OpenAI Instrumentation:
+Sample OpenAI instrumentation:
 
 ```python
 from opentelemetry.instrumentation.openai import OpenAIInstrumentor
@@ -120,10 +121,10 @@ response = client.chat.completions.create(
     messages=[{"role": "user", "content": "Hello!"}]
 )
 print(response.choices[0].message.content)
-
 ```
 
-Sample Anthropic Instrumentation:
+Sample Anthropic instrumentation:
+
 ```python
 from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor
 from openobserve import openobserve_init
@@ -142,15 +143,15 @@ response = client.messages.create(
     messages=[{"role": "user", "content": "Hello!"}]
 )
 print(response.content[0].text)
-
 ```
+
 Every call is now captured as a trace span and exported to OpenObserve.
 
-Note: The **openobserve-telemetry-sdk** is an optional thin wrapper around the standard OpenTelemetry Python SDK that simplifies setup and exporter configuration. If you already use OpenTelemetry, you can send telemetry directly to the OpenObserve OTLP endpoint without it.
+Note: the **openobserve-telemetry-sdk** is an optional thin wrapper around the standard OpenTelemetry Python SDK that simplifies setup and exporter configuration. If you already use OpenTelemetry, you can send telemetry directly to the OpenObserve OTLP endpoint without it.
 
-## **What gets captured**
+## What gets captured
 
-The `opentelemetry-instrumentation-openai` library attaches the following attributes to each span automatically:
+The `opentelemetry-instrumentation-openai` library attaches these attributes to each span automatically:
 
 | Attribute | Description |
 | ----- | ----- |
@@ -163,7 +164,7 @@ The `opentelemetry-instrumentation-openai` library attaches the following attrib
 | `duration` | End-to-end request latency |
 | `error` | Exception details if the request failed |
 
-In addition, OpenObserve computes and stores the following token and cost fields on each LLM span:
+OpenObserve also computes and stores token and cost fields on each LLM span:
 
 | Field | Type | Description |
 | ----- | ----- | ----- |
@@ -174,13 +175,14 @@ In addition, OpenObserve computes and stores the following token and cost fields
 | `llm_usage_cost_output` | Float64 | Cost of output tokens |
 | `llm_usage_cost_total` | Float64 | Total cost of the LLM call |
 
-The cost fields (`llm_usage_cost_input`, `llm_usage_cost_output`, `llm_usage_cost_total`) are populated only when the Model Pricing feature is enabled (`ZO_MODEL_PRICING_ENABLED`).
+The cost fields are populated only when the Model Pricing feature is enabled (`ZO_MODEL_PRICING_ENABLED`).
 
-## **Viewing traces in OpenObserve**
+## Viewing traces in OpenObserve
 
-1. Log in to your OpenObserve instance  
-2. Navigate to **Traces** in the left sidebar  
+1. Log in to your OpenObserve instance
+2. Navigate to **Traces** in the left sidebar
 3. Filter by service name, model, or time range
+
 ![LLM Traces](../images/llm-applications/llm-traces.png)
 
 4. Click any span to inspect token counts, latency, and full request metadata
@@ -189,37 +191,23 @@ The cost fields (`llm_usage_cost_input`, `llm_usage_cost_output`, `llm_usage_cos
 
 ![LLM Traces](../images/llm-applications/llm-span-attributes.png)
 
-
-
-## **LLM Evaluations**
+## LLM Evaluations and Experiments
 
 > **Enterprise feature.**
 
-OpenObserve can automatically evaluate your LLM traces using an LLM-evaluation pipeline. This lets you score model responses against criteria such as correctness, relevance, or safety without leaving OpenObserve.
+Once your traces are flowing, OpenObserve can score them automatically and run offline evaluations against versioned test sets:
 
-**How it works**
+- **[LLM Evaluations](https://openobserve.ai/docs/integration/ai/llm-evaluations/)**: continuously score live traces and spans in production using LLM-as-a-judge or remote scorers.
+- **[LLM Experiments](https://openobserve.ai/docs/integration/ai/llm-experiments/)**: run offline, batch evaluations against a versioned dataset and compare runs against a baseline.
 
-1. Set up an LLM-evaluation pipeline on a traces stream.
-2. As LLM traces arrive, the pipeline runs the configured evaluation and writes the results to a separate output stream named `<stream>_evaluations` (for example, a `default` stream produces `default_evaluations`).
-3. Per-trace evaluation results appear in an **Evaluations** tab in the trace detail view. This tab is shown only for LLM traces that have associated evaluation data.
-
-**Eval Templates**
-
-Evaluation logic is defined by Eval Templates, managed from the enterprise **Eval Templates** tab. Each template specifies:
-
-* **response_type**: the expected shape of the evaluation response
-* **dimensions**: the criteria the trace is evaluated against
-* **content**: the prompt/instructions used to perform the evaluation
-* **versioning**: templates are versioned so you can iterate without losing earlier definitions
-
-## **Troubleshooting**
+## Troubleshooting
 
 **Traces are not appearing in OpenObserve**
 
-* Confirm `OPENOBSERVE_ENABLED=true` in your `.env`  
-* Check that `OPENOBSERVE_URL` ends with a trailing `/`  
-* Verify `OPENOBSERVE_AUTH_TOKEN` is correctly Base64-encoded (`Basic <token>`)  
-* Ensure the SDK or tracer provider is initialised before any LLM calls
+* Confirm `OPENOBSERVE_ENABLED=true` in your `.env`
+* Check that `OPENOBSERVE_URL` ends with a trailing `/`
+* Verify `OPENOBSERVE_AUTH_TOKEN` is correctly Base64-encoded (`Basic <token>`)
+* Ensure the SDK or tracer provider is initialized before any LLM calls
 
 **`ModuleNotFoundError: No module named 'dotenv'`**
 
@@ -231,3 +219,5 @@ Evaluation logic is defined by Eval Templates, managed from the enterprise **Eva
 
 ## Read More
 - [OpenObserve Python SDK](https://openobserve.ai/docs/user-guide/data-processing/opentelemetry/openobserve-python-sdk/)
+- [LLM Evaluations](https://openobserve.ai/docs/integration/ai/llm-evaluations/)
+- [LLM Experiments](https://openobserve.ai/docs/integration/ai/llm-experiments/)


### PR DESCRIPTION
## What changed

- Replaced the stale **LLM Evaluations** section on the LLM Applications page (it described an old Eval Templates / `<stream>_evaluations` architecture that no longer matches the product) with a short, accurate pointer to the current [LLM Evaluations](https://openobserve.ai/docs/integration/ai/llm-evaluations/) and [LLM Experiments](https://openobserve.ai/docs/integration/ai/llm-experiments/) pages.
- Updated the `.env` config guidance to point readers at **Data Sources > Custom > Traces > OTel Collector** to copy their org ID and ready-made `Authorization` header, instead of telling them to hand-encode `Base64(email:password)`. Added a screenshot of that flow.
- Trimmed formatting cruft (stray spaces, redundant bold headings, em-dashes) and tightened a few wordy sentences.
- Added LLM Evaluations / Experiments to the Read More list.

## Why

The evaluations blurb was out of date and pointed to a feature shape (Eval Templates, per-stream `_evaluations` output) that doesn't exist anymore, which would confuse anyone following it. The auth-token instructions also encouraged manually constructing a Basic auth header rather than copying the ready-made one OpenObserve already shows in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)